### PR TITLE
Add tracing support using otel

### DIFF
--- a/packages/rum_sdk/android/build.gradle
+++ b/packages/rum_sdk/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.0'
     }
 }
 

--- a/packages/rum_sdk/android/build.gradle
+++ b/packages/rum_sdk/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/rum_sdk/example/android/app/build.gradle
+++ b/packages/rum_sdk/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'com.example.rum_sdk_example'
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
     defaultConfig{

--- a/packages/rum_sdk/example/android/app/build.gradle
+++ b/packages/rum_sdk/example/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -20,10 +21,6 @@ def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     namespace 'com.example.rum_sdk_example'
@@ -66,7 +63,6 @@ configurations.all {
         }
     }
 }
-
 
 flutter {
     source '../..'

--- a/packages/rum_sdk/example/android/app/src/debug/AndroidManifest.xml
+++ b/packages/rum_sdk/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.rum_sdk_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/packages/rum_sdk/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/rum_sdk/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.rum_sdk_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:label="rum_sdk_example"
         android:name="${applicationName}"

--- a/packages/rum_sdk/example/android/app/src/profile/AndroidManifest.xml
+++ b/packages/rum_sdk/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.rum_sdk_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/packages/rum_sdk/example/android/build.gradle
+++ b/packages/rum_sdk/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/rum_sdk/example/android/build.gradle
+++ b/packages/rum_sdk/example/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/packages/rum_sdk/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/rum_sdk/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/packages/rum_sdk/example/android/settings.gradle
+++ b/packages/rum_sdk/example/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+}
+
+include ":app"

--- a/packages/rum_sdk/example/pubspec.lock
+++ b/packages/rum_sdk/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
@@ -45,18 +45,18 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   connectivity_plus:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "2056db5241f96cdc0126bd94459fc4cdc13876753768fc7a31c425e50a7177d0"
+      sha256: "876849631b0c7dc20f8b471a2a03142841b482438e3b707955464f5ffca3e4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -172,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "76d306a1c3afb33fe82e2bbacad62a61f409b5634c915fceb0d799de1a913360"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.1"
   intl:
     dependency: transitive
     description:
@@ -188,18 +188,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -216,6 +216,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -255,14 +263,22 @@ packages:
       relative: true
     source: path
     version: "1.0.0"
+  opentelemetry:
+    dependency: transitive
+    description:
+      name: opentelemetry
+      sha256: "7ae74cb06c079bc1c69160d84eaf3b386922af5b7b3c77e260d4dc265b1dbb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.6"
   package_info_plus:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: "894f37107424311bdae3e476552229476777b8752c5a2a2369c0cb9a2d5442ef"
+      sha256: da8d9ac8c4b1df253d1a328b7bf01ae77ef132833479ab40763334db13b91cce
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -283,26 +299,26 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: c464428172cb986b758c6d1724c603097febb8fb855aa265aeecc9280c294d4a
+      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.12"
+    version: "2.2.15"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -339,10 +355,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -351,6 +367,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  protobuf:
+    dependency: transitive
+    description:
+      name: protobuf
+      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   rum_sdk:
     dependency: "direct main"
     description:
@@ -362,7 +394,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -383,10 +415,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -399,10 +431,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -415,18 +447,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   uuid:
     dependency: transitive
     description:
@@ -447,10 +479,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:
@@ -463,10 +495,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "4d45dc9069dba4619dc0ebd93c7cec5e66d8482cb625a370ac806dcc8165f2ec"
+      sha256: "8b338d4486ab3fbc0ba0db9f9b4f5239b6697fcee427939a40e720cbb9ee0a69"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.5"
+    version: "5.9.0"
   win32_registry:
     dependency: transitive
     description:

--- a/packages/rum_sdk/lib/rum_flutter.dart
+++ b/packages/rum_sdk/lib/rum_flutter.dart
@@ -9,6 +9,8 @@ import 'package:rum_sdk/rum_native_methods.dart';
 import 'package:rum_sdk/rum_sdk.dart';
 import 'package:rum_sdk/src/data_collection_policy.dart';
 import 'package:rum_sdk/src/models/session_attributes.dart';
+import 'package:rum_sdk/src/models/span_record.dart';
+import 'package:rum_sdk/src/tracing/tracer_provider.dart';
 import 'package:rum_sdk/src/transport/batch_transport.dart';
 import 'package:rum_sdk/src/util/generate_session.dart';
 
@@ -156,19 +158,33 @@ class RumFlutter {
     _instance._batchTransport?.updatePayloadMeta(_instance.meta);
   }
 
-  Future<void>? pushEvent(String name, {Map<String, String?>? attributes}) {
-    _batchTransport?.addEvent(Event(name, attributes: attributes));
+  Future<void>? pushEvent(
+    String name, {
+    Map<String, dynamic>? attributes,
+    Map<String, String>? trace,
+  }) {
+    _batchTransport?.addEvent(Event(
+      name,
+      attributes: attributes,
+      trace: trace,
+    ));
     return null;
   }
 
-  Future<void>? pushLog(String message,
-      {String? level,
-      Map<String, dynamic>? context,
-      Map<String, dynamic>? trace}) {
+  Future<void>? pushLog(
+    String message, {
+    String? level,
+    Map<String, dynamic>? context,
+    Map<String, String>? trace,
+  }) {
     _batchTransport?.addLog(
       RumLog(message, level: level, context: context, trace: trace),
     );
     return null;
+  }
+
+  Future<void> pushSpan(SpanRecord spanRecord) async {
+    _batchTransport?.addSpan(spanRecord);
   }
 
   Future<void>? pushError({
@@ -190,6 +206,10 @@ class RumFlutter {
   Future<void>? pushMeasurement(Map<String, dynamic>? values, String type) {
     _batchTransport?.addMeasurement(Measurement(values, type));
     return null;
+  }
+
+  Tracer getTracer() {
+    return DartOtelTracerProvider().getTracer();
   }
 
   void markEventStart(String key, String name) {

--- a/packages/rum_sdk/lib/rum_sdk.dart
+++ b/packages/rum_sdk/lib/rum_sdk.dart
@@ -12,6 +12,8 @@ export './src/rum_asset_bundle.dart';
 export './src/rum_navigation_observer.dart';
 export './src/rum_user_interaction_widget.dart';
 export './src/rum_widgets_binding_observer.dart';
+export './src/tracing/span.dart';
+export './src/tracing/tracer.dart';
 export './src/transport/rum_base_transport.dart';
 export './src/transport/rum_transport.dart';
 export 'rum_flutter.dart';

--- a/packages/rum_sdk/lib/src/models/event.dart
+++ b/packages/rum_sdk/lib/src/models/event.dart
@@ -1,17 +1,19 @@
 import 'package:intl/intl.dart';
 
 class Event {
-  Event(this.name, {this.attributes});
+  Event(this.name, {this.attributes, this.trace});
 
   Event.fromJson(dynamic json) {
     name = json['name'];
     domain = json['domain'];
     attributes = json['attributes'];
     timestamp = json['timestamp'];
+    trace = json['trace'];
   }
   String name = '';
   String domain = 'flutter';
   Map<String, dynamic>? attributes = {};
+  Map<String, dynamic>? trace = {};
   String timestamp = DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(
     DateTime.now().toUtc(),
   );
@@ -23,6 +25,7 @@ class Event {
     map['domain'] = domain;
     map['timestamp'] = timestamp;
     map['attributes'] = attributes;
+    map['trace'] = trace;
     return map;
   }
 }

--- a/packages/rum_sdk/lib/src/models/models.dart
+++ b/packages/rum_sdk/lib/src/models/models.dart
@@ -12,3 +12,4 @@ export './sdk.dart';
 export './session.dart';
 export './user.dart';
 export './view_meta.dart';
+export 'trace/trace.dart';

--- a/packages/rum_sdk/lib/src/models/payload.dart
+++ b/packages/rum_sdk/lib/src/models/payload.dart
@@ -31,21 +31,40 @@ class Payload {
         exceptions.add(RumException.fromJson(v));
       });
     }
+    if (json['traces'] != null) {
+      traces = Traces.fromJson(json['traces']);
+    }
     meta = json['meta'] != null ? Meta.fromJson(json['meta']) : null;
   }
   List<Event> events = [];
   List<Measurement> measurements = [];
   List<RumLog> logs = [];
   List<RumException> exceptions = [];
+  Traces traces = Traces();
   Meta? meta;
 
   Map<String, dynamic> toJson() {
     final map = <String, dynamic>{};
 
-    map['events'] = events.map((v) => v.toJson()).toList();
-    map['measurements'] = measurements.map((v) => v.toJson()).toList();
-    map['logs'] = logs.map((v) => v.toJson()).toList();
-    map['exceptions'] = exceptions.map((v) => v.toJson()).toList();
+    if (events.isNotEmpty) {
+      map['events'] = events.map((v) => v.toJson()).toList();
+    }
+
+    if (measurements.isNotEmpty) {
+      map['measurements'] = measurements.map((v) => v.toJson()).toList();
+    }
+
+    if (logs.isNotEmpty) {
+      map['logs'] = logs.map((v) => v.toJson()).toList();
+    }
+
+    if (exceptions.isNotEmpty) {
+      map['exceptions'] = exceptions.map((v) => v.toJson()).toList();
+    }
+
+    if (traces.hasTraces()) {
+      map['traces'] = traces.toJson();
+    }
 
     if (meta != null) {
       map['meta'] = meta!.toJson();

--- a/packages/rum_sdk/lib/src/models/span_record.dart
+++ b/packages/rum_sdk/lib/src/models/span_record.dart
@@ -1,0 +1,64 @@
+import 'package:opentelemetry/sdk.dart' as otel_sdk;
+import 'package:rum_sdk/src/models/trace/trace_resource.dart';
+import 'package:rum_sdk/src/models/trace/trace_scope_spans.dart';
+import 'package:rum_sdk/src/models/trace/trace_span.dart';
+import 'package:rum_sdk/src/tracing/extensions.dart';
+
+class SpanRecord {
+  SpanRecord({
+    required otel_sdk.ReadOnlySpan otelReadOnlySpan,
+  }) : _otelReadOnlySpan = otelReadOnlySpan;
+
+  final otel_sdk.ReadOnlySpan _otelReadOnlySpan;
+
+  String name() {
+    return _otelReadOnlySpan.name;
+  }
+
+  TraceResource getResource() {
+    return TraceResource(
+      attributes: _otelReadOnlySpan.resource.attributes.toTraceAttributes(),
+    );
+  }
+
+  TraceScope getScope() {
+    return TraceScope(
+      name: _otelReadOnlySpan.instrumentationScope.name,
+      version: _otelReadOnlySpan.instrumentationScope.version,
+    );
+  }
+
+  TraceSpan getSpan() {
+    final parentSpanId = _otelReadOnlySpan.parentSpanId;
+    return TraceSpan(
+      traceId: _otelReadOnlySpan.spanContext.traceId.toString(),
+      spanId: _otelReadOnlySpan.spanContext.spanId.toString(),
+      parentSpanId: parentSpanId.isValid ? parentSpanId.toString() : null,
+      name: _otelReadOnlySpan.name,
+      kind: _otelReadOnlySpan.kind.toCode(),
+      startTimeUnixNano: _otelReadOnlySpan.startTime,
+      endTimeUnixNano: _otelReadOnlySpan.endTime,
+      attributes: _otelReadOnlySpan.attributes.toTraceAttributes(),
+      events: _otelReadOnlySpan.events.toTraceSpanEventsList(),
+      droppedEventsCount: _otelReadOnlySpan.droppedEventsCount,
+      links: _otelReadOnlySpan.links.toTraceSpanLinksList(),
+      status: _otelReadOnlySpan.status.toTraceSpanStatus,
+    );
+  }
+
+  Map<String, String> getFaroSpanContext() {
+    return {
+      'trace_id': _otelReadOnlySpan.spanContext.traceId.toString(),
+      'span_id': _otelReadOnlySpan.spanContext.spanId.toString(),
+    };
+  }
+
+  Map<String, String> getFaroEventAttributes() {
+    final faroEventAttributes = <String, String>{};
+    for (final key in _otelReadOnlySpan.attributes.keys) {
+      faroEventAttributes[key] =
+          _otelReadOnlySpan.attributes.get(key).toString();
+    }
+    return faroEventAttributes;
+  }
+}

--- a/packages/rum_sdk/lib/src/models/trace/trace.dart
+++ b/packages/rum_sdk/lib/src/models/trace/trace.dart
@@ -1,0 +1,53 @@
+import 'package:rum_sdk/src/models/span_record.dart';
+import 'package:rum_sdk/src/models/trace/trace_resource_spans.dart';
+
+class Traces {
+  Traces();
+
+  Traces.fromJson(dynamic json) {
+    if (json['resourceSpans'] != null) {
+      _resourceSpans = [];
+      json['resourceSpans'].forEach((dynamic v) {
+        _resourceSpans.add(TraceResourceSpans.fromJson(v));
+      });
+    }
+  }
+
+  List<TraceResourceSpans> _resourceSpans = [];
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    map['resourceSpans'] = _resourceSpans.map((v) => v.toJson()).toList();
+    return map;
+  }
+
+  bool hasTraces() {
+    return numberSpans() > 0;
+  }
+
+  bool hasNoTraces() {
+    return hasTraces() == false;
+  }
+
+  int numberSpans() {
+    return _resourceSpans.fold(0, (total, resourceSpans) {
+      return total + resourceSpans.numberSpans();
+    });
+  }
+
+  void resetSpans() {
+    for (final resourceSpans in _resourceSpans) {
+      resourceSpans.resetSpans();
+    }
+  }
+
+  void addSpan(SpanRecord spanRecord) {
+    if (_resourceSpans.isEmpty) {
+      _resourceSpans.add(TraceResourceSpans());
+    }
+
+    for (final resourceSpans in _resourceSpans) {
+      resourceSpans.addSpan(spanRecord);
+    }
+  }
+}

--- a/packages/rum_sdk/lib/src/models/trace/trace_attribute.dart
+++ b/packages/rum_sdk/lib/src/models/trace/trace_attribute.dart
@@ -1,0 +1,49 @@
+class TraceAttribute {
+  TraceAttribute({
+    required String key,
+    required TraceAttributeValue value,
+  })  : _key = key,
+        _value = value;
+
+  TraceAttribute.fromJson(dynamic json) {
+    if (json['key'] != null) {
+      _key = json['key'];
+    }
+    if (json['value'] != null) {
+      _value = TraceAttributeValue.fromJson(json['value']);
+    }
+  }
+  String? _key;
+  TraceAttributeValue? _value;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (_key != null && _value != null) {
+      map['key'] = _key;
+      map['value'] = _value!.toJson();
+    }
+    return map;
+  }
+}
+
+class TraceAttributeValue {
+  TraceAttributeValue({
+    required String stringValue,
+  }) : _stringValue = stringValue;
+
+  TraceAttributeValue.fromJson(dynamic json) {
+    if (json['stringValue'] != null) {
+      _stringValue = json['stringValue'];
+    }
+  }
+
+  String? _stringValue;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (_stringValue != null) {
+      map['stringValue'] = _stringValue;
+    }
+    return map;
+  }
+}

--- a/packages/rum_sdk/lib/src/models/trace/trace_resource.dart
+++ b/packages/rum_sdk/lib/src/models/trace/trace_resource.dart
@@ -1,0 +1,24 @@
+import 'package:rum_sdk/src/models/trace/trace_attribute.dart';
+
+class TraceResource {
+  TraceResource({
+    required List<TraceAttribute> attributes,
+  }) : _attributes = attributes;
+
+  TraceResource.fromJson(dynamic json) {
+    if (json['attributes'] != null) {
+      _attributes = [];
+      json['attributes'].forEach((dynamic v) {
+        _attributes.add(TraceAttribute.fromJson(v));
+      });
+    }
+  }
+
+  List<TraceAttribute> _attributes = [];
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    map['attributes'] = _attributes.map((v) => v.toJson()).toList();
+    return map;
+  }
+}

--- a/packages/rum_sdk/lib/src/models/trace/trace_resource_spans.dart
+++ b/packages/rum_sdk/lib/src/models/trace/trace_resource_spans.dart
@@ -1,0 +1,56 @@
+import 'package:rum_sdk/src/models/span_record.dart';
+import 'package:rum_sdk/src/models/trace/trace_resource.dart';
+import 'package:rum_sdk/src/models/trace/trace_scope_spans.dart';
+
+class TraceResourceSpans {
+  TraceResourceSpans();
+
+  TraceResourceSpans.fromJson(dynamic json) {
+    if (json['resource'] != null) {
+      _resource = TraceResource.fromJson(json['resource']);
+    }
+    if (json['scopeSpans'] != null) {
+      _scopeSpansMap = {};
+      json['scopeSpans'].forEach((dynamic v) {
+        final scopeSpans = TraceScopeSpans.fromJson(v);
+        _scopeSpansMap[scopeSpans.scope!] = scopeSpans;
+      });
+    }
+  }
+
+  TraceResource? _resource;
+  Map<TraceScope, TraceScopeSpans> _scopeSpansMap = {};
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (_resource != null) {
+      map['resource'] = _resource!.toJson();
+    }
+    final scopeSpansList = _scopeSpansMap.values.toList();
+    if (scopeSpansList.isNotEmpty) {
+      map['scopeSpans'] = scopeSpansList.map((v) => v.toJson()).toList();
+    }
+    return map;
+  }
+
+  int numberSpans() {
+    return _scopeSpansMap.values
+        .fold(0, (total, spanScope) => total + spanScope.numberSpans);
+  }
+
+  void resetSpans() {
+    _scopeSpansMap = {};
+  }
+
+  void addSpan(SpanRecord spanRecord) {
+    _resource ??= spanRecord.getResource();
+
+    final scope = spanRecord.getScope();
+    final span = spanRecord.getSpan();
+
+    final scopeSpans =
+        _scopeSpansMap[scope] ?? TraceScopeSpans(scope: scope, spans: []);
+    scopeSpans.addSpan(span);
+    _scopeSpansMap[scope] = scopeSpans;
+  }
+}

--- a/packages/rum_sdk/lib/src/models/trace/trace_scope_spans.dart
+++ b/packages/rum_sdk/lib/src/models/trace/trace_scope_spans.dart
@@ -1,0 +1,84 @@
+import 'package:rum_sdk/src/models/trace/trace_span.dart';
+
+class TraceScopeSpans {
+  TraceScopeSpans({
+    required TraceScope scope,
+    required List<TraceSpan> spans,
+  })  : _scope = scope,
+        _spans = spans;
+
+  TraceScopeSpans.fromJson(dynamic json) {
+    if (json['scope'] != null) {
+      _scope = TraceScope.fromJson(json['scope']);
+    }
+    if (json['spans'] != null) {
+      _spans = [];
+      json['spans'].forEach((dynamic v) {
+        _spans.add(TraceSpan.fromJson(v));
+      });
+    }
+  }
+
+  TraceScope? _scope;
+  TraceScope? get scope => _scope;
+
+  List<TraceSpan> _spans = [];
+
+  int get numberSpans => _spans.length;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (_scope != null) {
+      map['scope'] = _scope!.toJson();
+    }
+    map['spans'] = _spans.map((v) => v.toJson()).toList();
+    return map;
+  }
+
+  void addSpan(TraceSpan span) {
+    _spans.add(span);
+  }
+}
+
+class TraceScope {
+  TraceScope({
+    required String name,
+    required String version,
+  })  : _name = name,
+        _version = version;
+
+  TraceScope.fromJson(dynamic json) {
+    if (json['name'] != null) {
+      _name = json['name'];
+    }
+    if (json['version'] != null) {
+      _version = json['version'];
+    }
+  }
+
+  String? _name;
+  String? _version;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (_name != null) {
+      map['name'] = _name;
+    }
+    if (_version != null) {
+      map['version'] = _version;
+    }
+    return map;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is TraceScope &&
+        other._name == _name &&
+        other._version == _version;
+  }
+
+  @override
+  int get hashCode => _name.hashCode ^ _version.hashCode;
+}

--- a/packages/rum_sdk/lib/src/models/trace/trace_span.dart
+++ b/packages/rum_sdk/lib/src/models/trace/trace_span.dart
@@ -1,0 +1,133 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:rum_sdk/src/models/trace/trace_attribute.dart';
+import 'package:rum_sdk/src/models/trace/trace_span_event.dart';
+import 'package:rum_sdk/src/models/trace/trace_span_link.dart';
+import 'package:rum_sdk/src/models/trace/trace_span_status.dart';
+
+class TraceSpan {
+  TraceSpan({
+    required String traceId,
+    required String spanId,
+    required String? parentSpanId,
+    required String name,
+    required int kind,
+    required Int64 startTimeUnixNano,
+    required Int64? endTimeUnixNano,
+    required List<TraceAttribute> attributes,
+    required TraceSpanStatus status,
+    required List<TraceSpanEvent> events,
+    required int droppedEventsCount,
+    required List<TraceSpanLink> links,
+  })  : _traceId = traceId,
+        _spanId = spanId,
+        _parentSpanId = parentSpanId,
+        _name = name,
+        _kind = kind,
+        _startTimeUnixNano = startTimeUnixNano.toString(),
+        _endTimeUnixNano = endTimeUnixNano.toString(),
+        _attributes = attributes,
+        _status = status,
+        _events = events,
+        _droppedEventsCount = droppedEventsCount,
+        _links = links;
+
+  TraceSpan.fromJson(dynamic json) {
+    if (json['traceId'] != null) {
+      _traceId = json['traceId'];
+    }
+    if (json['spanId'] != null) {
+      _spanId = json['spanId'];
+    }
+    if (json['parentSpanId'] != null) {
+      _parentSpanId = json['parentSpanId'];
+    }
+    if (json['name'] != null) {
+      _name = json['name'];
+    }
+    if (json['kind'] != null) {
+      _kind = json['kind'];
+    }
+    if (json['startTimeUnixNano'] != null) {
+      _startTimeUnixNano = json['startTimeUnixNano'];
+    }
+    if (json['endTimeUnixNano'] != null) {
+      _endTimeUnixNano = json['endTimeUnixNano'];
+    }
+    if (json['attributes'] != null) {
+      _attributes = [];
+      json['attributes'].forEach((dynamic v) {
+        _attributes.add(TraceAttribute.fromJson(v));
+      });
+    }
+    if (json['status'] != null) {
+      _status = TraceSpanStatus.fromJson(json['status']);
+    }
+    if (json['events'] != null) {
+      _events = [];
+      json['events'].forEach((dynamic v) {
+        _events.add(TraceSpanEvent.fromJson(v));
+      });
+    }
+    if (json['droppedEventsCount'] != null) {
+      _droppedEventsCount = json['droppedEventsCount'];
+    }
+    if (json['links'] != null) {
+      _links = [];
+      json['links'].forEach((dynamic v) {
+        _links.add(TraceSpanLink.fromJson(v));
+      });
+    }
+  }
+
+  String? _traceId;
+  String? _spanId;
+  String? _parentSpanId;
+  String? _name;
+  int? _kind;
+  String? _startTimeUnixNano;
+  String? _endTimeUnixNano;
+  List<TraceAttribute> _attributes = [];
+  TraceSpanStatus? _status;
+  List<TraceSpanEvent> _events = [];
+  int? _droppedEventsCount;
+  List<TraceSpanLink> _links = [];
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+
+    if (_traceId != null) {
+      map['traceId'] = _traceId;
+    }
+    if (_spanId != null) {
+      map['spanId'] = _spanId;
+    }
+    if (_parentSpanId != null) {
+      map['parentSpanId'] = _parentSpanId;
+    }
+    if (_name != null) {
+      map['name'] = _name;
+    }
+    if (_kind != null) {
+      map['kind'] = _kind;
+    }
+    if (_startTimeUnixNano != null) {
+      map['startTimeUnixNano'] = _startTimeUnixNano;
+    }
+    if (_endTimeUnixNano != null) {
+      map['endTimeUnixNano'] = _endTimeUnixNano;
+    }
+    if (_attributes.isNotEmpty) {
+      map['attributes'] = _attributes.map((v) => v.toJson()).toList();
+    }
+    if (_status != null) {
+      map['status'] = _status!.toJson();
+    }
+    map['events'] = _events.map((v) => v.toJson()).toList();
+    if (_droppedEventsCount != null) {
+      map['droppedEventsCount'] = _droppedEventsCount;
+    }
+    map['links'] = _links.map((v) => v.toJson()).toList();
+
+    return map;
+  }
+}

--- a/packages/rum_sdk/lib/src/models/trace/trace_span_event.dart
+++ b/packages/rum_sdk/lib/src/models/trace/trace_span_event.dart
@@ -1,0 +1,54 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:rum_sdk/src/models/trace/trace_attribute.dart';
+
+class TraceSpanEvent {
+  TraceSpanEvent({
+    required String name,
+    required Int64 timeUnixNano,
+    required int droppedAttributesCount,
+    required List<TraceAttribute> attributes,
+  })  : _name = name,
+        _timeUnixNano = timeUnixNano.toString(),
+        _droppedAttributesCount = droppedAttributesCount,
+        _attributes = attributes;
+
+  TraceSpanEvent.fromJson(dynamic json) {
+    if (json['name'] != null) {
+      _name = json['name'];
+    }
+    if (json['timeUnixNano'] != null) {
+      _timeUnixNano = json['timeUnixNano'];
+    }
+    if (json['droppedAttributesCount'] != null) {
+      _droppedAttributesCount = json['droppedAttributesCount'];
+    }
+    if (json['attributes'] != null) {
+      _attributes = [];
+      json['attributes'].forEach((dynamic v) {
+        _attributes.add(TraceAttribute.fromJson(v));
+      });
+    }
+  }
+
+  String? _name;
+  String? _timeUnixNano;
+  int? _droppedAttributesCount;
+  List<TraceAttribute> _attributes = [];
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+
+    if (_name != null) {
+      map['name'] = _name;
+    }
+    if (_timeUnixNano != null) {
+      map['timeUnixNano'] = _timeUnixNano;
+    }
+    if (_droppedAttributesCount != null) {
+      map['droppedAttributesCount'] = _droppedAttributesCount;
+    }
+    map['attributes'] = _attributes.map((v) => v.toJson()).toList();
+
+    return map;
+  }
+}

--- a/packages/rum_sdk/lib/src/models/trace/trace_span_link.dart
+++ b/packages/rum_sdk/lib/src/models/trace/trace_span_link.dart
@@ -1,0 +1,55 @@
+import 'package:rum_sdk/src/models/trace/trace_attribute.dart';
+
+class TraceSpanLink {
+  TraceSpanLink({
+    required String traceId,
+    required String spanId,
+    required String traceState,
+    required List<TraceAttribute> attributes,
+  })  : _traceId = traceId,
+        _spanId = spanId,
+        _traceState = traceState,
+        _attributes = attributes;
+
+  TraceSpanLink.fromJson(dynamic json) {
+    if (json['traceId'] != null) {
+      _traceId = json['traceId'];
+    }
+    if (json['spanId'] != null) {
+      _spanId = json['spanId'];
+    }
+    if (json['traceState'] != null) {
+      _traceState = json['traceState'];
+    }
+    if (json['attributes'] != null) {
+      _attributes = [];
+      json['attributes'].forEach((dynamic v) {
+        _attributes.add(TraceAttribute.fromJson(v));
+      });
+    }
+  }
+
+  String? _traceId;
+  String? _spanId;
+  String? _traceState;
+  List<TraceAttribute> _attributes = [];
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+
+    if (_traceId != null) {
+      map['traceId'] = _traceId;
+    }
+    if (_spanId != null) {
+      map['spanId'] = _spanId;
+    }
+    if (_traceState != null) {
+      map['traceState'] = _traceState;
+    }
+    if (_attributes.isNotEmpty) {
+      map['attributes'] = _attributes.map((v) => v.toJson()).toList();
+    }
+
+    return map;
+  }
+}

--- a/packages/rum_sdk/lib/src/models/trace/trace_span_status.dart
+++ b/packages/rum_sdk/lib/src/models/trace/trace_span_status.dart
@@ -1,0 +1,30 @@
+class TraceSpanStatus {
+  TraceSpanStatus({
+    required int code,
+    required String? message,
+  })  : _code = code,
+        _message = message;
+
+  TraceSpanStatus.fromJson(dynamic json) {
+    if (json['code'] != null) {
+      _code = json['code'];
+    }
+    if (json['message'] != null) {
+      _message = json['message'];
+    }
+  }
+
+  int? _code;
+  String? _message;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (_code != null) {
+      map['code'] = _code;
+    }
+    if (_message != null) {
+      map['message'] = _message;
+    }
+    return map;
+  }
+}

--- a/packages/rum_sdk/lib/src/tracing/dart_otel_tracer_resources_factory.dart
+++ b/packages/rum_sdk/lib/src/tracing/dart_otel_tracer_resources_factory.dart
@@ -1,0 +1,47 @@
+import 'package:opentelemetry/api.dart' as otel_api;
+import 'package:opentelemetry/sdk.dart' as otel_sdk;
+import 'package:rum_sdk/rum_flutter.dart';
+
+class DartOtelTracerResourcesFactory {
+  otel_sdk.Resource getTracerResource() {
+    final rumFlutter = RumFlutter();
+    const unknownString = 'unknown';
+
+    return otel_sdk.Resource(
+      [
+        // App info
+        otel_api.Attribute.fromString(
+          otel_api.ResourceAttributes.serviceName,
+          rumFlutter.meta.app?.name ?? unknownString,
+        ),
+        otel_api.Attribute.fromString(
+          otel_api.ResourceAttributes.deploymentEnvironment,
+          rumFlutter.meta.app?.environment ?? unknownString,
+        ),
+        otel_api.Attribute.fromString(
+          otel_api.ResourceAttributes.serviceVersion,
+          rumFlutter.meta.app?.version ?? unknownString,
+        ),
+
+        // Faro info
+        otel_api.Attribute.fromString('faro.sdk.name', 'faro-flutter-sdk'),
+        otel_api.Attribute.fromString('faro.sdk.language', 'dart'),
+        otel_api.Attribute.fromString(
+          'faro.sdk.version',
+          '1.0.0',
+        ),
+
+        // Otel info
+        otel_api.Attribute.fromString(
+          'telemetry.sdk.name',
+          'opentelemetry-dart',
+        ),
+        otel_api.Attribute.fromString('telemetry.sdk.language', 'dart'),
+        otel_api.Attribute.fromString(
+          'telemetry.sdk.version',
+          '0.18.6',
+        ),
+      ],
+    );
+  }
+}

--- a/packages/rum_sdk/lib/src/tracing/extensions.dart
+++ b/packages/rum_sdk/lib/src/tracing/extensions.dart
@@ -1,0 +1,112 @@
+import 'package:opentelemetry/api.dart' as otel_api;
+import 'package:opentelemetry/sdk.dart' as otel_sdk;
+import 'package:rum_sdk/src/models/trace/trace_attribute.dart';
+import 'package:rum_sdk/src/models/trace/trace_span_event.dart';
+import 'package:rum_sdk/src/models/trace/trace_span_link.dart';
+import 'package:rum_sdk/src/models/trace/trace_span_status.dart';
+
+extension TraceAttributesX on otel_sdk.Attributes {
+  List<TraceAttribute> toTraceAttributes() {
+    final attributes = <TraceAttribute>[];
+    for (final key in keys) {
+      attributes.add(
+        TraceAttribute(
+          key: key,
+          value: TraceAttributeValue(
+            stringValue: get(key).toString(),
+          ),
+        ),
+      );
+    }
+    return attributes;
+  }
+}
+
+extension IterableTraceAttributeX on Iterable<otel_api.Attribute> {
+  List<TraceAttribute> toTraceAttributes() {
+    final traceAttributes = <TraceAttribute>[];
+    for (final attribute in this) {
+      traceAttributes.add(
+        TraceAttribute(
+          key: attribute.key,
+          value: TraceAttributeValue(
+            stringValue: attribute.value.toString(),
+          ),
+        ),
+      );
+    }
+    return traceAttributes;
+  }
+}
+
+extension SpanKindX on otel_api.SpanKind {
+  int toCode() {
+    switch (this) {
+      case otel_api.SpanKind.internal:
+        return 1;
+      case otel_api.SpanKind.server:
+        return 2;
+      case otel_api.SpanKind.client:
+        return 3;
+      case otel_api.SpanKind.producer:
+        return 4;
+      case otel_api.SpanKind.consumer:
+        return 5;
+    }
+  }
+}
+
+extension SpanStatusX on otel_api.SpanStatus {
+  TraceSpanStatus get toTraceSpanStatus {
+    return TraceSpanStatus(
+      code: code.toCode(),
+      message: description.isNotEmpty ? description : null,
+    );
+  }
+}
+
+extension StatusCodeX on otel_api.StatusCode {
+  int toCode() {
+    switch (this) {
+      case otel_api.StatusCode.unset:
+        return 0;
+      case otel_api.StatusCode.ok:
+        return 1;
+      case otel_api.StatusCode.error:
+        return 2;
+    }
+  }
+}
+
+extension SpanEventListX on List<otel_api.SpanEvent> {
+  List<TraceSpanEvent> toTraceSpanEventsList() {
+    final events = <TraceSpanEvent>[];
+    for (final event in this) {
+      events.add(
+        TraceSpanEvent(
+          name: event.name,
+          timeUnixNano: event.timestamp,
+          droppedAttributesCount: event.droppedAttributesCount,
+          attributes: event.attributes.toTraceAttributes(),
+        ),
+      );
+    }
+
+    return events;
+  }
+}
+
+extension SpanLinkListX on List<otel_api.SpanLink> {
+  List<TraceSpanLink> toTraceSpanLinksList() {
+    final links = <TraceSpanLink>[];
+    for (final link in this) {
+      links.add(TraceSpanLink(
+        traceId: link.context.traceId.toString(),
+        spanId: link.context.spanId.toString(),
+        traceState: link.context.traceState.toString(),
+        attributes: link.attributes.toTraceAttributes(),
+      ));
+    }
+    return links;
+  }
+}

--- a/packages/rum_sdk/lib/src/tracing/faro_exporter.dart
+++ b/packages/rum_sdk/lib/src/tracing/faro_exporter.dart
@@ -1,0 +1,42 @@
+import 'package:opentelemetry/sdk.dart' as otel_sdk;
+import 'package:rum_sdk/rum_flutter.dart';
+import 'package:rum_sdk/src/models/span_record.dart';
+
+class FaroExporter implements otel_sdk.SpanExporter {
+  var _isShutdown = false;
+
+  @override
+  void export(List<otel_sdk.ReadOnlySpan> spans) {
+    if (_isShutdown) {
+      return;
+    }
+    _sendSpansToFaro(spans);
+  }
+
+  @override
+  void forceFlush() {
+    return;
+  }
+
+  @override
+  void shutdown() {
+    _isShutdown = true;
+  }
+
+  void _sendSpansToFaro(List<otel_sdk.ReadOnlySpan> spans) {
+    final rumFlutter = RumFlutter();
+
+    for (var i = 0; i < spans.length; i++) {
+      final otelReadOnlySpan = spans[i];
+      final spanRecord = SpanRecord(otelReadOnlySpan: otelReadOnlySpan);
+
+      rumFlutter.pushEvent(
+        'faro.tracing.${spanRecord.name()}',
+        attributes: spanRecord.getFaroEventAttributes(),
+        trace: spanRecord.getFaroSpanContext(),
+      );
+
+      rumFlutter.pushSpan(spanRecord);
+    }
+  }
+}

--- a/packages/rum_sdk/lib/src/tracing/span.dart
+++ b/packages/rum_sdk/lib/src/tracing/span.dart
@@ -1,0 +1,105 @@
+import 'package:opentelemetry/api.dart' as otel_api;
+
+abstract class Span {
+  String get traceId;
+  String get spanId;
+  bool get wasEnded;
+
+  void setStatus(SpanStatusCode statusCode, {String? message});
+  void addEvent(String message, {Map<String, String> attributes});
+  void setAttributes(Map<String, String> attributes);
+  void end();
+}
+
+class InternalSpan implements Span {
+  InternalSpan._({required otel_api.Span otelSpan}) : _otelSpan = otelSpan;
+
+  final otel_api.Span _otelSpan;
+
+  otel_api.Span get otelSpan => _otelSpan;
+
+  @override
+  String get traceId => _otelSpan.spanContext.traceId.toString();
+
+  @override
+  String get spanId => _otelSpan.spanContext.spanId.toString();
+
+  bool _wasEnded = false;
+
+  @override
+  bool get wasEnded => _wasEnded;
+
+  @override
+  void setStatus(SpanStatusCode statusCode, {String? message}) {
+    if (message != null) {
+      _otelSpan.setStatus(statusCode.toOtelStatusCode(), message);
+    } else {
+      _otelSpan.setStatus(statusCode.toOtelStatusCode());
+    }
+  }
+
+  @override
+  void addEvent(String message, {Map<String, String> attributes = const {}}) {
+    final listAttributes = attributes.entries.map((entry) {
+      return otel_api.Attribute.fromString(entry.key, entry.value);
+    }).toList();
+    _otelSpan.addEvent(message, attributes: listAttributes);
+  }
+
+  @override
+  void setAttributes(Map<String, String> attributes) {
+    final listAttributes = attributes.entries.map((entry) {
+      return otel_api.Attribute.fromString(entry.key, entry.value);
+    }).toList();
+    _otelSpan.setAttributes(listAttributes);
+  }
+
+  @override
+  void end() {
+    _wasEnded = true;
+    _otelSpan.end();
+  }
+
+  String toHttpTraceparent() {
+    // W3CTraceContextPropagator stuff.
+    // Copied from the OtelSift implementation
+    // https://github.com/open-telemetry/opentelemetry-swift/blob/7bad8ae7f230e7a1b9ec697f36dcae91a8debff9/Sources/OpenTelemetryApi/Trace/Propagation/W3CTraceContextPropagator.swift
+    const version = '00';
+    const delimiter = '-';
+    const endString = '01';
+    final traceparent =
+        '$version$delimiter$traceId$delimiter$spanId$delimiter$endString';
+    return traceparent;
+  }
+}
+
+class SpanProvider {
+  Span getSpan(otel_api.Span otelSpan) {
+    return InternalSpan._(otelSpan: otelSpan);
+  }
+}
+
+enum SpanStatusCode {
+  /// The default status.
+  unset,
+
+  /// The operation contains an error.
+  error,
+
+  /// The operation has been validated by an Application developers or
+  /// Operator to have completed successfully.
+  ok,
+}
+
+extension StatusCodeX on SpanStatusCode {
+  otel_api.StatusCode toOtelStatusCode() {
+    switch (this) {
+      case SpanStatusCode.unset:
+        return otel_api.StatusCode.unset;
+      case SpanStatusCode.error:
+        return otel_api.StatusCode.error;
+      case SpanStatusCode.ok:
+        return otel_api.StatusCode.ok;
+    }
+  }
+}

--- a/packages/rum_sdk/lib/src/tracing/tracer.dart
+++ b/packages/rum_sdk/lib/src/tracing/tracer.dart
@@ -1,0 +1,92 @@
+import 'package:opentelemetry/api.dart' as otel_api;
+import 'package:rum_sdk/rum_flutter.dart';
+import 'package:rum_sdk/src/tracing/span.dart';
+
+class Tracer {
+  Tracer._({required otel_api.Tracer otelTracer}) : _otelTracer = otelTracer;
+
+  final otel_api.Tracer _otelTracer;
+  Span? _activeSpan;
+
+  /// Creates a new span with the given name and returns it.
+  ///
+  /// If [isActive] is true, the span will be set as the active span, and any
+  /// spans created after this one (where [parentSpan] is not provided) will be
+  /// children of this active span (Until this active span is ended).
+  /// Any previously defined active span will be replaced by this new span.
+  ///
+  /// If [parentSpan] is provided, the new span
+  /// will be a child of the provided parentSpan.
+  Span startSpan(
+    String name, {
+    bool isActive = false,
+    Span? parentSpan,
+    Map<String, dynamic> attributes = const {},
+  }) {
+    final activeSpan = _validateAndGetActiveSpan(isCurrentSpanActive: isActive);
+
+    otel_api.Context? context;
+    if (parentSpan != null && parentSpan is InternalSpan) {
+      context = otel_api.contextWithSpan(
+        otel_api.globalContextManager.active,
+        parentSpan.otelSpan,
+      );
+    } else if (activeSpan != null) {
+      context = otel_api.contextWithSpan(
+        otel_api.globalContextManager.active,
+        activeSpan.otelSpan,
+      );
+    }
+
+    final otel_api.Span otelSpan;
+    if (context == null) {
+      otelSpan = _otelTracer.startSpan(
+        name,
+        kind: otel_api.SpanKind.client,
+      );
+    } else {
+      otelSpan = _otelTracer.startSpan(
+        name,
+        context: context,
+        kind: otel_api.SpanKind.client,
+      );
+    }
+
+    otelSpan.setAttributes(
+      attributes.entries.map((entry) {
+        return otel_api.Attribute.fromString(entry.key, entry.value.toString());
+      }).toList(),
+    );
+
+    final rumFlutter = RumFlutter();
+    otelSpan.setAttribute(otel_api.Attribute.fromString(
+      'session_id',
+      rumFlutter.meta.session?.id ?? '',
+    ));
+
+    final span = SpanProvider().getSpan(otelSpan);
+    if (isActive) {
+      _activeSpan = span;
+    }
+
+    return span;
+  }
+
+  InternalSpan? _validateAndGetActiveSpan({required bool isCurrentSpanActive}) {
+    final activeSpan = _activeSpan;
+    if (isCurrentSpanActive ||
+        activeSpan == null ||
+        activeSpan.wasEnded ||
+        activeSpan is! InternalSpan) {
+      _activeSpan = null;
+      return null;
+    }
+    return activeSpan;
+  }
+}
+
+class TracerBuilder {
+  Tracer buildTracer({required otel_api.Tracer otelTracer}) {
+    return Tracer._(otelTracer: otelTracer);
+  }
+}

--- a/packages/rum_sdk/lib/src/tracing/tracer_provider.dart
+++ b/packages/rum_sdk/lib/src/tracing/tracer_provider.dart
@@ -1,0 +1,41 @@
+import 'package:opentelemetry/api.dart' as otel_api;
+import 'package:opentelemetry/sdk.dart' as otel_sdk;
+import 'package:rum_sdk/rum_flutter.dart';
+import 'package:rum_sdk/src/tracing/dart_otel_tracer_resources_factory.dart';
+import 'package:rum_sdk/src/tracing/faro_exporter.dart';
+import 'package:rum_sdk/src/tracing/tracer.dart';
+
+abstract class TracerProvider {
+  Tracer getTracer();
+}
+
+class DartOtelTracerProvider implements TracerProvider {
+  static Tracer? _tracer;
+
+  @override
+  Tracer getTracer() {
+    if (_tracer != null) {
+      return _tracer!;
+    }
+
+    final exporter = FaroExporter();
+    final resource = DartOtelTracerResourcesFactory().getTracerResource();
+
+    final provider = otel_sdk.TracerProviderBase(
+      resource: resource,
+      processors: [otel_sdk.SimpleSpanProcessor(exporter)],
+    );
+
+    otel_api.registerGlobalTracerProvider(provider);
+
+    final rumFlutter = RumFlutter();
+    final otelTracer = provider.getTracer(
+      'main-instrumentation',
+      version: rumFlutter.meta.app?.version ?? 'unknown',
+    );
+
+    final tracer = TracerBuilder().buildTracer(otelTracer: otelTracer);
+    _tracer = tracer;
+    return tracer;
+  }
+}

--- a/packages/rum_sdk/lib/src/transport/batch_transport.dart
+++ b/packages/rum_sdk/lib/src/transport/batch_transport.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:rum_sdk/rum_sdk.dart';
+import 'package:rum_sdk/src/models/span_record.dart';
 
 class BatchTransport {
   BatchTransport(
@@ -33,6 +34,11 @@ class BatchTransport {
 
   Future<void> addLog(RumLog rumLog) async {
     payload.logs.add(rumLog);
+    checkPayloadItemLimit();
+  }
+
+  Future<void> addSpan(SpanRecord spanRecord) async {
+    payload.traces.addSpan(spanRecord);
     checkPayloadItemLimit();
   }
 
@@ -74,14 +80,16 @@ class BatchTransport {
     return payload.events.isEmpty &&
         payload.measurements.isEmpty &&
         payload.logs.isEmpty &&
-        payload.exceptions.isEmpty;
+        payload.exceptions.isEmpty &&
+        payload.traces.hasNoTraces();
   }
 
   int payloadSize() {
     return payload.logs.length +
         payload.measurements.length +
         payload.events.length +
-        payload.exceptions.length;
+        payload.exceptions.length +
+        payload.traces.numberSpans();
   }
 
   void resetPayload() {
@@ -89,5 +97,6 @@ class BatchTransport {
     payload.measurements = [];
     payload.logs = [];
     payload.exceptions = [];
+    payload.traces.resetSpans();
   }
 }

--- a/packages/rum_sdk/pubspec.lock
+++ b/packages/rum_sdk/pubspec.lock
@@ -5,31 +5,31 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.11.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
@@ -138,34 +138,34 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.0"
+    version: "4.10.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   dart_style:
     dependency: transitive
     description:
@@ -215,13 +215,13 @@ packages:
     source: hosted
     version: "7.0.1"
   fixnum:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -289,10 +289,10 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "76d306a1c3afb33fe82e2bbacad62a61f409b5634c915fceb0d799de1a913360"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.1"
   intl:
     dependency: "direct main"
     description:
@@ -305,10 +305,10 @@ packages:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   js:
     dependency: transitive
     description:
@@ -329,18 +329,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -353,26 +353,26 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413"
+      sha256: "4a16b3f03741e1252fda5de3ce712666d010ba2122f8e912c94f9f7b90e1a4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   macros:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -413,22 +413,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  opentelemetry:
+    dependency: "direct main"
+    description:
+      name: opentelemetry
+      sha256: "7ae74cb06c079bc1c69160d84eaf3b386922af5b7b3c77e260d4dc265b1dbb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.6"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   package_info_plus:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "894f37107424311bdae3e476552229476777b8752c5a2a2369c0cb9a2d5442ef"
+      sha256: da8d9ac8c4b1df253d1a328b7bf01ae77ef132833479ab40763334db13b91cce
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -461,14 +469,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  protobuf:
+    dependency: transitive
+    description:
+      name: protobuf
+      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   pubspec_parse:
     dependency: transitive
     description:
@@ -477,27 +493,35 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611"
+      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -518,10 +542,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -542,10 +566,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -558,26 +582,26 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   timing:
     dependency: transitive
     description:
       name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   uuid:
     dependency: "direct main"
     description:
@@ -598,10 +622,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:
@@ -638,10 +662,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "4d45dc9069dba4619dc0ebd93c7cec5e66d8482cb625a370ac806dcc8165f2ec"
+      sha256: "8b338d4486ab3fbc0ba0db9f9b4f5239b6697fcee427939a40e720cbb9ee0a69"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.5"
+    version: "5.9.0"
   win32_registry:
     dependency: transitive
     description:
@@ -659,5 +683,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.6.0-0 <4.0.0"
   flutter: ">=3.19.0"

--- a/packages/rum_sdk/pubspec.yaml
+++ b/packages/rum_sdk/pubspec.yaml
@@ -11,8 +11,10 @@ dependencies:
   device_info_plus: ^10.1.2
   flutter:
     sdk: flutter
+  fixnum: ^1.1.1
   http: ^1.2.2
   intl: ^0.19.0
+  opentelemetry: ^0.18.6
   package_info_plus: ^8.0.1
   plugin_platform_interface: ^2.0.2
   uuid: ^4.1.0

--- a/packages/rum_sdk/pubspec.yaml
+++ b/packages/rum_sdk/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 
 dependencies:
   device_info_plus: ^10.1.2
+  fixnum: ^1.1.1
   flutter:
     sdk: flutter
-  fixnum: ^1.1.1
   http: ^1.2.2
   intl: ^0.19.0
   opentelemetry: ^0.18.6

--- a/packages/rum_sdk/test/unit_test/batch_transport_test.dart
+++ b/packages/rum_sdk/test/unit_test/batch_transport_test.dart
@@ -29,6 +29,7 @@ void main() {
     when(() => mockPayload.measurements).thenReturn([]);
     when(() => mockPayload.logs).thenReturn([]);
     when(() => mockPayload.exceptions).thenReturn([]);
+    when(() => mockPayload.traces).thenReturn(Traces());
     when(() => mockPayload.toJson()).thenReturn({});
     when(() => mockBaseTransport.send(any())).thenAnswer((_) async {});
 

--- a/packages/rum_sdk/test/unit_test/http_tracking_client_test.dart
+++ b/packages/rum_sdk/test/unit_test/http_tracking_client_test.dart
@@ -20,14 +20,20 @@ void main() {
   group('RumHttpTrackingClient', () {
     late MockHttpClient mockHttpClient;
     late RumHttpTrackingClient rumHttpTrackingClient;
+    late MockHttpClientRequest mockHttpClientRequest;
+    late MockHttpHeaders mockHttpHeaders;
 
     setUp(() {
       mockHttpClient = MockHttpClient();
+      mockHttpClientRequest = MockHttpClientRequest();
+      mockHttpHeaders = MockHttpHeaders();
+
+      when(() => mockHttpClientRequest.method).thenReturn('GET');
+      when(() => mockHttpClientRequest.headers).thenReturn(mockHttpHeaders);
       rumHttpTrackingClient = RumHttpTrackingClient(mockHttpClient);
     });
 
     test('openUrl should call innerClient.openUrl', () async {
-      final mockHttpClientRequest = MockHttpClientRequest();
       final url = Uri.parse('http://example.com/path');
 
       when(() => mockHttpClient.openUrl('GET', url))
@@ -53,6 +59,8 @@ void main() {
 
       when(() => mockHttpHeaders.contentLength).thenReturn(100);
       when(() => mockHttpHeaders.contentType).thenReturn(null);
+      when(() => mockHttpClientRequest.method).thenReturn('GET');
+      when(() => mockHttpClientRequest.headers).thenReturn(mockHttpHeaders);
 
       userAttributes = {
         'method': 'GET',


### PR DESCRIPTION
This PR adds support for traces.

Traces are collected under the hood using the [opentelemetry](https://pub.dev/packages/opentelemetry) package.
A custom Faro-exporter extracts the traces out from Otel and sends them over the existing faro protocol.

The external opentelemetry dependency is hidden and the public Faro-Trace-API exposes its own types.
This makes it safe in the future to change the underlying implementation without a need to change the API.

This is the first version of tracing support. It supports:
- auto instrumenting all http requests
- manually passing a parent span when creating a new span
- or setting a span to "active", and all spans created later will inherit that span as a parent.

Later we will probably add zone-support for inferring parent spans.

This PR solves #5 