### PR TITLE
Remove already reported crash reports on android

### DIFF
--- a/packages/rum_sdk/android/build.gradle
+++ b/packages/rum_sdk/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.example.rum_sdk'
-version '1.0'
+version '0.1.1'
 
 buildscript {
     repositories {
@@ -38,6 +38,7 @@ android {
 
 dependencies {
     implementation 'androidx.metrics:metrics-performance:1.0.0-beta01'
+    implementation 'androidx.annotation:annotation-jvm:1.9.1'
 //    implementation 'androidx.annotation:annotation-jvm:1.8.0-beta02'
 }
 

--- a/packages/rum_sdk/android/src/main/java/com/example/rum_sdk/ANRTracker.java
+++ b/packages/rum_sdk/android/src/main/java/com/example/rum_sdk/ANRTracker.java
@@ -2,21 +2,15 @@ package com.example.rum_sdk;
 
 import android.os.Handler;
 import android.os.Looper;
-import android.provider.Settings;
 
 import androidx.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.lang.Exception;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-
-import io.flutter.Log;
-
 
 
 public class ANRTracker extends Thread {

--- a/packages/rum_sdk/android/src/main/java/com/example/rum_sdk/ApplicationExitInfoExt.java
+++ b/packages/rum_sdk/android/src/main/java/com/example/rum_sdk/ApplicationExitInfoExt.java
@@ -1,0 +1,78 @@
+package com.example.rum_sdk;
+
+import android.app.ApplicationExitInfo;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class ApplicationExitInfoExt {
+    private ApplicationExitInfoExt() {
+        // Prevent instantiation
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.R)
+    private static List<Integer> getExitReasonsToCapture() {
+        return Arrays.asList(
+                ApplicationExitInfo.REASON_ANR,
+                ApplicationExitInfo.REASON_CRASH,
+                ApplicationExitInfo.REASON_CRASH_NATIVE,
+                ApplicationExitInfo.REASON_DEPENDENCY_DIED,
+                ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE,
+                ApplicationExitInfo.REASON_EXIT_SELF,
+                ApplicationExitInfo.REASON_INITIALIZATION_FAILURE,
+                ApplicationExitInfo.REASON_LOW_MEMORY,
+                ApplicationExitInfo.REASON_SIGNALED,
+                ApplicationExitInfo.REASON_UNKNOWN
+        );
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.R)
+    public static boolean shouldBeReported(ApplicationExitInfo exitInfo) {
+        return getExitReasonsToCapture().contains(exitInfo.getReason());
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.R)
+    public static String getUniqueId(ApplicationExitInfo exitInfo) {
+        return exitInfo.getTimestamp() + ":" + exitInfo.getPid();
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.R)
+    public static String getReasonName(ApplicationExitInfo exitInfo) {
+        int reason = exitInfo.getReason();
+        switch (reason) {
+            case ApplicationExitInfo.REASON_ANR:
+                return "ANR";
+            case ApplicationExitInfo.REASON_CRASH:
+                return "Crash";
+            case ApplicationExitInfo.REASON_CRASH_NATIVE:
+                return "Native Crash";
+            case ApplicationExitInfo.REASON_DEPENDENCY_DIED:
+                return "Dependency Died";
+            case ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE:
+                return "Excessive Resource Usage";
+            case ApplicationExitInfo.REASON_EXIT_SELF:
+                return "Exit Self";
+            case ApplicationExitInfo.REASON_INITIALIZATION_FAILURE:
+                return "Initialization Failure";
+            case ApplicationExitInfo.REASON_LOW_MEMORY:
+                return "Low Memory";
+            case ApplicationExitInfo.REASON_OTHER:
+                return "Other";
+            case ApplicationExitInfo.REASON_PERMISSION_CHANGE:
+                return "Permission Change";
+            case ApplicationExitInfo.REASON_SIGNALED:
+                return "Signaled";
+            case ApplicationExitInfo.REASON_UNKNOWN:
+                return "Unknown";
+            case ApplicationExitInfo.REASON_USER_REQUESTED:
+                return "User Requested";
+            case ApplicationExitInfo.REASON_USER_STOPPED:
+                return "User Stopped";
+            default:
+                return "Unknown Reason";
+        }
+    }
+}

--- a/packages/rum_sdk/android/src/main/java/com/example/rum_sdk/ExitInfoHelper.java
+++ b/packages/rum_sdk/android/src/main/java/com/example/rum_sdk/ExitInfoHelper.java
@@ -10,35 +10,63 @@ import androidx.annotation.RequiresApi;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.Arrays;
-
-
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 
 public class ExitInfoHelper {
+    private final SharedPreferencesService preferencesService;
 
-    public static List<ApplicationExitInfo> getApplicationExitInfo(Context context) {
+    public ExitInfoHelper(Context context) {
+        this.preferencesService = new SharedPreferencesService(context);
+    }
+
+    public List<ApplicationExitInfo> getApplicationExitInfo(Context context) {
         ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
 
         if (activityManager != null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                return activityManager.getHistoricalProcessExitReasons(null, 0, 15);
+                List<ApplicationExitInfo> exitInfoList = activityManager.getHistoricalProcessExitReasons(null, 0, 15);
+                return filterHandledExitInfo(exitInfoList);
             }
         }
 
         return null;
     }
 
-    public static JSONObject getExitInfo(ApplicationExitInfo exitInfo) throws JSONException {
+    @RequiresApi(api = Build.VERSION_CODES.R)
+    private List<ApplicationExitInfo> filterHandledExitInfo(List<ApplicationExitInfo> exitInfoList) {
+        if (exitInfoList == null || exitInfoList.isEmpty()) {
+            return exitInfoList;
+        }
+
+        Set<String> handledExitInfo = preferencesService.getHandledExitInfos();
+        List<ApplicationExitInfo> newExitInfo = new ArrayList<>();
+        Set<String> updatedHandledExitInfo = new HashSet<>(handledExitInfo);
+
+        for (ApplicationExitInfo exitInfo : exitInfoList) {
+            String exitInfoKey = ApplicationExitInfoExt.getUniqueId(exitInfo);
+            if (!handledExitInfo.contains(exitInfoKey)) {
+                newExitInfo.add(exitInfo);
+                updatedHandledExitInfo.add(exitInfoKey);
+            }
+        }
+
+        preferencesService.setHandledExitInfos(updatedHandledExitInfo);
+
+        return newExitInfo;
+    }
+
+    public JSONObject getExitInfo(ApplicationExitInfo exitInfo) throws JSONException {
         JSONObject jsonObject = new JSONObject();
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-            int reason = exitInfo.getReason();
-            if(getExitReasonsToCapture().contains(reason)){
+            if(ApplicationExitInfoExt.shouldBeReported(exitInfo)){
                 long timestamp = exitInfo.getTimestamp();
                 int status = exitInfo.getStatus();
                 String description = exitInfo.getDescription();
-                jsonObject.put("reason", getReasonName(reason));
+                jsonObject.put("reason", ApplicationExitInfoExt.getReasonName(exitInfo));
                 jsonObject.put("timestamp", timestamp);
                 jsonObject.put("status", status);
                 jsonObject.put("description", description);
@@ -48,55 +76,5 @@ public class ExitInfoHelper {
         }
         return jsonObject;
     }
-
-    @RequiresApi(api = Build.VERSION_CODES.R)
-    private static List<Integer> getExitReasonsToCapture() {
-        return Arrays.asList(
-                ApplicationExitInfo.REASON_ANR,
-                ApplicationExitInfo.REASON_CRASH,
-                ApplicationExitInfo.REASON_CRASH_NATIVE,
-                ApplicationExitInfo.REASON_DEPENDENCY_DIED,
-                ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE,
-                ApplicationExitInfo.REASON_EXIT_SELF,
-                ApplicationExitInfo.REASON_INITIALIZATION_FAILURE,
-                ApplicationExitInfo.REASON_LOW_MEMORY,
-                ApplicationExitInfo.REASON_SIGNALED,
-                ApplicationExitInfo.REASON_UNKNOWN
-        );
-    }
-
-    private static String getReasonName(int reason) {
-        switch (reason) {
-            case ApplicationExitInfo.REASON_ANR:
-                return "ANR";
-            case ApplicationExitInfo.REASON_CRASH:
-                return "Crash";
-            case ApplicationExitInfo.REASON_CRASH_NATIVE:
-                return "Native Crash";
-            case ApplicationExitInfo.REASON_DEPENDENCY_DIED:
-                return "Dependency Died";
-            case ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE:
-                return "Excessive Resource Usage";
-            case ApplicationExitInfo.REASON_EXIT_SELF:
-                return "Exit Self";
-            case ApplicationExitInfo.REASON_INITIALIZATION_FAILURE:
-                return "Initialization Failure";
-            case ApplicationExitInfo.REASON_LOW_MEMORY:
-                return "Low Memory";
-            case ApplicationExitInfo.REASON_OTHER:
-                return "Other";
-            case ApplicationExitInfo.REASON_PERMISSION_CHANGE:
-                return "Permission Change";
-            case ApplicationExitInfo.REASON_SIGNALED:
-                return "Signaled";
-            case ApplicationExitInfo.REASON_UNKNOWN:
-                return "Unknown";
-            case ApplicationExitInfo.REASON_USER_REQUESTED:
-                return "User Requested";
-            case ApplicationExitInfo.REASON_USER_STOPPED:
-                return "User Stopped";
-            default:
-                return "Unknown Reason";
-        }
-    }
 }
+

--- a/packages/rum_sdk/android/src/main/java/com/example/rum_sdk/RumSdkPlugin.java
+++ b/packages/rum_sdk/android/src/main/java/com/example/rum_sdk/RumSdkPlugin.java
@@ -42,6 +42,7 @@ public class RumSdkPlugin implements FlutterPlugin, MethodCallHandler, ActivityA
   private Context context;
   private @Nullable WeakReference<Activity> activity= null;
   private ANRTracker anrTracker;
+  private ExitInfoHelper exitInfoHelper;
   private Window window;
   private Application application;
 
@@ -82,6 +83,7 @@ public class RumSdkPlugin implements FlutterPlugin, MethodCallHandler, ActivityA
     }
     context = binding.getActivity();
     RumCache.setContext(activity.get().getApplicationContext());
+    exitInfoHelper = new ExitInfoHelper(context);
     RumCache rumCache = new RumCache();
     ArrayList<String> lst = rumCache.readFromCache();
     if(lst.size()>0){
@@ -189,12 +191,12 @@ public class RumSdkPlugin implements FlutterPlugin, MethodCallHandler, ActivityA
   }
 
   private List<String> getExitInfo() throws JSONException {
-    List<ApplicationExitInfo> exitInfos = ExitInfoHelper.getApplicationExitInfo(context);
+    List<ApplicationExitInfo> exitInfos = exitInfoHelper.getApplicationExitInfo(context);
     List<String> infoList = new ArrayList<>();
 
     if (exitInfos != null) {
       for (ApplicationExitInfo exitInfo : exitInfos) {
-        JSONObject info = ExitInfoHelper.getExitInfo(exitInfo);
+        JSONObject info = exitInfoHelper.getExitInfo(exitInfo);
         if(info != null && info.length() > 0){
           String infoString = info.toString();
           infoList.add(infoString);

--- a/packages/rum_sdk/android/src/main/java/com/example/rum_sdk/SharedPreferencesService.java
+++ b/packages/rum_sdk/android/src/main/java/com/example/rum_sdk/SharedPreferencesService.java
@@ -1,0 +1,25 @@
+package com.example.rum_sdk;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class SharedPreferencesService {
+    private static final String PREFS_NAME = "rum_sdk_lib_prefs";
+    private static final String HANDLED_EXIT_INFO_KEY = "handled_exit_info";
+    private final SharedPreferences prefs;
+
+    public SharedPreferencesService(Context context) {
+        this.prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    public Set<String> getHandledExitInfos() {
+        return new HashSet<>(prefs.getStringSet(HANDLED_EXIT_INFO_KEY, new HashSet<>()));
+    }
+
+    public void setHandledExitInfos(Set<String> handledExitInfos) {
+        prefs.edit().putStringSet(HANDLED_EXIT_INFO_KEY, new HashSet<>(handledExitInfos)).apply();
+    }
+}

--- a/packages/rum_sdk/example/ios/Podfile.lock
+++ b/packages/rum_sdk/example/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
     - Flutter
     - FlutterMacOS
   - PLCrashReporter (1.11.2)
-  - rum_sdk (0.0.1):
+  - rum_sdk (0.1.1):
     - Flutter
     - PLCrashReporter
   - shared_preferences_foundation (0.0.1):
@@ -48,13 +48,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
-  connectivity_plus: 4c41c08fc6d7c91f63bc7aec70ffe3730b04f563
+  connectivity_plus: 18382e7311ba19efcaee94442b23b32507b20695
   device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   PLCrashReporter: 499c53b0104f95c302d94fd723ebb03c56d9bac8
-  rum_sdk: db4dd1b69e549d7bd79f198d366cb4f9560480be
+  rum_sdk: a5f1d268c968c0a638a744d7f2ee0b01d0a35565
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
 
 PODFILE CHECKSUM: 3765b805c03121794c6d132546df9366f592bc4d

--- a/packages/rum_sdk/example/pubspec.lock
+++ b/packages/rum_sdk/example/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "876849631b0c7dc20f8b471a2a03142841b482438e3b707955464f5ffca3e4c3"
+      sha256: "8a68739d3ee113e51ad35583fdf9ab82c55d09d693d3c39da1aebab87c938412"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.2"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -257,7 +257,7 @@ packages:
     source: hosted
     version: "0.5.0"
   offline_transport:
-    dependency: "direct main"
+    dependency: "direct overridden"
     description:
       path: "../../offline_transport"
       relative: true
@@ -389,7 +389,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "0.1.1"
   shared_preferences:
     dependency: transitive
     description:

--- a/packages/rum_sdk/example/pubspec.yaml
+++ b/packages/rum_sdk/example/pubspec.yaml
@@ -16,8 +16,6 @@ dependencies:
     sdk: flutter
   rum_sdk:
     path: ../
-  offline_transport:
-    path: ../../offline_transport
   http: ^1.2.2
   #    path: ../../rum_dart
 

--- a/packages/rum_sdk/ios/rum_sdk.podspec
+++ b/packages/rum_sdk/ios/rum_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'rum_sdk'
-  s.version          = '0.0.1'
+  s.version          = '0.1.1'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/packages/rum_sdk/pubspec.yaml
+++ b/packages/rum_sdk/pubspec.yaml
@@ -1,7 +1,7 @@
 publish_to: none
 name: rum_sdk
 description: A new Flutter plugin project.
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
On Android, we use `activityManager.getHistoricalProcessExitReasons(...)` to get the latests crash reports.
These are stored on device and are persisted. I think it keeps the last 100 crash reports.

We were asking android for these reports on each start of our package. So we kept getting the same reports.

To fix this. I now store the handled reports in sharedPrefs. And then ignore these reports when I grab the next report.