### PR TITLE
set default namespace when null and not send trace when no data

### DIFF
--- a/packages/rum_sdk/lib/rum_flutter.dart
+++ b/packages/rum_sdk/lib/rum_flutter.dart
@@ -105,7 +105,7 @@ class RumFlutter {
       appVersion: optionsConfiguration.appVersion == null
           ? packageInfo.version
           : optionsConfiguration.appVersion!,
-      namespace: optionsConfiguration.namespace,
+      namespace: optionsConfiguration.namespace ?? '',
     );
     if (config?.enableCrashReporting == true) {
       _instance.enableCrashReporter(

--- a/packages/rum_sdk/lib/src/models/event.dart
+++ b/packages/rum_sdk/lib/src/models/event.dart
@@ -25,7 +25,11 @@ class Event {
     map['domain'] = domain;
     map['timestamp'] = timestamp;
     map['attributes'] = attributes;
-    map['trace'] = trace;
+
+    if(trace != null){
+      map['trace'] = trace;
+    }
+    
     return map;
   }
 }

--- a/packages/rum_sdk/lib/src/models/event.dart
+++ b/packages/rum_sdk/lib/src/models/event.dart
@@ -26,10 +26,10 @@ class Event {
     map['timestamp'] = timestamp;
     map['attributes'] = attributes;
 
-    if(trace != null){
+    if (trace != null) {
       map['trace'] = trace;
     }
-    
+
     return map;
   }
 }

--- a/packages/rum_sdk/lib/src/transport/rum_transport.dart
+++ b/packages/rum_sdk/lib/src/transport/rum_transport.dart
@@ -45,7 +45,7 @@ class RUMTransport extends BaseTransport {
     if (response != null && response?.statusCode ~/ 100 != 2) {
       log(
         // ignore: lines_longer_than_80_chars
-        'Error sending payload: ${response?.statusCode}, body: ${response?.body}',
+        'Error sending payload: ${response?.statusCode}, body: ${response?.body} payload:${jsonEncode(payloadJson)}',
       );
     }
   }


### PR DESCRIPTION
- set default namespace when nul
- not sending trace on event when no trace available
- add payload to error message