### PR TITLE
chore: update CHANGELOG and GitHub workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to pub.dev
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 on:
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.1
 
-- Version bump
+- Updates README
 
 ## 0.3.0
 


### PR DESCRIPTION
- Updated CHANGELOG.md to reflect changes in the README.
- Added 'id-token: write' permission to the publish workflow for enhanced security and functionality.