### PR TITLE
feat: add header to config to send with each request

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ Faro().runApp(
       appVersion: "1.0.0",
       appEnv: "Production",
       apiKey: "<API_KEY>",
-      collectorUrl: "faro receiver endpoint"
+      collectorUrl: "faro receiver endpoint",
+      collectorHeaders: {
+        ... // custom headers to be sent with each request to the collector url
+      }
   ),
   appRunner: () => runApp(
    FaroUserInteractionWidget(child: MyApp())

--- a/lib/faro.dart
+++ b/lib/faro.dart
@@ -94,6 +94,7 @@ class Faro {
               apiKey: optionsConfiguration.apiKey,
               maxBufferLimit: config?.maxBufferLimit,
               sessionId: meta.session?.id,
+              headers: optionsConfiguration.headers,
             ),
           );
     } else {

--- a/lib/faro.dart
+++ b/lib/faro.dart
@@ -94,7 +94,7 @@ class Faro {
               apiKey: optionsConfiguration.apiKey,
               maxBufferLimit: config?.maxBufferLimit,
               sessionId: meta.session?.id,
-              headers: optionsConfiguration.headers,
+              headers: optionsConfiguration.collectorHeaders,
             ),
           );
     } else {

--- a/lib/src/configurations/faro_config.dart
+++ b/lib/src/configurations/faro_config.dart
@@ -18,6 +18,7 @@ class FaroConfig {
     BatchConfig? batchConfig,
     this.ignoreUrls,
     this.maxBufferLimit = 30,
+    this.headers,
   })  : assert(appName.isNotEmpty, 'appName cannot be empty'),
         assert(appEnv.isNotEmpty, 'appEnv cannot be empty'),
         assert(apiKey.isNotEmpty, 'apiKey cannot be empty'),
@@ -39,6 +40,7 @@ class FaroConfig {
   final int maxBufferLimit;
   final Duration? fetchVitalsInterval;
   final List<RegExp>? ignoreUrls;
+  final Map<String, String>? headers;
 
 // Other methods or properties of FaroConfig can be added here
 }

--- a/lib/src/configurations/faro_config.dart
+++ b/lib/src/configurations/faro_config.dart
@@ -18,7 +18,7 @@ class FaroConfig {
     BatchConfig? batchConfig,
     this.ignoreUrls,
     this.maxBufferLimit = 30,
-    this.headers,
+    this.collectorHeaders,
   })  : assert(appName.isNotEmpty, 'appName cannot be empty'),
         assert(appEnv.isNotEmpty, 'appEnv cannot be empty'),
         assert(apiKey.isNotEmpty, 'apiKey cannot be empty'),
@@ -30,6 +30,7 @@ class FaroConfig {
   final String? appVersion;
   final String? namespace;
   final String? collectorUrl;
+  final Map<String, String>? collectorHeaders;
   final List<FaroTransport>? transports;
   final bool memoryUsageVitals;
   final bool cpuUsageVitals;
@@ -40,7 +41,6 @@ class FaroConfig {
   final int maxBufferLimit;
   final Duration? fetchVitalsInterval;
   final List<RegExp>? ignoreUrls;
-  final Map<String, String>? headers;
 
 // Other methods or properties of FaroConfig can be added here
 }

--- a/lib/src/transport/faro_transport.dart
+++ b/lib/src/transport/faro_transport.dart
@@ -13,6 +13,7 @@ class FaroTransport extends BaseTransport {
     required this.apiKey,
     this.sessionId,
     int? maxBufferLimit,
+    this.headers,
   }) {
     _taskBuffer = TaskBuffer(maxBufferLimit ?? 30);
   }
@@ -20,6 +21,7 @@ class FaroTransport extends BaseTransport {
   final String apiKey;
   final String? sessionId;
   TaskBuffer<dynamic>? _taskBuffer;
+  final Map<String, String>? headers;
 
   @override
   Future<void> send(Map<String, dynamic> payloadJson) async {
@@ -38,6 +40,7 @@ class FaroTransport extends BaseTransport {
         'Content-Type': 'application/json',
         'x-api-key': apiKey,
         if (sessionId != null) 'x-faro-session-id': sessionId,
+        ...?this.headers,
       };
       final response = await _taskBuffer?.add(() {
         return http.post(


### PR DESCRIPTION
## Summary

This pull request adds support for custom HTTP headers in the `FaroConfig`, allowing users to specify headers that will be included in all outgoing requests made by the SDK.

## Context

In our internal usage of the faro-flutter-sdk, requests to our Alloy instance were returning 404 Not Found responses. After debugging, we identified that our deployment requires a host header to correctly route and process tracking events.

To support this, we introduced a configurable `headers` field in `FaroConfig`, which enables us (and others with similar requirements) to inject any necessary headers globally.

## Changes

- Added a new `Map<String, String>? headers` field to FaroConfig.
- These headers are now included in all HTTP requests made by the SDK.