### PR TITLE
chore: bump version to v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2025-05-28
+
+### Added
+
+- Support for custom HTTP headers in `FaroConfig` via the `collectorHeaders` field
+  - Allows users to specify headers that will be included in all requests to the collector endpoint
+  - Useful for deployments that require specific headers for routing or authentication
+
 ## [0.3.4] - 2025-05-22
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.3.4'
+version '0.3.5'
 
 buildscript {
     repositories {

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.3.4'
+  s.version          = '0.3.5'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.3.4
+version: 0.3.5
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 


### PR DESCRIPTION
- Bumped version to 0.3.5 in pubspec.yaml, build.gradle, and faro.podspec.
- Updated CHANGELOG.md to include the addition of `collectorHeaders` in `FaroConfig`, allowing users to specify custom HTTP headers for requests to the collector endpoint.