### PR TITLE
feat: implement persistent data collection setting across app restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Data Collection Persistence**: The `enableDataCollection` setting now persists across app restarts
+  - Automatically saves the data collection preference to device storage using SharedPreferences
+  - Defaults to enabled on first app launch
+  - Fire-and-forget persistence - no need to await setting changes
+  - Maintains full backward compatibility with existing API
+  - Resolves issue #62: "Persist faro.enableDataCollection"
 - GitHub issue templates for bug reports and feature requests
 - Pull request template for standardized contributions
 - Code of Conduct (Contributor Covenant v1.4)

--- a/doc/Configurations.md
+++ b/doc/Configurations.md
@@ -180,3 +180,34 @@ To capture the duration of an event you can use the following methods
     // example
     Faro().addUserMeta(userId:"123",userName:"user",userEmail:"jhondoes@something.com")
 ```
+
+### Data Collection Control
+
+Faro provides the ability to enable or disable data collection at runtime. This setting is automatically persisted across app restarts, so you don't need to set it every time your app starts.
+
+#### Getting Current State
+
+```dart
+bool isEnabled = Faro().enableDataCollection;
+```
+
+#### Enabling/Disabling Data Collection
+
+```dart
+// Disable data collection (automatically persisted)
+Faro().enableDataCollection = false;
+```
+
+#### Persistence Behavior
+
+- **Default State**: Data collection is enabled by default on first app launch
+- **Automatic Persistence**: Any changes to the data collection setting are automatically saved to device storage
+- **Cross-Session**: The setting persists across app restarts, device reboots, and app updates
+- **Storage**: Uses SharedPreferences on both iOS and Android for reliable persistence
+
+#### Use Cases
+
+This feature is particularly useful for:
+
+- **Privacy Controls**: Allow users to opt-out of data collection
+- **Compliance**: Meet regulatory requirements for data collection consent

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -143,102 +143,114 @@ class _FeaturesPageState extends State<FeaturesPage> {
       appBar: AppBar(
         title: const Text('Features'),
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton(
-              child: const Text('HTTP POST Request - success'),
-              onPressed: () async {
-                await http.post(
-                  Uri.parse('https://httpbin.io/post'),
-                  body: jsonEncode(<String, String>{
-                    'title': "This is a title",
-                  }),
-                );
-              },
-            ),
-            ElevatedButton(
-              child: const Text('HTTP POST Request - fail'),
-              onPressed: () async {
-                await http.post(
-                  Uri.parse('https://httpbin.io/unstable'),
-                  body: jsonEncode(<String, String>{
-                    'title': "This is a title",
-                  }),
-                );
-              },
-            ),
-            ElevatedButton(
-              child: const Text('HTTP GET Request - success'),
-              onPressed: () async {
-                await http.get(Uri.parse('https://httpbin.io/get?foo=bar'));
-              },
-            ),
-            ElevatedButton(
-              child: const Text('HTTP GET Request - fail'),
-              onPressed: () async {
-                await http.get(Uri.parse('https://httpbin.io/unstable'));
-              },
-            ),
-            ElevatedButton(
-              child: const Text('Custom Warn Log'),
-              onPressed: () {
-                Faro().pushLog("Custom Log", level: "warn");
-              },
-            ),
-            ElevatedButton(
-              child: const Text('Custom Measurement'),
-              onPressed: () {
-                Faro()
-                    .pushMeasurement({'custom_value': 1}, "custom_measurement");
-              },
-            ),
-            ElevatedButton(
-              child: const Text('Custom Event'),
-              onPressed: () {
-                Faro().pushEvent("custom_event");
-              },
-            ),
-            ElevatedButton(
-              child: const Text('Error'),
-              onPressed: () {
-                setState(() {
-                  throw Error();
-                });
-              },
-            ),
-            ElevatedButton(
-              child: const Text('Exception'),
-              onPressed: () {
-                setState(() {
-                  double _ = 0 / 0;
-                  throw Exception("This is an Exception!");
-                });
-              },
-            ),
-            ElevatedButton(
-              child: const Text('Mark Event Start'),
-              onPressed: () async {
-                Faro().markEventStart("event1", "event1_duration");
-              },
-            ),
-            ElevatedButton(
-              child: const Text('Mark Event End'),
-              onPressed: () async {
-                Faro().markEventEnd("event1", "event1_duration");
-              },
-            ),
-            ElevatedButton(
-              onPressed: () => simulateANR(),
-              child: const Text('Simulate ANR (10s)'),
-            ),
-            ElevatedButton(
-              onPressed: () => simulateANR(seconds: 8),
-              child: const Text('Simulate ANR (8s)'),
-            ),
-            const SizedBox(height: 16),
-          ],
+      body: SingleChildScrollView(
+        physics: const BouncingScrollPhysics(),
+        padding: const EdgeInsets.all(16.0),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                child: const Text('HTTP POST Request - success'),
+                onPressed: () async {
+                  await http.post(
+                    Uri.parse('https://httpbin.io/post'),
+                    body: jsonEncode(<String, String>{
+                      'title': "This is a title",
+                    }),
+                  );
+                },
+              ),
+              ElevatedButton(
+                child: const Text('HTTP POST Request - fail'),
+                onPressed: () async {
+                  await http.post(
+                    Uri.parse('https://httpbin.io/unstable'),
+                    body: jsonEncode(<String, String>{
+                      'title': "This is a title",
+                    }),
+                  );
+                },
+              ),
+              ElevatedButton(
+                child: const Text('HTTP GET Request - success'),
+                onPressed: () async {
+                  await http.get(Uri.parse('https://httpbin.io/get?foo=bar'));
+                },
+              ),
+              ElevatedButton(
+                child: const Text('HTTP GET Request - fail'),
+                onPressed: () async {
+                  await http.get(Uri.parse('https://httpbin.io/unstable'));
+                },
+              ),
+              ElevatedButton(
+                child: const Text('Custom Warn Log'),
+                onPressed: () {
+                  Faro().pushLog("Custom Log", level: "warn");
+                },
+              ),
+              ElevatedButton(
+                child: const Text('Custom Measurement'),
+                onPressed: () {
+                  Faro().pushMeasurement(
+                      {'custom_value': 1}, "custom_measurement");
+                },
+              ),
+              ElevatedButton(
+                child: const Text('Custom Event'),
+                onPressed: () {
+                  Faro().pushEvent("custom_event");
+                },
+              ),
+              ElevatedButton(
+                child: const Text('Error'),
+                onPressed: () {
+                  setState(() {
+                    throw Error();
+                  });
+                },
+              ),
+              ElevatedButton(
+                child: const Text('Exception'),
+                onPressed: () {
+                  setState(() {
+                    double _ = 0 / 0;
+                    throw Exception("This is an Exception!");
+                  });
+                },
+              ),
+              ElevatedButton(
+                child: const Text('Mark Event Start'),
+                onPressed: () async {
+                  Faro().markEventStart("event1", "event1_duration");
+                },
+              ),
+              ElevatedButton(
+                child: const Text('Mark Event End'),
+                onPressed: () async {
+                  Faro().markEventEnd("event1", "event1_duration");
+                },
+              ),
+              ElevatedButton(
+                onPressed: () => simulateANR(),
+                child: const Text('Simulate ANR (10s)'),
+              ),
+              ElevatedButton(
+                onPressed: () => simulateANR(seconds: 8),
+                child: const Text('Simulate ANR (8s)'),
+              ),
+              ElevatedButton(
+                child: Text(
+                    'Data Collection: ${Faro().enableDataCollection ? "ENABLED" : "DISABLED"}'),
+                onPressed: () {
+                  Faro().enableDataCollection = !Faro().enableDataCollection;
+                  setState(() {}); // Refresh UI
+                },
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/faro.dart
+++ b/lib/faro.dart
@@ -33,12 +33,15 @@ class Faro {
   @visibleForTesting
   static set instance(Faro instance) => _instance = instance;
 
-  bool get enableDataCollection => DataCollectionPolicy().isEnabled;
+  bool get enableDataCollection => _dataCollectionPolicy?.isEnabled ?? true;
+
+  /// Set data collection enabled/disabled.
+  /// This setting will be automatically persisted across app restarts.
   set enableDataCollection(bool enable) {
     if (enable) {
-      DataCollectionPolicy().enable();
+      _dataCollectionPolicy?.enable();
     } else {
-      DataCollectionPolicy().disable();
+      _dataCollectionPolicy?.disable();
     }
   }
 
@@ -46,6 +49,7 @@ class Faro {
   List<BaseTransport> _transports = [];
   BatchTransport? _batchTransport;
   List<BaseTransport> get transports => _transports;
+  DataCollectionPolicy? _dataCollectionPolicy;
 
   Meta meta = Meta(
       session: Session(generateSessionID(), attributes: {}),
@@ -74,7 +78,14 @@ class Faro {
     _batchTransport = batchTransport;
   }
 
+  @visibleForTesting
+  set dataCollectionPolicy(DataCollectionPolicy? policy) {
+    _dataCollectionPolicy = policy;
+  }
+
   Future<void> init({required FaroConfig optionsConfiguration}) async {
+    _dataCollectionPolicy = await DataCollectionPolicyFactory().create();
+
     final attributesProvider =
         await SessionAttributesProviderFactory().create();
     meta.session?.attributes = await attributesProvider.getAttributes();

--- a/lib/src/data_collection_policy.dart
+++ b/lib/src/data_collection_policy.dart
@@ -1,23 +1,48 @@
 import 'dart:developer';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class DataCollectionPolicy {
-  factory DataCollectionPolicy() {
-    return _instance;
+  DataCollectionPolicy({
+    required SharedPreferences sharedPreferences,
+  }) : _sharedPreferences = sharedPreferences {
+    _initialize();
   }
 
-  DataCollectionPolicy._();
-  static final DataCollectionPolicy _instance = DataCollectionPolicy._();
-
+  final SharedPreferences _sharedPreferences;
+  static const String _enableDataCollectionKey = 'faro_enable_data_collection';
   bool _isEnabled = true;
+
   bool get isEnabled => _isEnabled;
 
-  void enable() {
-    log('Enabling data collection');
+  Future<void> enable() async {
+    log('Enabling faro telemetry collection');
     _isEnabled = true;
+    await _persistSetting();
   }
 
-  void disable() {
-    log('Disabling data collection');
+  Future<void> disable() async {
+    log('Disabling faro telemetry collection');
     _isEnabled = false;
+    await _persistSetting();
+  }
+
+  void _initialize() {
+    _isEnabled = _sharedPreferences.getBool(_enableDataCollectionKey) ?? true;
+  }
+
+  Future<void> _persistSetting() async {
+    try {
+      await _sharedPreferences.setBool(_enableDataCollectionKey, _isEnabled);
+      log('Data collection setting persisted: $_isEnabled');
+    } catch (error) {
+      log('Failed to persist data collection setting: $error');
+    }
+  }
+}
+
+class DataCollectionPolicyFactory {
+  Future<DataCollectionPolicy> create() async {
+    final sharedPreferences = await SharedPreferences.getInstance();
+    return DataCollectionPolicy(sharedPreferences: sharedPreferences);
   }
 }

--- a/lib/src/transport/faro_transport.dart
+++ b/lib/src/transport/faro_transport.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 
-import 'package:faro/src/data_collection_policy.dart';
+import 'package:faro/faro.dart';
 import 'package:faro/src/transport/faro_base_transport.dart';
 import 'package:faro/src/transport/task_buffer.dart';
 import 'package:http/http.dart' as http;
@@ -25,7 +25,7 @@ class FaroTransport extends BaseTransport {
 
   @override
   Future<void> send(Map<String, dynamic> payloadJson) async {
-    if (DataCollectionPolicy().isEnabled == false) {
+    if (Faro().enableDataCollection == false) {
       log('Data collection is disabled. Skipping sending data.');
       return;
     }

--- a/test/unit_test/data_collection_policy_test.dart
+++ b/test/unit_test/data_collection_policy_test.dart
@@ -1,0 +1,151 @@
+import 'package:faro/src/data_collection_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockSharedPreferences extends Mock implements SharedPreferences {}
+
+void main() {
+  late MockSharedPreferences mockSharedPreferences;
+  late DataCollectionPolicy sut;
+
+  setUp(() {
+    mockSharedPreferences = MockSharedPreferences();
+    reset(mockSharedPreferences);
+  });
+
+  group('DataCollectionPolicy:', () {
+    test('should default to enabled when no previous value is stored', () {
+      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .thenReturn(null);
+      when(() => mockSharedPreferences.setBool(any(), any()))
+          .thenAnswer((_) async => true);
+
+      sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
+
+      expect(sut.isEnabled, isTrue);
+      verify(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .called(1);
+    });
+
+    test('should load persisted disabled state', () {
+      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .thenReturn(false);
+      when(() => mockSharedPreferences.setBool(any(), any()))
+          .thenAnswer((_) async => true);
+
+      sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
+
+      expect(sut.isEnabled, isFalse);
+      verify(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .called(1);
+    });
+
+    test('should load persisted enabled state', () {
+      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .thenReturn(true);
+      when(() => mockSharedPreferences.setBool(any(), any()))
+          .thenAnswer((_) async => true);
+
+      sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
+
+      expect(sut.isEnabled, isTrue);
+      verify(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .called(1);
+    });
+
+    test('should persist enabled state when calling enable()', () async {
+      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .thenReturn(null);
+      when(() => mockSharedPreferences.setBool(any(), any()))
+          .thenAnswer((_) async => true);
+
+      sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
+
+      await sut.enable();
+
+      expect(sut.isEnabled, isTrue);
+      verify(() => mockSharedPreferences.setBool(
+          'faro_enable_data_collection', true)).called(1);
+    });
+
+    test('should persist disabled state when calling disable()', () async {
+      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .thenReturn(null);
+      when(() => mockSharedPreferences.setBool(any(), any()))
+          .thenAnswer((_) async => true);
+
+      sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
+
+      await sut.disable();
+
+      expect(sut.isEnabled, isFalse);
+      verify(() => mockSharedPreferences.setBool(
+          'faro_enable_data_collection', false)).called(1);
+    });
+
+    test('should persist state change from enabled to disabled', () async {
+      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .thenReturn(true);
+      when(() => mockSharedPreferences.setBool(any(), any()))
+          .thenAnswer((_) async => true);
+
+      sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
+
+      expect(sut.isEnabled, isTrue);
+
+      await sut.disable();
+
+      expect(sut.isEnabled, isFalse);
+      verify(() => mockSharedPreferences.setBool(
+          'faro_enable_data_collection', false)).called(1);
+    });
+
+    test('should persist state change from disabled to enabled', () async {
+      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .thenReturn(false);
+      when(() => mockSharedPreferences.setBool(any(), any()))
+          .thenAnswer((_) async => true);
+
+      sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
+
+      expect(sut.isEnabled, isFalse);
+
+      await sut.enable();
+
+      expect(sut.isEnabled, isTrue);
+      verify(() => mockSharedPreferences.setBool(
+          'faro_enable_data_collection', true)).called(1);
+    });
+
+    test('should handle SharedPreferences setBool errors gracefully', () async {
+      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
+          .thenReturn(null);
+      when(() => mockSharedPreferences.setBool(any(), any()))
+          .thenThrow(Exception('Storage failed'));
+
+      sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
+
+      // Should not throw, just log the error
+      await sut.enable();
+
+      // State should still be updated in memory
+      expect(sut.isEnabled, isTrue);
+      verify(() => mockSharedPreferences.setBool(
+          'faro_enable_data_collection', true)).called(1);
+    });
+  });
+
+  group('DataCollectionPolicyFactory:', () {
+    test('should create DataCollectionPolicy instance', () async {
+      // The factory uses real SharedPreferences, so we need Flutter binding
+      SharedPreferences.setMockInitialValues({});
+
+      final factory = DataCollectionPolicyFactory();
+      final policy = await factory.create();
+
+      expect(policy, isA<DataCollectionPolicy>());
+      expect(policy.isEnabled, isTrue); // Default state
+    });
+  });
+}


### PR DESCRIPTION
## Description

Before the `enableDataCollection` settings was only kept in memory. So if you toggled it off, then on next app start, it would be on again.
This fix changes this behavior so that the setting is persisted between app starts. 
The setting is stored in UserDefaults on iOS and SharedPreferences on Android.

Also updates the example app with a new button to toggle the enableDataCollection and show that current state.

## Related Issue(s)

Fixes #62 

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section
