### PR TITLE
fix: resolve Critical NullPointerException in Android frame monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Developer experience with better onboarding documentation
 - Code contribution workflow with standardized templates and processes
 
+### Fixed
+
+- **Critical NullPointerException in Android frame monitoring**: Fixed crash when frame monitoring callbacks execute after Flutter engine detachment
+  - Added proper cleanup in `stopFrameMonitoring()` to remove Choreographer callbacks
+  - Added null checks in `handleFrameDrop()`, `handleSlowFrameDrop()`, and `handleRefreshRate()` methods
+  - Added safety guards to prevent frame processing when monitoring is stopped
+  - Prevents crashes when app goes to background or during configuration changes
+
 ## [0.3.5] - 2025-05-28
 
 ### Added


### PR DESCRIPTION
## Description

This PR addresses a critical NullPointerException that occurred during frame monitoring callbacks after the Flutter engine detachment. 

### Changes Made
- Implemented proper cleanup in `stopFrameMonitoring()` to remove Choreographer callbacks.
- Added null checks in `handleFrameDrop()`, `handleSlowFrameDrop()`, and `handleRefreshRate()` methods to prevent crashes.
- Introduced safety guards to ensure frame processing is halted when monitoring is stopped, preventing crashes during background transitions or configuration changes.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [x] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section
