### PR TITLE
fix: correct span event naming for HTTP vs non-HTTP spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Span event naming**: Fixed incorrect event names for tracing spans
+  - HTTP spans now correctly use `faro.tracing.fetch` event name
+  - Non-HTTP spans use `span.{name}` format for better event categorization
+  - Added logic to detect HTTP spans based on `http.scheme` or `http.method` attributes
+  - Resolves issue #41: Incorrect span event names being sent to collector
+
 ## [0.3.6] - 2025-06-05
 
 ### Added

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -61,4 +61,23 @@ class SpanRecord {
     }
     return faroEventAttributes;
   }
+
+  String getFaroEventName() {
+    // Check for HTTP semantic attributes to determine if it's an HTTP span
+    final attributes = _otelReadOnlySpan.attributes;
+    final httpScheme = attributes.get('http.scheme');
+    final httpMethod = attributes.get('http.method');
+
+    final hasHttpScheme =
+        httpScheme != null && httpScheme.toString().isNotEmpty;
+    final hasHttpMethod =
+        httpMethod != null && httpMethod.toString().isNotEmpty;
+
+    if (hasHttpScheme || hasHttpMethod) {
+      return 'faro.tracing.fetch';
+    } else {
+      // Use the original span name prefixed with "span." for non-HTTP spans
+      return 'span.${name()}';
+    }
+  }
 }

--- a/lib/src/tracing/faro_exporter.dart
+++ b/lib/src/tracing/faro_exporter.dart
@@ -31,7 +31,7 @@ class FaroExporter implements otel_sdk.SpanExporter {
       final spanRecord = SpanRecord(otelReadOnlySpan: otelReadOnlySpan);
 
       faro.pushEvent(
-        'faro.tracing.${spanRecord.name()}',
+        spanRecord.getFaroEventName(),
         attributes: spanRecord.getFaroEventAttributes(),
         trace: spanRecord.getFaroSpanContext(),
       );

--- a/test/src/models/span_record_test.dart
+++ b/test/src/models/span_record_test.dart
@@ -1,0 +1,162 @@
+import 'package:faro/src/models/span_record.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:opentelemetry/sdk.dart' as otel_sdk;
+
+class MockReadOnlySpan extends Mock implements otel_sdk.ReadOnlySpan {}
+
+class MockAttributes extends Mock implements otel_sdk.Attributes {}
+
+void main() {
+  group('SpanRecord:', () {
+    group('getFaroEventName:', () {
+      test('returns "faro.tracing.fetch" for HTTP spans with http.scheme', () {
+        // Arrange
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.name).thenReturn('HTTP GET');
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.get('http.scheme')).thenReturn('https');
+        when(() => mockAttributes.get('http.method')).thenReturn(null);
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventName();
+
+        // Assert
+        expect(result, 'faro.tracing.fetch');
+      });
+
+      test('returns "faro.tracing.fetch" for HTTP spans with http.method', () {
+        // Arrange
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.name).thenReturn('HTTP POST');
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.get('http.scheme')).thenReturn(null);
+        when(() => mockAttributes.get('http.method')).thenReturn('POST');
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventName();
+
+        // Assert
+        expect(result, 'faro.tracing.fetch');
+      });
+
+      test('returns "faro.tracing.fetch" for HTTP spans with both attributes',
+          () {
+        // Arrange
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.name).thenReturn('HTTP GET');
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.get('http.scheme')).thenReturn('https');
+        when(() => mockAttributes.get('http.method')).thenReturn('GET');
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventName();
+
+        // Assert
+        expect(result, 'faro.tracing.fetch');
+      });
+
+      test('returns "span.{name}" for non-HTTP spans', () {
+        // Arrange
+        const spanName = 'database-query';
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.name).thenReturn(spanName);
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.get('http.scheme')).thenReturn(null);
+        when(() => mockAttributes.get('http.method')).thenReturn(null);
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventName();
+
+        // Assert
+        expect(result, 'span.$spanName');
+      });
+
+      test('returns "span.{name}" for spans with empty HTTP attributes', () {
+        // Arrange
+        const spanName = 'custom-operation';
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.name).thenReturn(spanName);
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.get('http.scheme')).thenReturn('');
+        when(() => mockAttributes.get('http.method')).thenReturn('');
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventName();
+
+        // Assert
+        expect(result, 'span.$spanName');
+      });
+
+      test('handles complex span names correctly', () {
+        // Arrange
+        const spanName =
+            'my-service.complex-operation-with-dashes_and_underscores';
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.name).thenReturn(spanName);
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.get('http.scheme')).thenReturn(null);
+        when(() => mockAttributes.get('http.method')).thenReturn(null);
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventName();
+
+        // Assert
+        expect(result, 'span.$spanName');
+      });
+
+      test('handles empty span names correctly', () {
+        // Arrange
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.name).thenReturn('');
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.get('http.scheme')).thenReturn(null);
+        when(() => mockAttributes.get('http.method')).thenReturn(null);
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventName();
+
+        // Assert
+        expect(result, 'span.');
+      });
+    });
+
+    group('name:', () {
+      test('returns the span name from OpenTelemetry span', () {
+        // Arrange
+        const expectedName = 'test-span-name';
+        final mockSpan = MockReadOnlySpan();
+        when(() => mockSpan.name).thenReturn(expectedName);
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.name();
+
+        // Assert
+        expect(result, expectedName);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

- Add getFaroEventName() method to SpanRecord for proper event naming
- HTTP spans now use 'faro.tracing.fetch' event name
- Non-HTTP spans use 'span.{name}' format for better categorization
- Add comprehensive tests for span event name logic

## Related Issue(s)

Fixes #41

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section
