### PR TITLE
fix: sanitize attribute values to ensure consistent formatting

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -108,6 +108,27 @@ This is a Flutter SDK that implements the Grafana Faro protocol for mobile obser
 - Provide migration guides
 - Include troubleshooting information
 
+## Git & Commit Guidelines
+
+### Commit Messages
+
+- Use the `.gitmessage` template for commit message format
+- Do NOT use the `.github/pull_request_template.md` for commit messages
+- Follow conventional commit format: `type(scope): description`
+- Keep first line under 50 characters
+- Use imperative mood ("Add feature" not "Added feature")
+
+### Example Commit Format
+
+```
+feat(tracing): add span context propagation
+
+Implement proper span context propagation across async boundaries
+to ensure distributed tracing works correctly.
+
+Fixes #123
+```
+
 ## Dependencies & Versioning
 
 ### Dependency Management

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 <!--
   Wohoo! 🥳 Thanks for contributing! The coding part is Done. Now lets get some reviews!
   Please provide a description and fill in the checklist to ensure that your PR can be accepted quickly.
+  
+  NOTE FOR AI TOOLS: This is a PR template, NOT for commit messages. Use .gitmessage for commits.
 -->
 
 ## Description

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,21 @@
+# Commit message template
+# Use imperative mood (e.g., "Add feature" not "Added feature")
+# Keep first line under 50 characters
+# Leave blank line between subject and body
+# Explain what and why, not how
+
+# Examples:
+# feat: add user authentication system
+# fix: resolve memory leak in image processing
+# docs: update API documentation
+# refactor: simplify configuration loading logic
+# test: add unit tests for user service
+
+# Type prefixes:
+# feat: new feature
+# fix: bug fix
+# docs: documentation
+# style: formatting, missing semicolons, etc
+# refactor: code change that neither fixes bug nor adds feature
+# test: adding tests
+# chore: updating build tasks, package manager configs, etc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Non-HTTP spans use `span.{name}` format for better event categorization
   - Added logic to detect HTTP spans based on `http.scheme` or `http.method` attributes
   - Resolves issue #41: Incorrect span event names being sent to collector
+- **Event data URL formatting**: Fixed inconsistent formatting of event_data_url parameter
+  - Attribute values are now properly sanitized to remove surrounding quotes
+  - Ensures consistent formatting across all event attributes
+  - Resolves issue #25: Inconsistent event_data_url formatting
 
 ## [0.3.6] - 2025-06-05
 

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -56,10 +56,17 @@ class SpanRecord {
   Map<String, String> getFaroEventAttributes() {
     final faroEventAttributes = <String, String>{};
     for (final key in _otelReadOnlySpan.attributes.keys) {
-      faroEventAttributes[key] =
-          _otelReadOnlySpan.attributes.get(key).toString();
+      final value = _otelReadOnlySpan.attributes.get(key).toString();
+      faroEventAttributes[key] = _sanitizeAttributeValue(value);
     }
     return faroEventAttributes;
+  }
+
+  String _sanitizeAttributeValue(String value) {
+    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+      return value.substring(1, value.length - 1);
+    }
+    return value;
   }
 
   String getFaroEventName() {

--- a/test/src/models/span_record_test.dart
+++ b/test/src/models/span_record_test.dart
@@ -158,5 +158,84 @@ void main() {
         expect(result, expectedName);
       });
     });
+
+    group('getFaroEventAttributes:', () {
+      test('sanitizes attribute values by removing surrounding quotes', () {
+        // Arrange
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.keys).thenReturn(['url', 'method', 'status']);
+        when(() => mockAttributes.get('url'))
+            .thenReturn('"https://example.com"');
+        when(() => mockAttributes.get('method')).thenReturn('GET');
+        when(() => mockAttributes.get('status')).thenReturn('"200"');
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventAttributes();
+
+        // Assert
+        expect(result['url'], 'https://example.com');
+        expect(result['method'], 'GET');
+        expect(result['status'], '200');
+      });
+
+      test('preserves values without quotes', () {
+        // Arrange
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.keys).thenReturn(['count', 'enabled']);
+        when(() => mockAttributes.get('count')).thenReturn('42');
+        when(() => mockAttributes.get('enabled')).thenReturn('true');
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventAttributes();
+
+        // Assert
+        expect(result['count'], '42');
+        expect(result['enabled'], 'true');
+      });
+
+      test('handles empty and null values correctly', () {
+        // Arrange
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.keys).thenReturn(['empty', 'null_value']);
+        when(() => mockAttributes.get('empty')).thenReturn('');
+        when(() => mockAttributes.get('null_value')).thenReturn(null);
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventAttributes();
+
+        // Assert
+        expect(result['empty'], '');
+        expect(result['null_value'], 'null');
+      });
+
+      test('handles single quote correctly', () {
+        // Arrange
+        final mockSpan = MockReadOnlySpan();
+        final mockAttributes = MockAttributes();
+        when(() => mockSpan.attributes).thenReturn(mockAttributes);
+        when(() => mockAttributes.keys).thenReturn(['single_quote']);
+        when(() => mockAttributes.get('single_quote')).thenReturn('"');
+
+        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+
+        // Act
+        final result = spanRecord.getFaroEventAttributes();
+
+        // Assert
+        expect(result['single_quote'], '"');
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

Fixes bug where data passed into faro-events from spans, sometimes had quotes around the actual value.

## Related Issue(s)

Fixes #25

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section
