### PR TITLE
feat: add human-readable timestamps to Android crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Human-readable timestamps for Android crashes**: Added readable timestamp formatting for crash reports
+  - Crash context now includes both original Unix epoch timestamp and human-readable ISO 8601 format
+  - Added `timestamp_readable` field alongside existing `timestamp` field
+  - Timestamps converted to UTC ISO 8601 format (e.g., "2025-06-04T23:49:20.296Z")
+  - Includes new `TimestampExtension` utility for reusable timestamp conversion
+  - Improves debugging experience with easily interpretable crash timestamps
+  - Resolves issue #53: Add human readable timestamp for Android crashes
 - **Trace event duration**: Added duration information to trace events
   - Events now include `duration_ns` attribute with span duration in nanoseconds
   - Duration calculated as `endTime - startTime` when both timestamps are valid

--- a/lib/faro.dart
+++ b/lib/faro.dart
@@ -13,6 +13,7 @@ import 'package:faro/src/models/span_record.dart';
 import 'package:faro/src/tracing/tracer_provider.dart';
 import 'package:faro/src/transport/batch_transport.dart';
 import 'package:faro/src/util/generate_session.dart';
+import 'package:faro/src/util/timestamp_extension.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
@@ -304,6 +305,8 @@ class Faro {
             final stacktrace =
                 stringifiedContext['stacktrace'] ?? 'No stacktrace';
             final timestamp = stringifiedContext['timestamp'] ?? 'No timestamp';
+            final humanReadableTimestamp = timestamp.toHumanReadableTimestamp();
+
             final importance =
                 stringifiedContext['importance'] ?? 'No importance';
             final processName =
@@ -316,6 +319,7 @@ class Faro {
                 'description': description,
                 'stacktrace': stacktrace,
                 'timestamp': timestamp,
+                'timestamp_readable': humanReadableTimestamp,
                 'importance': importance,
                 'processName': processName,
               },

--- a/lib/src/util/timestamp_extension.dart
+++ b/lib/src/util/timestamp_extension.dart
@@ -1,0 +1,28 @@
+// ignore_for_file: lines_longer_than_80_chars
+
+extension TimestampExtension on String {
+  /// Converts a Unix epoch timestamp (in milliseconds) to a human-readable UTC ISO 8601 string.
+  ///
+  /// Returns the ISO 8601 formatted string if successful, or an error message if parsing fails.
+  ///
+  /// Example:
+  /// ```dart
+  /// final timestamp = "1749080960296";
+  /// final readable = timestamp.toHumanReadableTimestamp();
+  /// // Returns: "2025-06-06T14:42:40.296Z"
+  /// ```
+  String toHumanReadableTimestamp() {
+    if (this == 'No timestamp') {
+      return 'No readable timestamp';
+    }
+
+    try {
+      final timestampMs = int.parse(this);
+      final dateTime =
+          DateTime.fromMillisecondsSinceEpoch(timestampMs, isUtc: true);
+      return dateTime.toIso8601String();
+    } catch (error) {
+      return 'Invalid timestamp format';
+    }
+  }
+}

--- a/test/unit_test/timestamp_extension_test.dart
+++ b/test/unit_test/timestamp_extension_test.dart
@@ -1,0 +1,64 @@
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:faro/src/util/timestamp_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TimestampExtension:', () {
+    test(
+        'converts valid Unix epoch timestamp in milliseconds to ISO 8601 string',
+        () {
+      const timestamp = '1749080960296';
+      final result = timestamp.toHumanReadableTimestamp();
+      expect(result, '2025-06-04T23:49:20.296Z');
+    });
+
+    test('converts another valid timestamp correctly', () {
+      const timestamp = '1744879144096';
+      final result = timestamp.toHumanReadableTimestamp();
+      expect(result, '2025-04-17T08:39:04.096Z');
+    });
+
+    test('handles "No timestamp" input', () {
+      const timestamp = 'No timestamp';
+      final result = timestamp.toHumanReadableTimestamp();
+      expect(result, 'No readable timestamp');
+    });
+
+    test('handles invalid numeric string', () {
+      const timestamp = 'invalid_number';
+      final result = timestamp.toHumanReadableTimestamp();
+      expect(result, 'Invalid timestamp format');
+    });
+
+    test('handles empty string', () {
+      const timestamp = '';
+      final result = timestamp.toHumanReadableTimestamp();
+      expect(result, 'Invalid timestamp format');
+    });
+
+    test('handles very large timestamp', () {
+      const timestamp = '999999999999999999';
+      final result = timestamp.toHumanReadableTimestamp();
+      expect(result, 'Invalid timestamp format');
+    });
+
+    test('handles negative timestamp', () {
+      const timestamp = '-1749080960296';
+      final result = timestamp.toHumanReadableTimestamp();
+      expect(result, '1914-07-30T00:10:39.704Z');
+    });
+
+    test('handles zero timestamp', () {
+      const timestamp = '0';
+      final result = timestamp.toHumanReadableTimestamp();
+      expect(result, '1970-01-01T00:00:00.000Z');
+    });
+
+    test('handles timestamp with decimal point', () {
+      const timestamp = '1749080960296.5';
+      final result = timestamp.toHumanReadableTimestamp();
+      expect(result, 'Invalid timestamp format');
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds timestamp_readable field alongside existing timestamp in crash context. Timestamps are converted from Unix epoch milliseconds to ISO 8601 UTC format. Includes new TimestampExtension utility and comprehensive tests.

## Related Issue(s)

Fixes #53

## Type of Change

- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section
