### PR TITLE
Add more context to http spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Enhanced HTTP tracing attributes**: HTTP spans now include additional attributes for better observability
+  - Added `http.request_size` attribute with request content length
+  - Added `http.response_size` attribute with response content length
+  - Added `http.content_type` attribute with response content type
+  - Provides more comprehensive HTTP request/response metadata for monitoring
+- **Session attributes in OpenTelemetry traces**: Tracer resources now automatically include session attributes
+  - Session metadata is propagated to all OpenTelemetry spans
+  - Enables correlation of traces with user sessions and custom session data
+  - Supports dynamic session attribute values (strings, numbers, booleans, objects)
+  - Added comprehensive test coverage for `DartOtelTracerResourcesFactory`
 - **Human-readable timestamps for Android crashes**: Added readable timestamp formatting for crash reports
   - Crash context now includes both original Unix epoch timestamp and human-readable ISO 8601 format
   - Added `timestamp_readable` field alongside existing `timestamp` field
@@ -24,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Removed duplicate HTTP event tracking**: Fixed redundant event creation for HTTP requests
+  - Removed unnecessary `markEventStart()` and `markEventEnd()` calls in HTTP tracking client
+  - HTTP requests are now properly tracked only through OpenTelemetry spans
+  - Eliminates duplicate events that were creating noise in observability data
+  - Resolves issue with unnecessary HTTP events being sent to collector
 - **Span event naming**: Fixed incorrect event names for tracing spans
   - HTTP spans now correctly use `faro.tracing.fetch` event name
   - Non-HTTP spans use `span.{name}` format for better event categorization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Removed duplicate HTTP event tracking**: Fixed redundant event creation for HTTP requests
-  - Removed unnecessary `markEventStart()` and `markEventEnd()` calls in HTTP tracking client
-  - HTTP requests are now properly tracked only through OpenTelemetry spans
-  - Eliminates duplicate events that were creating noise in observability data
-  - Resolves issue with unnecessary HTTP events being sent to collector
 - **Span event naming**: Fixed incorrect event names for tracing spans
   - HTTP spans now correctly use `faro.tracing.fetch` event name
   - Non-HTTP spans use `span.{name}` format for better event categorization

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -67,7 +67,6 @@ class FaroHttpTrackingClient implements HttpClient {
       request = await innerClient.openUrl(method, url);
       if (url.toString() != Faro().config?.collectorUrl) {
         final key = const Uuid().v1();
-        Faro().markEventStart(key, 'http_request');
         request = FaroTrackingHttpClientRequest(
           key,
           request,
@@ -251,6 +250,9 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
 
       _httpSpan.setAttributes({
         'http.status_code': '${value.statusCode}',
+        'http.request_size': '${innerContext.contentLength}',
+        'http.response_size': '${value.headers.contentLength}',
+        'http.content_type': '${value.headers.contentType}',
       });
 
       _httpSpan.setStatus(SpanStatusCode.ok);
@@ -394,16 +396,11 @@ class FaroTrackingHttpResponse extends Stream<List<int>>
         }
       },
       onDone: () {
-        _onFinish();
         if (onDone != null) {
           onDone();
         }
       },
     );
-  }
-
-  void _onFinish() {
-    Faro().markEventEnd(key, 'http_request', attributes: userAttributes);
   }
 
   @override

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -67,6 +67,7 @@ class FaroHttpTrackingClient implements HttpClient {
       request = await innerClient.openUrl(method, url);
       if (url.toString() != Faro().config?.collectorUrl) {
         final key = const Uuid().v1();
+        Faro().markEventStart(key, 'http_request');
         request = FaroTrackingHttpClientRequest(
           key,
           request,
@@ -396,11 +397,16 @@ class FaroTrackingHttpResponse extends Stream<List<int>>
         }
       },
       onDone: () {
+        _onFinish();
         if (onDone != null) {
           onDone();
         }
       },
     );
+  }
+
+  void _onFinish() {
+    Faro().markEventEnd(key, 'http_request', attributes: userAttributes);
   }
 
   @override

--- a/lib/src/tracing/dart_otel_tracer_resources_factory.dart
+++ b/lib/src/tracing/dart_otel_tracer_resources_factory.dart
@@ -44,7 +44,20 @@ class DartOtelTracerResourcesFactory {
           'telemetry.sdk.platform',
           'flutter',
         ),
+
+        // Session attributes
+        ..._buildSessionAttributes(faro.meta.session?.attributes),
       ],
     );
+  }
+
+  List<otel_api.Attribute> _buildSessionAttributes(
+      Map<String, dynamic>? sessionAttributes) {
+    if (sessionAttributes == null) return [];
+
+    return sessionAttributes.entries
+        .map((entry) => otel_api.Attribute.fromString(
+            entry.key, entry.value?.toString() ?? ''))
+        .toList();
   }
 }

--- a/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
+++ b/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: lines_longer_than_80_chars
+
 import 'package:faro/faro_sdk.dart';
 import 'package:faro/src/tracing/dart_otel_tracer_resources_factory.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
+++ b/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
@@ -1,0 +1,234 @@
+import 'package:faro/faro_sdk.dart';
+import 'package:faro/src/tracing/dart_otel_tracer_resources_factory.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:opentelemetry/api.dart' as otel_api;
+
+class MockMeta extends Mock implements Meta {}
+
+class MockApp extends Mock implements App {}
+
+class MockSession extends Mock implements Session {}
+
+void main() {
+  group('DartOtelTracerResourcesFactory:', () {
+    late DartOtelTracerResourcesFactory factory;
+    late MockMeta mockMeta;
+    late MockApp mockApp;
+    late MockSession mockSession;
+
+    setUp(() {
+      factory = DartOtelTracerResourcesFactory();
+      mockMeta = MockMeta();
+      mockApp = MockApp();
+      mockSession = MockSession();
+
+      // Set up the Faro singleton with mocked meta
+      Faro().meta = mockMeta;
+    });
+
+    tearDown(() {
+      // No need to reset Faro.instance - tests use the same instance
+    });
+
+    group('getTracerResource', () {
+      test(
+          'should create resource with app information when all app data is present',
+          () {
+        // Arrange
+        when(() => mockMeta.app).thenReturn(mockApp);
+        when(() => mockMeta.session).thenReturn(null);
+        when(() => mockApp.name).thenReturn('TestApp');
+        when(() => mockApp.environment).thenReturn('production');
+        when(() => mockApp.version).thenReturn('1.2.3');
+        when(() => mockApp.namespace).thenReturn('test.namespace');
+
+        // Act
+        final resource = factory.getTracerResource();
+
+        // Assert
+        expect(resource, isNotNull);
+        expect(resource.attributes.keys, isNotEmpty);
+
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.serviceName)
+                .toString(),
+            equals('TestApp'));
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.deploymentEnvironment)
+                .toString(),
+            equals('production'));
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.serviceVersion)
+                .toString(),
+            equals('1.2.3'));
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.serviceNamespace)
+                .toString(),
+            equals('test.namespace'));
+      });
+
+      test('should use default values when app data is null', () {
+        // Arrange
+        when(() => mockMeta.app).thenReturn(null);
+        when(() => mockMeta.session).thenReturn(null);
+
+        // Act
+        final resource = factory.getTracerResource();
+
+        // Assert
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.serviceName)
+                .toString(),
+            equals('unknown'));
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.deploymentEnvironment)
+                .toString(),
+            equals('unknown'));
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.serviceVersion)
+                .toString(),
+            equals('unknown'));
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.serviceNamespace)
+                .toString(),
+            equals('flutter_app'));
+      });
+
+      test('should use default values when individual app fields are null', () {
+        // Arrange
+        when(() => mockMeta.app).thenReturn(mockApp);
+        when(() => mockMeta.session).thenReturn(null);
+        when(() => mockApp.name).thenReturn(null);
+        when(() => mockApp.environment).thenReturn(null);
+        when(() => mockApp.version).thenReturn(null);
+        when(() => mockApp.namespace).thenReturn(null);
+
+        // Act
+        final resource = factory.getTracerResource();
+
+        // Assert
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.serviceName)
+                .toString(),
+            equals('unknown'));
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.deploymentEnvironment)
+                .toString(),
+            equals('unknown'));
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.serviceVersion)
+                .toString(),
+            equals('unknown'));
+        expect(
+            resource.attributes
+                .get(otel_api.ResourceAttributes.serviceNamespace)
+                .toString(),
+            equals('flutter_app'));
+      });
+
+      test('should include SDK telemetry attributes', () {
+        // Arrange
+        when(() => mockMeta.app).thenReturn(null);
+        when(() => mockMeta.session).thenReturn(null);
+
+        // Act
+        final resource = factory.getTracerResource();
+
+        // Assert
+        expect(resource.attributes.get('telemetry.sdk.name').toString(),
+            equals('faro-flutter-sdk'));
+        expect(resource.attributes.get('telemetry.sdk.language').toString(),
+            equals('dart'));
+        expect(resource.attributes.get('telemetry.sdk.version').toString(),
+            equals('1.0.0'));
+        expect(resource.attributes.get('telemetry.sdk.platform').toString(),
+            equals('flutter'));
+      });
+
+      test('should include session attributes when session exists', () {
+        // Arrange
+        when(() => mockMeta.app).thenReturn(null);
+        when(() => mockMeta.session).thenReturn(mockSession);
+        when(() => mockSession.attributes).thenReturn({
+          'session_id': '12345',
+          'user_id': 'user123',
+          'custom_attr': 'value'
+        });
+
+        // Act
+        final resource = factory.getTracerResource();
+
+        // Assert
+        expect(
+            resource.attributes.get('session_id').toString(), equals('12345'));
+        expect(
+            resource.attributes.get('user_id').toString(), equals('user123'));
+        expect(
+            resource.attributes.get('custom_attr').toString(), equals('value'));
+      });
+
+      test('should handle empty session attributes', () {
+        // Arrange
+        when(() => mockMeta.app).thenReturn(null);
+        when(() => mockMeta.session).thenReturn(mockSession);
+        when(() => mockSession.attributes).thenReturn(<String, dynamic>{});
+
+        // Act
+        final resource = factory.getTracerResource();
+
+        // Assert - should not throw and should still include other attributes
+        expect(resource, isNotNull);
+        expect(resource.attributes.keys, isNotEmpty);
+      });
+
+      test('should handle session attributes with dynamic values', () {
+        // Arrange
+        when(() => mockMeta.app).thenReturn(null);
+        when(() => mockMeta.session).thenReturn(mockSession);
+        when(() => mockSession.attributes).thenReturn({
+          'number': 42,
+          'boolean': true,
+          'null_value': null,
+          'object': {'nested': 'value'},
+        });
+
+        // Act
+        final resource = factory.getTracerResource();
+
+        // Assert
+        expect(resource.attributes.get('number').toString(), equals('42'));
+        expect(resource.attributes.get('boolean').toString(), equals('true'));
+        expect(resource.attributes.get('null_value').toString(), equals(''));
+        expect(resource.attributes.get('object').toString(),
+            equals('{nested: value}'));
+      });
+
+      test('should handle null session', () {
+        // Arrange
+        when(() => mockMeta.app).thenReturn(null);
+        when(() => mockMeta.session).thenReturn(null);
+
+        // Act
+        final resource = factory.getTracerResource();
+
+        // Assert - should not throw and should still include other attributes
+        expect(resource, isNotNull);
+        expect(resource.attributes.keys, isNotEmpty);
+        // Should not have any session attributes
+        expect(resource.attributes.get('session_id'), isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

This PR does this:

- We were sending a custom http_request event for each http request. But this is not needed since we capture all http requests with Otel-spans. and we send a custom tracing-event for there. So I just removed these http_request event.
- Added session attributes to the Otel span resources. So that you can see all needed session attributes directly in the span resources.
- Added some more http data to the span attributes

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section
