### PR TITLE
Feature/refactor not needed future api and make it sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: Synchronous API for telemetry methods**: Refactored telemetry methods to remove unnecessary async patterns for improved performance and developer experience
+
+  - **Breaking Change**: The following methods changed from `Future<void>?` to `void`:
+    - `pushEvent()` - Send custom events
+    - `pushLog()` - Send custom logs
+    - `pushError()` - Send custom errors
+    - `pushMeasurement()` - Send custom measurements
+    - `markEventEnd()` - Mark event completion
+  - **Migration**: Remove `await` keywords from calls to these methods as they are now synchronous
+
+    ```dart
+    // Before
+    await Faro().pushEvent('event_name');
+    await Faro().pushLog('message', level: LogLevel.info);
+
+    // After
+    Faro().pushEvent('event_name');
+    Faro().pushLog('message', level: LogLevel.info);
+    ```
+
+  - **Benefits**:
+    - Improved performance by eliminating unnecessary async overhead
+    - Cleaner API that better reflects the synchronous nature of these operations
+    - Reduced complexity in application code
+  - **Internal Architecture**: Introduced `BatchTransportFactory` singleton pattern for better dependency management and testing
+
 - **BREAKING: pushLog API requires LogLevel enum**: Enhanced logging API for better type safety and consistency
 
   - **Breaking Change**: `pushLog()` now requires a `LogLevel` parameter instead of optional `String?`

--- a/lib/src/tracing/faro_tracer.dart
+++ b/lib/src/tracing/faro_tracer.dart
@@ -96,7 +96,7 @@ class FaroTracerFactory {
       return _faroTracer!;
     }
 
-    final exporter = FaroExporter();
+    final exporter = FaroExporterFactory().create();
     final resource = DartOtelTracerResourcesFactory().getTracerResource();
     final provider = otel_sdk.TracerProviderBase(
       resource: resource,

--- a/lib/src/transport/batch_transport.dart
+++ b/lib/src/transport/batch_transport.dart
@@ -1,7 +1,10 @@
+// ignore_for_file: use_setters_to_change_properties
+
 import 'dart:async';
 import 'package:faro/faro_sdk.dart';
 import 'package:faro/src/models/span_record.dart';
 import 'package:faro/src/util/payload_extension.dart';
+import 'package:flutter/foundation.dart';
 
 class BatchTransport {
   BatchTransport(
@@ -23,27 +26,27 @@ class BatchTransport {
   List<BaseTransport> transports;
   Timer? flushTimer;
 
-  Future<void> addEvent(Event event) async {
+  void addEvent(Event event) {
     payload.events.add(event);
     checkPayloadItemLimit();
   }
 
-  Future<void> addMeasurement(Measurement measurement) async {
+  void addMeasurement(Measurement measurement) {
     payload.measurements.add(measurement);
     checkPayloadItemLimit();
   }
 
-  Future<void> addLog(FaroLog faroLog) async {
+  void addLog(FaroLog faroLog) {
     payload.logs.add(faroLog);
     checkPayloadItemLimit();
   }
 
-  Future<void> addSpan(SpanRecord spanRecord) async {
+  void addSpan(SpanRecord spanRecord) {
     payload.traces.addSpan(spanRecord);
     checkPayloadItemLimit();
   }
 
-  Future<void> addExceptions(FaroException exception) async {
+  void addExceptions(FaroException exception) {
     payload.exceptions.add(exception);
     checkPayloadItemLimit();
   }
@@ -100,5 +103,41 @@ class BatchTransport {
     payload.logs = [];
     payload.exceptions = [];
     payload.traces.resetSpans();
+  }
+}
+
+class BatchTransportFactory {
+  static BatchTransport? _instance;
+
+  BatchTransport? get instance => _instance;
+
+  BatchTransport create({
+    required Payload initialPayload,
+    required BatchConfig batchConfig,
+    required List<BaseTransport> transports,
+  }) {
+    if (_instance != null) {
+      return _instance!;
+    }
+
+    final instance = BatchTransport(
+        payload: initialPayload,
+        batchConfig: batchConfig,
+        transports: transports);
+
+    _instance = instance;
+    return instance;
+  }
+
+  /// Reset the singleton instance. This is primarily for testing purposes.
+  @visibleForTesting
+  void reset() {
+    _instance = null;
+  }
+
+  /// Set the singleton instance. This is primarily for testing purposes.
+  @visibleForTesting
+  void setInstance(BatchTransport instance) {
+    _instance = instance;
   }
 }

--- a/test/unit_test/batch_transport_test.dart
+++ b/test/unit_test/batch_transport_test.dart
@@ -53,7 +53,7 @@ void main() {
     final mockEvents = <Event>[];
     when(() => mockPayload.events).thenReturn(mockEvents);
 
-    await batchTransport.addEvent(event);
+    batchTransport.addEvent(event);
 
     expect(mockEvents.length, equals(1));
     expect(mockEvents[0].toJson(), event.toJson());
@@ -65,7 +65,7 @@ void main() {
     final mockMeasurements = <Measurement>[];
     when(() => mockPayload.measurements).thenReturn(mockMeasurements);
 
-    await batchTransport.addMeasurement(measurement);
+    batchTransport.addMeasurement(measurement);
 
     expect(mockMeasurements.length, equals(1));
     expect(mockMeasurements[0].toJson(), measurement.toJson());
@@ -76,7 +76,7 @@ void main() {
     final mockLogs = <FaroLog>[];
     when(() => mockPayload.logs).thenReturn(mockLogs);
 
-    await batchTransport.addLog(log);
+    batchTransport.addLog(log);
 
     expect(mockLogs.length, equals(1));
     expect(mockLogs[0].toJson(), log.toJson());
@@ -88,7 +88,7 @@ void main() {
     final mockExceptions = <FaroException>[];
     when(() => mockPayload.exceptions).thenReturn(mockExceptions);
 
-    await batchTransport.addExceptions(exception);
+    batchTransport.addExceptions(exception);
 
     expect(mockExceptions.length, equals(1));
     expect(mockExceptions[0].toJson(), exception.toJson());
@@ -143,8 +143,8 @@ void main() {
         batchConfig: BatchConfig(
             sendTimeout: const Duration(seconds: 5), payloadItemLimit: 1));
 
-    await batchTransport.addEvent(event);
-    await batchTransport.addEvent(event); // This should trigger flush
+    batchTransport.addEvent(event);
+    batchTransport.addEvent(event); // This should trigger flush
     verify(() => mockBaseTransport.send(any())).called(2);
   });
   test('dispose should cancel flush timer', () {
@@ -202,7 +202,7 @@ void main() {
     );
 
     final event = Event('test_event');
-    await batchTransportDisabled.addEvent(event);
+    batchTransportDisabled.addEvent(event);
     await Future<void>.delayed(const Duration(milliseconds: 500));
     verify(() => mockBaseTransport.send(any())).called(1);
   });


### PR DESCRIPTION
## Description

Refactors the Faro SDK API to remove unnecessary `Future` return types from synchronous operations, making the API more intuitive and performant. Key changes include:

- Changed `pushEvent`, `pushLog`, `pushError`, `pushMeasurement`, and `markEventEnd` methods from `Future<void>?` to `void`
- Introduced `BatchTransportFactory` as a singleton pattern for better dependency management
- Refactored `FaroExporter` to use dependency injection with the new factory pattern
- Updated `BatchTransport` methods to be truly synchronous instead of unnecessarily async
- Removed redundant `await` calls for operations that were already synchronous

This change improves the developer experience by removing the need to await operations that don't perform asynchronous work, while maintaining the same functionality.

## Type of Change

- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [ ] 📈 Performance improvement
- [x] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section