### PR TITLE
chore: bump version to v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-07-02 ⚠️ BREAKING CHANGES
+
 ### Changed
 
 - **BREAKING: Package structure refactoring to follow Flutter plugin conventions**: Reorganized the package to align with Flutter/Dart ecosystem standards and best practices

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.3.7'
+version '0.4.0'
 
 buildscript {
     repositories {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -119,7 +119,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.7"
+    version: "0.4.0"
   ffi:
     dependency: transitive
     description:

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.3.7'
+  s.version          = '0.4.0'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,7 +1,7 @@
 /// Constants for the Faro Flutter SDK
 class FaroConstants {
   /// The version of the Faro Flutter SDK
-  static const String sdkVersion = '0.3.7';
+  static const String sdkVersion = '0.4.0';
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-flutter-sdk';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.3.7
+version: 0.4.0
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 


### PR DESCRIPTION
## Description

Release v0.4.0 of the Faro Flutter SDK with package structure refactoring, enhanced tracing API, and improved developer experience. 

**Breaking Changes:**
- Main entry point changed from `faro_sdk.dart` to `faro.dart`
- Telemetry methods now synchronous (remove `await` from `pushEvent()`, `pushLog()`, etc.)
- `pushLog()` now requires `LogLevel` enum instead of string

**New Features:**
- Type-safe `LogLevel` enum
- Enhanced tracing with `startSpan<T>()`, `startSpanManual()`, and `getActiveSpan()` methods
- Zone-based span context management with automatic session ID injection
- Centralized session management

## Type of Change

- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [x] 📈 Performance improvement
- [x] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section