### PR TITLE
feat(tracing): enhance span status management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **FaroZoneSpanManager span status preservation**: Fixed issue where manually set span statuses were overridden by automatic status setting
+  - Added `statusHasBeenSet` property to `Span` interface to track when status has been manually set
+  - Updated `FaroZoneSpanManager.executeWithSpan()` to respect manually set span statuses for both success and error cases
+  - Prevents overriding of custom span statuses (e.g., business logic errors) when code executes without throwing exceptions
+  - Maintains existing behavior for spans that haven't had their status manually set
+  - Resolves issue #86: FaroZoneSpanManager overrides manually set span statuses on success
+
 ## [0.4.0] - 2025-07-02 ⚠️ BREAKING CHANGES
 
 ### Changed

--- a/lib/src/tracing/faro_zone_span_manager.dart
+++ b/lib/src/tracing/faro_zone_span_manager.dart
@@ -35,11 +35,12 @@ class FaroZoneSpanManager {
     return _zoneRunner(() async {
       try {
         final result = await body(span);
-        span.setStatus(SpanStatusCode.ok);
+        if (!span.statusHasBeenSet) {
+          span.setStatus(SpanStatusCode.ok);
+        }
         return result;
       } catch (error, stackTrace) {
-        // If no error was set yet, then the sdk will set it to error.
-        if (span.status != SpanStatusCode.error) {
+        if (!span.statusHasBeenSet) {
           span.setStatus(
             SpanStatusCode.error,
             message: error.toString(),

--- a/lib/src/tracing/span.dart
+++ b/lib/src/tracing/span.dart
@@ -7,6 +7,7 @@ abstract class Span {
   String get spanId;
   bool get wasEnded;
   SpanStatusCode get status;
+  bool get statusHasBeenSet;
 
   void setStatus(SpanStatusCode statusCode, {String? message});
   void addEvent(String message, {Map<String, String> attributes});
@@ -51,6 +52,11 @@ class InternalSpan implements Span {
     return _statusCode;
   }
 
+  bool _statusHasBeenSet = false;
+
+  @override
+  bool get statusHasBeenSet => _statusHasBeenSet;
+
   @override
   void setStatus(SpanStatusCode statusCode, {String? message}) {
     if (message != null) {
@@ -59,6 +65,7 @@ class InternalSpan implements Span {
       _otelSpan.setStatus(statusCode.toOtelStatusCode());
     }
     _statusCode = statusCode;
+    _statusHasBeenSet = true;
   }
 
   @override

--- a/test/src/tracing/faro_zone_span_manager_test.dart
+++ b/test/src/tracing/faro_zone_span_manager_test.dart
@@ -314,7 +314,8 @@ void main() {
         verify(() => mockSpan.setStatus(SpanStatusCode.ok)).called(1);
       });
 
-      test('should NOT set status to OK when statusHasBeenSet is true on success',
+      test(
+          'should NOT set status to OK when statusHasBeenSet is true on success',
           () async {
         // Arrange
         when(() => mockSpan.statusHasBeenSet).thenReturn(true);
@@ -363,7 +364,8 @@ void main() {
             )).called(1);
       });
 
-      test('should NOT set status to ERROR when statusHasBeenSet is true on error',
+      test(
+          'should NOT set status to ERROR when statusHasBeenSet is true on error',
           () async {
         // Arrange
         final testException = Exception('test-exception');
@@ -399,7 +401,8 @@ void main() {
       test('should respect manually set status during success flow', () async {
         // Arrange
         var statusHasBeenSet = false;
-        when(() => mockSpan.statusHasBeenSet).thenAnswer((_) => statusHasBeenSet);
+        when(() => mockSpan.statusHasBeenSet)
+            .thenAnswer((_) => statusHasBeenSet);
         when(() => mockZoneRunner.call<String>(any(), any()))
             .thenAnswer((invocation) async {
           final callback =
@@ -425,7 +428,8 @@ void main() {
         // Arrange
         final testException = Exception('test-exception');
         var statusHasBeenSet = false;
-        when(() => mockSpan.statusHasBeenSet).thenAnswer((_) => statusHasBeenSet);
+        when(() => mockSpan.statusHasBeenSet)
+            .thenAnswer((_) => statusHasBeenSet);
         when(() => mockZoneRunner.call<String>(any(), any()))
             .thenAnswer((invocation) async {
           final callback =

--- a/test/src/tracing/faro_zone_span_manager_test.dart
+++ b/test/src/tracing/faro_zone_span_manager_test.dart
@@ -48,6 +48,7 @@ void main() {
 
       // Stub the status getter to return a default value
       when(() => mockSpan.status).thenReturn(SpanStatusCode.unset);
+      when(() => mockSpan.statusHasBeenSet).thenReturn(false);
 
       faroZoneSpanManager = FaroZoneSpanManager(
         parentSpanLookup: mockParentSpanLookup.call,
@@ -291,6 +292,171 @@ void main() {
               {const Symbol('faroParentSpan'): mockSpan},
             )).called(1);
       });
+
+      test('should set status to OK when statusHasBeenSet is false on success',
+          () async {
+        // Arrange
+        when(() => mockSpan.statusHasBeenSet).thenReturn(false);
+        when(() => mockZoneRunner.call<String>(any(), any()))
+            .thenAnswer((invocation) async {
+          final callback =
+              invocation.positionalArguments[0] as Future<String> Function();
+          return callback();
+        });
+
+        // Act
+        await faroZoneSpanManager.executeWithSpan<String>(
+          mockSpan,
+          (span) => 'result',
+        );
+
+        // Assert
+        verify(() => mockSpan.setStatus(SpanStatusCode.ok)).called(1);
+      });
+
+      test('should NOT set status to OK when statusHasBeenSet is true on success',
+          () async {
+        // Arrange
+        when(() => mockSpan.statusHasBeenSet).thenReturn(true);
+        when(() => mockZoneRunner.call<String>(any(), any()))
+            .thenAnswer((invocation) async {
+          final callback =
+              invocation.positionalArguments[0] as Future<String> Function();
+          return callback();
+        });
+
+        // Act
+        await faroZoneSpanManager.executeWithSpan<String>(
+          mockSpan,
+          (span) => 'result',
+        );
+
+        // Assert
+        verifyNever(() => mockSpan.setStatus(SpanStatusCode.ok));
+      });
+
+      test('should set status to ERROR when statusHasBeenSet is false on error',
+          () async {
+        // Arrange
+        final testException = Exception('test-exception');
+        when(() => mockSpan.statusHasBeenSet).thenReturn(false);
+        when(() => mockZoneRunner.call<String>(any(), any()))
+            .thenAnswer((invocation) async {
+          final callback =
+              invocation.positionalArguments[0] as Future<String> Function();
+          return callback();
+        });
+
+        // Act & Assert
+        expect(
+          () async => faroZoneSpanManager.executeWithSpan<String>(
+            mockSpan,
+            (span) => throw testException,
+          ),
+          throwsA(equals(testException)),
+        );
+
+        // Verify span error handling
+        verify(() => mockSpan.setStatus(
+              SpanStatusCode.error,
+              message: testException.toString(),
+            )).called(1);
+      });
+
+      test('should NOT set status to ERROR when statusHasBeenSet is true on error',
+          () async {
+        // Arrange
+        final testException = Exception('test-exception');
+        when(() => mockSpan.statusHasBeenSet).thenReturn(true);
+        when(() => mockZoneRunner.call<String>(any(), any()))
+            .thenAnswer((invocation) async {
+          final callback =
+              invocation.positionalArguments[0] as Future<String> Function();
+          return callback();
+        });
+
+        // Act & Assert
+        expect(
+          () async => faroZoneSpanManager.executeWithSpan<String>(
+            mockSpan,
+            (span) => throw testException,
+          ),
+          throwsA(equals(testException)),
+        );
+
+        // Verify span error handling is NOT called
+        verifyNever(() => mockSpan.setStatus(
+              SpanStatusCode.error,
+              message: testException.toString(),
+            ));
+        // But exception is still recorded
+        verify(() => mockSpan.recordException(
+              testException,
+              stackTrace: any(named: 'stackTrace'),
+            )).called(1);
+      });
+
+      test('should respect manually set status during success flow', () async {
+        // Arrange
+        var statusHasBeenSet = false;
+        when(() => mockSpan.statusHasBeenSet).thenAnswer((_) => statusHasBeenSet);
+        when(() => mockZoneRunner.call<String>(any(), any()))
+            .thenAnswer((invocation) async {
+          final callback =
+              invocation.positionalArguments[0] as Future<String> Function();
+          return callback();
+        });
+
+        // Act
+        await faroZoneSpanManager.executeWithSpan<String>(
+          mockSpan,
+          (span) {
+            // Simulate manually setting status during execution
+            statusHasBeenSet = true;
+            return 'result';
+          },
+        );
+
+        // Assert - should NOT have been called since statusHasBeenSet was true when checked
+        verifyNever(() => mockSpan.setStatus(SpanStatusCode.ok));
+      });
+
+      test('should respect manually set status during error flow', () async {
+        // Arrange
+        final testException = Exception('test-exception');
+        var statusHasBeenSet = false;
+        when(() => mockSpan.statusHasBeenSet).thenAnswer((_) => statusHasBeenSet);
+        when(() => mockZoneRunner.call<String>(any(), any()))
+            .thenAnswer((invocation) async {
+          final callback =
+              invocation.positionalArguments[0] as Future<String> Function();
+          return callback();
+        });
+
+        // Act & Assert
+        expect(
+          () async => faroZoneSpanManager.executeWithSpan<String>(
+            mockSpan,
+            (span) {
+              // Simulate manually setting status during execution
+              statusHasBeenSet = true;
+              throw testException;
+            },
+          ),
+          throwsA(equals(testException)),
+        );
+
+        // Assert - should NOT have been called since statusHasBeenSet was true when checked
+        verifyNever(() => mockSpan.setStatus(
+              SpanStatusCode.error,
+              message: testException.toString(),
+            ));
+        // But exception should still be recorded
+        verify(() => mockSpan.recordException(
+              testException,
+              stackTrace: any(named: 'stackTrace'),
+            )).called(1);
+      });
     });
   });
 
@@ -315,6 +481,9 @@ void main() {
       final spanManager = factory.create();
       final mockSpan = MockSpan();
       var callbackExecuted = false;
+
+      // Setup required stubs for the mock span
+      when(() => mockSpan.statusHasBeenSet).thenReturn(false);
 
       // Act
       final result = await spanManager.executeWithSpan<String>(


### PR DESCRIPTION
## Description

Add a new boolean property `statusHasBeenSet` to the `Span` interface to track if the span status has already been set. Update the `FaroZoneSpanManager` to conditionally set the span status to OK or ERROR based on this property. 
Introduce comprehensive tests to verify the new behavior, ensuring that the status is only set when it hasn't been previously defined.

## Related Issue(s)

Fixes #86 

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

