### PR TITLE
chore: bump version to v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2025-07-16
+
 ### Fixed
+
+- **SDK name consistency across telemetry types**: Updated SDK identification to use consistent naming
+
+  - Changed hardcoded 'rum-flutter' SDK name to use `FaroConstants.sdkName` for consistency with OpenTelemetry traces
+  - Maintains backend-compatible version '1.3.5' for proper web SDK version validation
+  - Added actual Faro Flutter SDK version to session attributes as 'faro_sdk_version' for tracking real SDK version
 
 - **FaroZoneSpanManager span status preservation**: Fixed issue where manually set span statuses were overridden by automatic status setting
   - Added `statusHasBeenSet` property to `Span` interface to track when status has been manually set

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.4.0'
+version '0.4.1'
 
 buildscript {
     repositories {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -119,7 +119,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   ffi:
     dependency: transitive
     description:

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.4.0'
+  s.version          = '0.4.1'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/src/device_info/session_attributes_provider.dart
+++ b/lib/src/device_info/session_attributes_provider.dart
@@ -1,5 +1,6 @@
 import 'package:faro/src/device_info/device_id_provider.dart';
 import 'package:faro/src/device_info/device_info_provider.dart';
+import 'package:faro/src/util/constants.dart';
 
 class SessionAttributesProvider {
   SessionAttributesProvider({
@@ -16,6 +17,7 @@ class SessionAttributesProvider {
     final deviceInfo = await _deviceInfoProvider.getDeviceInfo();
 
     final attributes = <String, String>{
+      'faro_sdk_version': FaroConstants.sdkVersion,
       'dart_version': deviceInfo.dartVersion,
       'device_os': deviceInfo.deviceOs,
       'device_os_version': deviceInfo.deviceOsVersion,

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -21,6 +21,7 @@ import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/transport/batch_transport.dart';
 import 'package:faro/src/transport/faro_base_transport.dart';
 import 'package:faro/src/transport/faro_transport.dart';
+import 'package:faro/src/util/constants.dart';
 import 'package:faro/src/util/timestamp_extension.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -65,7 +66,7 @@ class Faro {
         SessionIdProviderFactory().create().sessionId,
         attributes: {},
       ),
-      sdk: Sdk('rum-flutter', '1.3.5', []),
+      sdk: Sdk(FaroConstants.sdkName, '1.3.5', []),
       app: App(name: '', environment: '', version: ''),
       view: ViewMeta('default'));
 

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,7 +1,7 @@
 /// Constants for the Faro Flutter SDK
 class FaroConstants {
   /// The version of the Faro Flutter SDK
-  static const String sdkVersion = '0.4.0';
+  static const String sdkVersion = '0.4.1';
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-flutter-sdk';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.4.0
+version: 0.4.1
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 

--- a/test/src/device_info/session_attributes_provider_test.dart
+++ b/test/src/device_info/session_attributes_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:faro/src/device_info/device_id_provider.dart';
 import 'package:faro/src/device_info/device_info_provider.dart';
 import 'package:faro/src/device_info/session_attributes_provider.dart';
 import 'package:faro/src/models/models.dart';
+import 'package:faro/src/util/constants.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -44,6 +45,7 @@ void main() {
       final attributes = await sut.getAttributes();
 
       expect(attributes, {
+        'faro_sdk_version': FaroConstants.sdkVersion,
         'dart_version': 'Some-dart-version',
         'device_os': 'Some-OS',
         'device_os_version': 'Some-OS-version',


### PR DESCRIPTION
 ## Description

Release v0.4.1 of the Faro Flutter SDK.

This release contains two main improvements:

1. **SDK name consistency across telemetry types**: Updated SDK identification to use consistent naming across all telemetry types, using `FaroConstants.sdkName` instead of hardcoded values while maintaining backend compatibility.

2. **Enhanced span status management**: Fixed issue where manually set span statuses were being overridden by automatic status setting in `FaroZoneSpanManager`. Added `statusHasBeenSet` property to track when status has been manually set.

## Related Issue(s)

Fixes #86

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [x] 🧹 Chore / Housekeeping

## Checklist

  - [x] I have made corresponding changes to the documentation
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have updated the CHANGELOG.md under the "Unreleased" section

