### PR TITLE
chore: bump version to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-10-31
+
 ### Added
 
 - **Custom session attributes**: New optional `sessionAttributes` parameter in `FaroConfig` for adding custom labels to all telemetry

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.4.2'
+version '0.5.0'
 
 buildscript {
     repositories {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -119,7 +119,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.2"
+    version: "0.5.0"
   ffi:
     dependency: transitive
     description:

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.4.2'
+  s.version          = '0.5.0'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,7 +1,7 @@
 /// Constants for the Faro Flutter SDK
 class FaroConstants {
   /// The version of the Faro Flutter SDK
-  static const String sdkVersion = '0.4.2';
+  static const String sdkVersion = '0.5.0';
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-flutter-sdk';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.4.2
+version: 0.5.0
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 


### PR DESCRIPTION
## Description

This minor release introduces **custom session attributes**, allowing developers to add custom labels to all telemetry data collected by the SDK. This feature enables:

- Setting custom key-value pairs included in all telemetry (logs, events, exceptions, traces, measurements)
- Access control labels and team/department segmentation
- Environment-specific metadata tagging
- Custom attributes are merged with default attributes (SDK version, device info, etc.)
- Aligns with Faro Web SDK's `sessionTracking.session.attributes` functionality

## Related Issue(s)

N/A

## Type of Change

- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Release 0.5.0 adding custom session attributes and bumping versions across Dart, Android, and iOS.
> 
> - **Release 0.5.0**
>   - CHANGELOG: documents new `FaroConfig.sessionAttributes` for custom labels across telemetry.
> - **Version bumps**
>   - Dart: `pubspec.yaml` to `0.5.0`; `lib/src/util/constants.dart` `sdkVersion` to `0.5.0`.
>   - Android: `android/build.gradle` `version` to `0.5.0`.
>   - iOS: `ios/faro.podspec` `s.version` to `0.5.0`.
>   - Example app lockfile updated to reference `0.5.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e687bd0af1d18fbf54e262ee22f111db43a68222. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->