### PR TITLE
chore: bump version to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-01-28
+
 ### Fixed
 
 - **OTLP trace attributes now preserve types**: Span attributes and event attributes now correctly preserve their original types (int, double, bool, String) when sent via OTLP

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.8.0'
+version '0.9.0'
 
 buildscript {
     repositories {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -167,7 +167,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   ffi:
     dependency: transitive
     description:

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.8.0'
+  s.version          = '0.9.0'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,7 +1,7 @@
 /// Constants for the Faro Flutter SDK
 class FaroConstants {
   /// The version of the Faro Flutter SDK
-  static const String sdkVersion = '0.8.0';
+  static const String sdkVersion = '0.9.0';
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-flutter-sdk';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.8.0
+version: 0.9.0
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 


### PR DESCRIPTION
## Summary
- Bump version from 0.8.0 to 0.9.0
- Update version in pubspec.yaml, android/build.gradle, ios/faro.podspec, lib/src/util/constants.dart
- Update CHANGELOG.md with release date

## What's in this release

#### Fixed
- **OTLP trace attributes now preserve types**: Span attributes and event attributes now correctly preserve their original types (int, double, bool, String) when sent via OTLP
  - Previously, all attribute values were converted to strings, making numeric querying and bucketing difficult in Grafana/Tempo
  - Now attributes like `user.account_count: 42` are sent as integers, enabling queries like `account_count > 10` and proper histogram bucketing
  - Updated `TraceAttributeValue` to support `stringValue`, `intValue`, `doubleValue`, and `boolValue` fields per OTLP specification
  - Updated `Span.setAttributes()` and `Span.addEvent()` to accept `Map<String, Object>` for typed values
  - Updated `Span.setAttribute(String key, Object value)` to accept any supported type
  - Backward compatible: `Span.setAttribute(String key, String value)` still works
  - Resolves issue #126

### Checklist
- [x] Pre-release checks passed
- [x] Version bumped in all files
- [x] CHANGELOG updated with release date
- [x] Post-release checks passed (dry-run publish)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepares the 0.9.0 release and updates version metadata across platforms.
> 
> - Updates version to `0.9.0` in `pubspec.yaml`, `android/build.gradle`, `ios/faro.podspec`, `lib/src/util/constants.dart`, and example `pubspec.lock`
> - Adds CHANGELOG entry for `0.9.0` (2026-01-28): fixes OTLP trace attribute typing so attributes preserve original types; notes updated APIs (`TraceAttributeValue` type fields, `Span.setAttributes()`/`addEvent()` accept typed maps, `Span.setAttribute(String, Object)` support)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e87916443c7010d67a1f0deccbfa276e9b83c05e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->