### PR TITLE
chore: bump version to v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-04-09
+
 ### Added
 
 - `FaroWebViewBridge` — a public API for cross-boundary session and trace

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.12.0'
+version '0.13.0'
 
 buildscript {
     repositories {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -175,7 +175,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.13.0"
   ffi:
     dependency: transitive
     description:

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.12.0'
+  s.version          = '0.13.0'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,7 +1,7 @@
 /// Constants for the Faro Flutter SDK
 class FaroConstants {
   /// The version of the Faro Flutter SDK
-  static const String sdkVersion = '0.12.0';
+  static const String sdkVersion = '0.13.0';
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-flutter-sdk';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.12.0
+version: 0.13.0
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 


### PR DESCRIPTION
## Description

Release v0.13.0 of the Faro Flutter SDK.

### Added
- `FaroWebViewBridge` — cross-boundary session and trace correlation between Flutter apps and WebView-hosted web apps
- `Span.traceparent` getter — exposes the W3C `traceparent` header directly on the `Span` interface

### Changed
- Widened `connectivity_plus` dependency to `>=6.1.2 <8.0.0` (adds v7.x support)
- Widened `package_info_plus` dependency to `>=8.0.1 <10.0.0` (adds v9.x support)

### Fixed
- `Faro.init()` now ignores repeated calls after the first successful initialization
- Asset loads and tracked HTTP requests now keep user actions pending until completion

## Checklist
- [x] Pre-release checks pass (`dart tool/pre_release_check.dart`)
- [x] Version bump applied (`dart tool/version_bump.dart minor`)
- [x] Post-release checks pass (`dart tool/pre_release_check.dart --post`)
- [x] CHANGELOG updated

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: updates version numbers and the changelog, with no runtime logic changes in this diff.
> 
> **Overview**
> Prepares the `0.13.0` release by adding a `0.13.0` section to `CHANGELOG.md` (documenting new APIs and fixes) and bumping the package version across the repo.
> 
> Synchronizes the version to `0.13.0` in `pubspec.yaml`, `lib/src/util/constants.dart`, Android `build.gradle`, iOS `faro.podspec`, and the example app’s `pubspec.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6cc68c40f245f5929e4e8b0303f87c578221925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->