### PR TITLE
fix(android): cap ANR stack traces to reduce OOM risk

### DIFF
--- a/.github/workflows/flutter_checks.yml
+++ b/.github/workflows/flutter_checks.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
       - name: Set up Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
@@ -32,6 +37,10 @@ jobs:
 
       - name: Install dependencies
         run: flutter pub get
+
+      - name: Android ANR stack formatter unit tests
+        working-directory: android
+        run: ./gradlew :anr-stack-formatter-tests:test --no-daemon
 
       - name: Create api-config file
         run: tool/create-api-config-file.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump Android `compileSdkVersion` from 35 to 36 (aligned with Flutter default since May 2025).
 
+### Fixed
+
+- Android `ANRTracker` now caps main-thread stack traces (frames and total
+  characters) and avoids logging the full trace, reducing risk of OOM when
+  capturing ANR diagnostics on low-memory devices ([#174](https://github.com/grafana/faro-flutter-sdk/issues/174)).
+
 ## [0.13.0] - 2026-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   characters) and avoids logging the full trace, reducing risk of OOM when
   capturing ANR diagnostics on low-memory devices ([#174](https://github.com/grafana/faro-flutter-sdk/issues/174)).
 
+### Added
+
+- Android: JUnit tests for bounded ANR stack formatting (`AnrStackTraceFormatter`),
+  run via `./gradlew :anr-stack-formatter-tests:test` in CI.
+
 ## [0.13.0] - 2026-04-09
 
 ### Added

--- a/android/anr-stack-formatter-tests/build.gradle
+++ b/android/anr-stack-formatter-tests/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'java-library'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'androidx.annotation:annotation-jvm:1.9.1'
+    testImplementation 'junit:junit:4.13.2'
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['../src/main/java']
+            include 'com/grafana/faro/AnrStackTraceFormatter.java'
+        }
+    }
+    test {
+        java {
+            srcDir 'src/test/java'
+        }
+    }
+}
+
+tasks.withType(Test).configureEach {
+    useJUnit()
+}

--- a/android/anr-stack-formatter-tests/src/test/java/com/grafana/faro/AnrStackTraceFormatterTest.java
+++ b/android/anr-stack-formatter-tests/src/test/java/com/grafana/faro/AnrStackTraceFormatterTest.java
@@ -1,0 +1,98 @@
+package com.grafana.faro;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for bounded ANR stack string building (#174).
+ *
+ * <p>TDD-style: these assert the caps that prevent unbounded allocation; if
+ * {@link AnrStackTraceFormatter} regresses to dumping the full stack without
+ * limits, the max-frames and max-chars cases fail.
+ */
+public class AnrStackTraceFormatterTest {
+
+    @Test
+    public void buildBoundedStackTraceString_empty_returnsEmpty() {
+        AnrStackTraceFormatter.Result r =
+                AnrStackTraceFormatter.buildBoundedStackTraceString(
+                        new StackTraceElement[0], 128, 64 * 1024);
+        assertEquals("", r.text);
+        assertFalse(r.truncated);
+        assertEquals(0, r.includedFrames);
+    }
+
+    @Test
+    public void buildBoundedStackTraceString_smallStack_notTruncated() {
+        StackTraceElement[] trace =
+                new StackTraceElement[] {
+                    new StackTraceElement("a.A", "m", "A.java", 1),
+                    new StackTraceElement("b.B", "n", "B.java", 2),
+                };
+        AnrStackTraceFormatter.Result r =
+                AnrStackTraceFormatter.buildBoundedStackTraceString(
+                        trace, 128, 64 * 1024);
+        assertFalse(r.truncated);
+        assertEquals(2, r.includedFrames);
+        assertTrue(r.text.contains("a.A.m"));
+        assertTrue(r.text.contains("b.B.n"));
+    }
+
+    @Test
+    public void buildBoundedStackTraceString_respectsMaxFrames() {
+        StackTraceElement[] trace = new StackTraceElement[20];
+        for (int i = 0; i < trace.length; i++) {
+            trace[i] = new StackTraceElement("pkg.C", "run", "C.java", i);
+        }
+        AnrStackTraceFormatter.Result r =
+                AnrStackTraceFormatter.buildBoundedStackTraceString(
+                        trace, 5, 64 * 1024);
+        assertTrue(r.truncated);
+        assertEquals(5, r.includedFrames);
+        assertTrue(r.text.contains("truncated"));
+    }
+
+    @Test
+    public void buildBoundedStackTraceString_respectsMaxChars() {
+        StackTraceElement[] trace =
+                new StackTraceElement[] {
+                    new StackTraceElement(
+                            "very.long.package.name.ClassName",
+                            "veryLongMethodName",
+                            "VeryLongFileName.java",
+                            999),
+                };
+        AnrStackTraceFormatter.Result r =
+                AnrStackTraceFormatter.buildBoundedStackTraceString(
+                        trace, 128, 40);
+        assertTrue(r.truncated);
+        assertEquals(0, r.includedFrames);
+        assertTrue(r.text.contains("truncated"));
+        assertTrue(
+                "output must stay within maxChars to limit allocation",
+                r.text.length() <= 40);
+    }
+
+    @Test
+    public void buildBoundedStackTraceString_outputNeverExceedsMaxChars() {
+        StackTraceElement[] trace = new StackTraceElement[200];
+        for (int i = 0; i < trace.length; i++) {
+            trace[i] =
+                    new StackTraceElement(
+                            "some.pkg.DeepClassNameNumber" + i,
+                            "method" + i,
+                            "SourceFile.java",
+                            i);
+        }
+        int maxChars = 500;
+        AnrStackTraceFormatter.Result r =
+                AnrStackTraceFormatter.buildBoundedStackTraceString(
+                        trace, 128, maxChars);
+        assertTrue(
+                "bounded formatter must not grow past maxChars",
+                r.text.length() <= maxChars);
+    }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'faro'
+
+include 'anr-stack-formatter-tests'

--- a/android/src/main/java/com/grafana/faro/ANRTracker.java
+++ b/android/src/main/java/com/grafana/faro/ANRTracker.java
@@ -11,7 +11,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -25,6 +24,15 @@ public class ANRTracker extends Thread {
     private static final String TAG = "ANRTracker";
     private static final long TIMEOUT = 5000L; // Time interval for checking ANR, in milliseconds
     private static final long CHECK_INTERVAL = 500L; // Time to wait between checks, in milliseconds
+
+    /**
+     * Maximum stack frames to stringify. Deep Flutter stacks can be huge and
+     * building unbounded strings risks OOM on low-memory devices (see #174).
+     */
+    private static final int MAX_STACK_FRAMES = 128;
+
+    /** Maximum characters for the stack trace string, including truncation note. */
+    private static final int MAX_STACKTRACE_CHARS = 64 * 1024;
     
     // Thread-safe list to store ANR information
     private static final List<String> anrList = Collections.synchronizedList(new ArrayList<>());
@@ -169,44 +177,119 @@ public class ANRTracker extends Thread {
      */
     private void handleAnrDetected() {
         try {
-            // Get the main thread's stack trace
             StackTraceElement[] stackTrace = mainThread.getStackTrace();
-            
-            // Build a readable stack trace
-            StringBuilder stackTraceStr = new StringBuilder();
-            for (StackTraceElement element : stackTrace) {
-                stackTraceStr.append(element.getClassName())
-                        .append(".")
-                        .append(element.getMethodName())
-                        .append("(")
-                        .append(element.getFileName())
-                        .append(":")
-                        .append(element.getLineNumber())
-                        .append(")\n");
-            }
-            
-            // Create JSON object with ANR information
+            int totalFrames = stackTrace.length;
+            StackTraceStringResult stackResult =
+                    buildBoundedStackTraceString(
+                            stackTrace, MAX_STACK_FRAMES, MAX_STACKTRACE_CHARS);
+
             JSONObject anrInfo = new JSONObject();
             try {
                 anrInfo.put("type", "ANR");
                 anrInfo.put("timestamp", System.currentTimeMillis());
-                anrInfo.put("stacktrace", stackTraceStr.toString());
-                
-                // Add duration estimate (at least TIMEOUT ms)
+                anrInfo.put("stacktrace", stackResult.text);
+                anrInfo.put("stacktrace_truncated", stackResult.truncated);
+                anrInfo.put("stacktrace_total_frames", totalFrames);
+                anrInfo.put("stacktrace_included_frames", stackResult.includedFrames);
                 anrInfo.put("duration", TIMEOUT);
             } catch (JSONException e) {
                 Log.e(TAG, "Error creating ANR JSON", e);
             }
-            
-            // Store the ANR information
+
             String anrData = anrInfo.toString();
             synchronized (anrList) {
                 anrList.add(anrData);
             }
-            
-            Log.w(TAG, "ANR detected: " + stackTraceStr);
+
+            Log.w(
+                    TAG,
+                    "ANR detected: included "
+                            + stackResult.includedFrames
+                            + "/"
+                            + totalFrames
+                            + " frames, truncated="
+                            + stackResult.truncated);
         } catch (Exception e) {
             Log.e(TAG, "Error handling ANR", e);
         }
+    }
+
+    private static final class StackTraceStringResult {
+        final @NonNull String text;
+        final boolean truncated;
+        final int includedFrames;
+
+        StackTraceStringResult(
+                @NonNull String text, boolean truncated, int includedFrames) {
+            this.text = text;
+            this.truncated = truncated;
+            this.includedFrames = includedFrames;
+        }
+    }
+
+    /**
+     * Builds a stack trace string capped by {@code maxFrames} and
+     * {@code maxChars} to limit peak allocation on ANR paths.
+     */
+    @NonNull
+    private static StackTraceStringResult buildBoundedStackTraceString(
+            @NonNull StackTraceElement[] stackTrace,
+            int maxFrames,
+            int maxChars) {
+        int total = stackTrace.length;
+        if (total == 0) {
+            return new StackTraceStringResult("", false, 0);
+        }
+
+        StringBuilder sb = new StringBuilder(
+                Math.min(total, maxFrames) * 80);
+        int included = 0;
+        boolean truncated = false;
+
+        for (int i = 0; i < total && included < maxFrames; i++) {
+            String line = formatStackFrameLine(stackTrace[i]);
+            int nextLen = sb.length() + line.length();
+            if (nextLen > maxChars) {
+                truncated = true;
+                break;
+            }
+            sb.append(line);
+            included++;
+        }
+
+        if (included < total) {
+            truncated = true;
+        }
+
+        if (truncated) {
+            String note =
+                    "... (truncated: "
+                            + included
+                            + " of "
+                            + total
+                            + " frames, maxFrames="
+                            + maxFrames
+                            + ", maxChars="
+                            + maxChars
+                            + ")\n";
+            if (sb.length() + note.length() > maxChars) {
+                sb.setLength(Math.max(0, maxChars - note.length()));
+            }
+            sb.append(note);
+        }
+
+        return new StackTraceStringResult(sb.toString(), truncated, included);
+    }
+
+    @NonNull
+    private static String formatStackFrameLine(@NonNull StackTraceElement element) {
+        return element.getClassName()
+                + "."
+                + element.getMethodName()
+                + "("
+                + element.getFileName()
+                + ":"
+                + element.getLineNumber()
+                + ")\n";
     }
 }

--- a/android/src/main/java/com/grafana/faro/ANRTracker.java
+++ b/android/src/main/java/com/grafana/faro/ANRTracker.java
@@ -179,8 +179,8 @@ public class ANRTracker extends Thread {
         try {
             StackTraceElement[] stackTrace = mainThread.getStackTrace();
             int totalFrames = stackTrace.length;
-            StackTraceStringResult stackResult =
-                    buildBoundedStackTraceString(
+            AnrStackTraceFormatter.Result stackResult =
+                    AnrStackTraceFormatter.buildBoundedStackTraceString(
                             stackTrace, MAX_STACK_FRAMES, MAX_STACKTRACE_CHARS);
 
             JSONObject anrInfo = new JSONObject();
@@ -214,82 +214,4 @@ public class ANRTracker extends Thread {
         }
     }
 
-    private static final class StackTraceStringResult {
-        final @NonNull String text;
-        final boolean truncated;
-        final int includedFrames;
-
-        StackTraceStringResult(
-                @NonNull String text, boolean truncated, int includedFrames) {
-            this.text = text;
-            this.truncated = truncated;
-            this.includedFrames = includedFrames;
-        }
-    }
-
-    /**
-     * Builds a stack trace string capped by {@code maxFrames} and
-     * {@code maxChars} to limit peak allocation on ANR paths.
-     */
-    @NonNull
-    private static StackTraceStringResult buildBoundedStackTraceString(
-            @NonNull StackTraceElement[] stackTrace,
-            int maxFrames,
-            int maxChars) {
-        int total = stackTrace.length;
-        if (total == 0) {
-            return new StackTraceStringResult("", false, 0);
-        }
-
-        StringBuilder sb = new StringBuilder(
-                Math.min(total, maxFrames) * 80);
-        int included = 0;
-        boolean truncated = false;
-
-        for (int i = 0; i < total && included < maxFrames; i++) {
-            String line = formatStackFrameLine(stackTrace[i]);
-            int nextLen = sb.length() + line.length();
-            if (nextLen > maxChars) {
-                truncated = true;
-                break;
-            }
-            sb.append(line);
-            included++;
-        }
-
-        if (included < total) {
-            truncated = true;
-        }
-
-        if (truncated) {
-            String note =
-                    "... (truncated: "
-                            + included
-                            + " of "
-                            + total
-                            + " frames, maxFrames="
-                            + maxFrames
-                            + ", maxChars="
-                            + maxChars
-                            + ")\n";
-            if (sb.length() + note.length() > maxChars) {
-                sb.setLength(Math.max(0, maxChars - note.length()));
-            }
-            sb.append(note);
-        }
-
-        return new StackTraceStringResult(sb.toString(), truncated, included);
-    }
-
-    @NonNull
-    private static String formatStackFrameLine(@NonNull StackTraceElement element) {
-        return element.getClassName()
-                + "."
-                + element.getMethodName()
-                + "("
-                + element.getFileName()
-                + ":"
-                + element.getLineNumber()
-                + ")\n";
-    }
 }

--- a/android/src/main/java/com/grafana/faro/AnrStackTraceFormatter.java
+++ b/android/src/main/java/com/grafana/faro/AnrStackTraceFormatter.java
@@ -1,0 +1,91 @@
+package com.grafana.faro;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Formats main-thread stack traces for ANR reporting with bounded allocation.
+ */
+public final class AnrStackTraceFormatter {
+
+    private AnrStackTraceFormatter() {}
+
+    /** Result of {@link #buildBoundedStackTraceString}. */
+    public static final class Result {
+        public final @NonNull String text;
+        public final boolean truncated;
+        public final int includedFrames;
+
+        public Result(@NonNull String text, boolean truncated, int includedFrames) {
+            this.text = text;
+            this.truncated = truncated;
+            this.includedFrames = includedFrames;
+        }
+    }
+
+    /**
+     * Builds a stack trace string capped by {@code maxFrames} and {@code maxChars}
+     * to limit peak allocation on ANR paths.
+     */
+    @NonNull
+    public static Result buildBoundedStackTraceString(
+            @NonNull StackTraceElement[] stackTrace, int maxFrames, int maxChars) {
+        int total = stackTrace.length;
+        if (total == 0) {
+            return new Result("", false, 0);
+        }
+
+        StringBuilder sb = new StringBuilder(Math.min(total, maxFrames) * 80);
+        int included = 0;
+        boolean truncated = false;
+
+        for (int i = 0; i < total && included < maxFrames; i++) {
+            String line = formatStackFrameLine(stackTrace[i]);
+            int nextLen = sb.length() + line.length();
+            if (nextLen > maxChars) {
+                truncated = true;
+                break;
+            }
+            sb.append(line);
+            included++;
+        }
+
+        if (included < total) {
+            truncated = true;
+        }
+
+        if (truncated) {
+            String note =
+                    "... (truncated: "
+                            + included
+                            + " of "
+                            + total
+                            + " frames, maxFrames="
+                            + maxFrames
+                            + ", maxChars="
+                            + maxChars
+                            + ")\n";
+            if (sb.length() + note.length() > maxChars) {
+                sb.setLength(Math.max(0, maxChars - note.length()));
+            }
+            sb.append(note);
+        }
+
+        String out = sb.toString();
+        if (out.length() > maxChars) {
+            out = out.substring(0, maxChars);
+        }
+        return new Result(out, truncated, included);
+    }
+
+    @NonNull
+    private static String formatStackFrameLine(@NonNull StackTraceElement element) {
+        return element.getClassName()
+                + "."
+                + element.getMethodName()
+                + "("
+                + element.getFileName()
+                + ":"
+                + element.getLineNumber()
+                + ")\n";
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This change bounds how much of the main thread stack we stringify when the in-app ANR watchdog fires. Deep Flutter stacks can be very large; building and logging unbounded strings on low-memory devices contributed to `OutOfMemoryError` during ANR capture (see #174).

- Cap at **128 frames** and **64 KiB** for the stored stack trace string.
- Add JSON fields: `stacktrace_truncated`, `stacktrace_total_frames`, `stacktrace_included_frames`.
- Replace full-stack `Log.w` with a short summary (included/total frames, truncated flag).
- Extract **`AnrStackTraceFormatter`** (pure Java) with JUnit tests in **`android/anr-stack-formatter-tests`**; CI runs `./gradlew :anr-stack-formatter-tests:test`. The formatter guarantees the returned string length never exceeds `maxChars` (including truncation suffix).

## Related Issue(s)

Fixes #174

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Chore / Housekeeping

## Checklist

- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Additional Notes

TDD-style: tests were added for max frame count, max character budget, and global length bound; a follow-up fix ensures the formatted string is hard-capped at `maxChars` when the truncation note would otherwise exceed the limit.

`dart tool/pre_release_check.dart` passes locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48f64d3f-ee85-4d4d-a8ad-d22371ce3cb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48f64d3f-ee85-4d4d-a8ad-d22371ce3cb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

