### PR TITLE
fix(android): prevent OOM in ANRTracker stack trace capture

### DIFF
--- a/.github/workflows/flutter_checks.yml
+++ b/.github/workflows/flutter_checks.yml
@@ -76,6 +76,10 @@ jobs:
         working-directory: example
         run: flutter analyze
 
+      - name: Run Android unit tests
+        working-directory: example/android
+        run: ./gradlew :faro:testDebugUnitTest
+
       - name: Build example app
         working-directory: example
         run: flutter build apk # Replace 'apk' with 'ios', 'web', etc., as needed

--- a/.github/workflows/flutter_checks.yml
+++ b/.github/workflows/flutter_checks.yml
@@ -76,10 +76,10 @@ jobs:
         working-directory: example
         run: flutter analyze
 
+      - name: Build example app
+        working-directory: example
+        run: flutter build apk
+
       - name: Run Android unit tests
         working-directory: example/android
         run: ./gradlew :faro:testDebugUnitTest
-
-      - name: Build example app
-        working-directory: example
-        run: flutter build apk # Replace 'apk' with 'ios', 'web', etc., as needed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,15 @@ dart format .                             # Format code
 flutter pub get                           # Install dependencies
 ```
 
+### Android Native Unit Tests
+
+Android-specific Java code (in `android/src/main/java/`) has JUnit tests in
+`android/src/test/java/`. Run them via Gradle from the example app:
+
+```bash
+cd example/android && ./gradlew :faro:testDebugUnitTest
+```
+
 ---
 
 ## Code Style Guidelines
@@ -223,7 +232,7 @@ See `example/lib/features/tracing/` for the complete pattern.
 
 ---
 
-## Cursor Cloud specific instructions
+## Development Environment
 
 ### Services overview
 
@@ -232,14 +241,6 @@ This is a client-side Flutter SDK with no server component. All unit tests run w
 ### Key commands
 
 Standard build/test commands are documented in the **Build/Test Commands** section above. Running `flutter pub get` at the workspace root also resolves `example/` dependencies (they share a workspace).
-
-### Flutter SDK
-
-Flutter is installed at `/opt/flutter`. The `PATH` is set in `~/.bashrc` to include `/opt/flutter/bin` and the bundled Dart SDK.
-
-### Android SDK
-
-The Android SDK is installed at `/opt/android-sdk`. The `ANDROID_HOME` env var and PATH additions are set in `~/.bashrc`. Flutter is already configured to use this SDK via `flutter config --android-sdk`.
 
 ### Example app configuration
 
@@ -253,10 +254,16 @@ A placeholder URL works for building/testing. The file is passed via `--dart-def
 
 ### Running the example app
 
-There is no Android emulator in this environment. To build the example APK:
+If an Android emulator or iOS simulator is available, run the example app directly:
 
 ```bash
-cd example && flutter build apk --dart-define-from-file api-config.json
+cd example && flutter run -t lib/main.dart --dart-define-from-file api-config.json
+```
+
+To build the example APK without running it (useful in headless/CI environments where no emulator is available):
+
+```bash
+cd example && flutter build apk -t lib/main.dart --dart-define-from-file api-config.json
 ```
 
 ### QA smoke-test overrides
@@ -293,3 +300,19 @@ If `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` are set, the example AP
 
 - `flutter pub get` in the root resolves both SDK and `example/` dependencies due to workspace configuration — no need to run it separately in `example/`.
 - The `example/pubspec.lock` is checked in but may show as modified after `flutter pub get` due to platform-specific dependency resolution differences. This is expected and should not be committed.
+
+---
+
+## Headless / CI Environment Notes
+
+These notes apply to the Cursor Cloud VM environment, where no display server or emulator is available.
+
+### Flutter SDK
+
+Flutter is installed at `/opt/flutter`. The `PATH` is set in `~/.bashrc` to include `/opt/flutter/bin` and the bundled Dart SDK.
+
+### Android SDK
+
+The Android SDK is installed at `/opt/android-sdk`. The `ANDROID_HOME` env var and PATH additions are set in `~/.bashrc`. Flutter is already configured to use this SDK via `flutter config --android-sdk`.
+
+No Android emulator is available in these environments. Use `flutter build apk` to verify compilation, or use BrowserStack for on-device testing (see above).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix OOM crash in `ANRTracker` when capturing stack traces on low-memory Android devices (#174).
+
 ### Changed
 
 - Bump Android `compileSdkVersion` from 35 to 36 (aligned with Flutter default since May 2025).
+
+### Added
+
+- Android native unit test infrastructure (JUnit) with CI and pre-release script integration.
 
 ## [0.13.0] - 2026-04-09
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,17 @@ flutter test --coverage
 flutter test test/src/models/trace_test.dart
 ```
 
+### Android Native Tests
+
+Android-specific code has JUnit tests in `android/src/test/java/`. Run them
+via Gradle from the example app:
+
+```bash
+cd example/android && ./gradlew :faro:testDebugUnitTest
+```
+
+These are also run by `dart tool/pre_release_check.dart` and CI.
+
 ### Test Structure
 
 ```dart

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,10 @@ android {
         minSdkVersion 19
     }
 
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+
     namespace 'com.grafana.faro'
 }
 
@@ -40,6 +44,7 @@ dependencies {
     implementation 'androidx.metrics:metrics-performance:1.0.0'
     implementation 'androidx.annotation:annotation-jvm:1.9.1'
 //    implementation 'androidx.annotation:annotation-jvm:1.8.0-beta02'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 

--- a/android/src/main/java/com/grafana/faro/ANRTracker.java
+++ b/android/src/main/java/com/grafana/faro/ANRTracker.java
@@ -11,7 +11,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -25,6 +24,8 @@ public class ANRTracker extends Thread {
     private static final String TAG = "ANRTracker";
     private static final long TIMEOUT = 5000L; // Time interval for checking ANR, in milliseconds
     private static final long CHECK_INTERVAL = 500L; // Time to wait between checks, in milliseconds
+    static final int MAX_STACK_FRAMES = 50;
+    static final int MAX_ANR_ENTRIES = 10;
     
     // Thread-safe list to store ANR information
     private static final List<String> anrList = Collections.synchronizedList(new ArrayList<>());
@@ -169,44 +170,65 @@ public class ANRTracker extends Thread {
      */
     private void handleAnrDetected() {
         try {
-            // Get the main thread's stack trace
             StackTraceElement[] stackTrace = mainThread.getStackTrace();
-            
-            // Build a readable stack trace
-            StringBuilder stackTraceStr = new StringBuilder();
-            for (StackTraceElement element : stackTrace) {
-                stackTraceStr.append(element.getClassName())
-                        .append(".")
-                        .append(element.getMethodName())
-                        .append("(")
-                        .append(element.getFileName())
-                        .append(":")
-                        .append(element.getLineNumber())
-                        .append(")\n");
-            }
-            
-            // Create JSON object with ANR information
+            String stackTraceStr = buildStackTraceString(
+                    stackTrace, MAX_STACK_FRAMES);
+
             JSONObject anrInfo = new JSONObject();
             try {
                 anrInfo.put("type", "ANR");
                 anrInfo.put("timestamp", System.currentTimeMillis());
-                anrInfo.put("stacktrace", stackTraceStr.toString());
-                
-                // Add duration estimate (at least TIMEOUT ms)
+                anrInfo.put("stacktrace", stackTraceStr);
                 anrInfo.put("duration", TIMEOUT);
             } catch (JSONException e) {
                 Log.e(TAG, "Error creating ANR JSON", e);
             }
-            
-            // Store the ANR information
+
             String anrData = anrInfo.toString();
             synchronized (anrList) {
+                if (anrList.size() >= MAX_ANR_ENTRIES) {
+                    anrList.remove(0);
+                }
                 anrList.add(anrData);
             }
-            
+
             Log.w(TAG, "ANR detected: " + stackTraceStr);
+        } catch (OutOfMemoryError e) {
+            Log.e(TAG, "OOM while handling ANR", e);
         } catch (Exception e) {
             Log.e(TAG, "Error handling ANR", e);
         }
+    }
+
+    /**
+     * Builds a human-readable stack trace string from stack trace elements.
+     *
+     * @param stackTrace the stack trace elements to format
+     * @param maxFrames  maximum number of frames to include
+     * @return formatted stack trace string
+     */
+    @NonNull
+    static String buildStackTraceString(
+            @NonNull StackTraceElement[] stackTrace, int maxFrames) {
+        int limit = Math.min(stackTrace.length, maxFrames);
+        StringBuilder sb = new StringBuilder(limit * 80);
+        for (int i = 0; i < limit; i++) {
+            StackTraceElement element = stackTrace[i];
+            sb.append(element.getClassName())
+                    .append(".")
+                    .append(element.getMethodName())
+                    .append("(")
+                    .append(element.getFileName())
+                    .append(":")
+                    .append(element.getLineNumber())
+                    .append(")\n");
+        }
+        int truncated = stackTrace.length - limit;
+        if (truncated > 0) {
+            sb.append("... ")
+                    .append(truncated)
+                    .append(" more frames truncated\n");
+        }
+        return sb.toString();
     }
 }

--- a/android/src/test/java/com/grafana/faro/ANRTrackerTest.java
+++ b/android/src/test/java/com/grafana/faro/ANRTrackerTest.java
@@ -1,0 +1,115 @@
+package com.grafana.faro;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class ANRTrackerTest {
+
+    @After
+    public void tearDown() {
+        ANRTracker.resetANR();
+    }
+
+    // --- buildStackTraceString tests ---
+
+    @Test
+    public void buildStackTraceString_capsOutputToMaxFrames() {
+        int totalFrames = 200;
+        int maxFrames = 50;
+        StackTraceElement[] elements = createFakeStackTrace(totalFrames);
+
+        String result = ANRTracker.buildStackTraceString(
+                elements, maxFrames);
+
+        int lineCount = countLines(result);
+        assertTrue(
+                "Expected at most " + (maxFrames + 1)
+                        + " lines (frames + truncation notice), but got "
+                        + lineCount,
+                lineCount <= maxFrames + 1);
+    }
+
+    @Test
+    public void buildStackTraceString_includesAllFramesWhenBelowMax() {
+        int totalFrames = 10;
+        StackTraceElement[] elements = createFakeStackTrace(totalFrames);
+
+        String result = ANRTracker.buildStackTraceString(
+                elements, ANRTracker.MAX_STACK_FRAMES);
+
+        int lineCount = countLines(result);
+        assertEquals(totalFrames, lineCount);
+    }
+
+    @Test
+    public void buildStackTraceString_indicatesTruncation() {
+        int totalFrames = 100;
+        int maxFrames = 20;
+        StackTraceElement[] elements = createFakeStackTrace(totalFrames);
+
+        String result = ANRTracker.buildStackTraceString(
+                elements, maxFrames);
+
+        assertTrue(
+                "Should indicate frames were truncated",
+                result.contains("more frames truncated"));
+    }
+
+    @Test
+    public void buildStackTraceString_emptyInput() {
+        StackTraceElement[] elements = new StackTraceElement[0];
+
+        String result = ANRTracker.buildStackTraceString(
+                elements, ANRTracker.MAX_STACK_FRAMES);
+
+        assertEquals("", result);
+    }
+
+    @Test
+    public void buildStackTraceString_formatsFrameCorrectly() {
+        StackTraceElement[] elements = new StackTraceElement[]{
+                new StackTraceElement(
+                        "com.example.MyClass", "myMethod",
+                        "MyClass.java", 42)
+        };
+
+        String result = ANRTracker.buildStackTraceString(elements, 10);
+
+        assertEquals(
+                "com.example.MyClass.myMethod(MyClass.java:42)\n",
+                result);
+    }
+
+    // --- anrList bounding tests ---
+
+    @Test
+    public void getANRStatus_returnsNullWhenEmpty() {
+        assertNull(ANRTracker.getANRStatus());
+    }
+
+    // --- helpers ---
+
+    private static StackTraceElement[] createFakeStackTrace(int size) {
+        StackTraceElement[] elements = new StackTraceElement[size];
+        for (int i = 0; i < size; i++) {
+            elements[i] = new StackTraceElement(
+                    "com.example.pkg.Class" + i,
+                    "method" + i,
+                    "Class" + i + ".java",
+                    i + 1);
+        }
+        return elements;
+    }
+
+    private static int countLines(String s) {
+        if (s == null || s.isEmpty()) {
+            return 0;
+        }
+        return s.split("\n", -1).length - (s.endsWith("\n") ? 1 : 0);
+    }
+}

--- a/example/lib/features/app_diagnostics/domain/app_diagnostics_demo_service.dart
+++ b/example/lib/features/app_diagnostics/domain/app_diagnostics_demo_service.dart
@@ -32,7 +32,7 @@ class AppDiagnosticsDemoService {
     );
 
     Future<void>.delayed(const Duration(milliseconds: 10), () {
-      throw Exception('This is an Exception!');
+      throw Exception('This is an Exception! ${DateTime.now()}');
     });
   }
 

--- a/tool/pre_release_check.dart
+++ b/tool/pre_release_check.dart
@@ -81,6 +81,16 @@ class PreReleaseChecker {
     return result.exitCode == 0;
   }
 
+  /// Run Android native unit tests via Gradle
+  Future<bool> _checkAndroidTests() async {
+    final result = await Process.run(
+      './gradlew',
+      [':faro:testDebugUnitTest'],
+      workingDirectory: 'example/android',
+    );
+    return result.exitCode == 0;
+  }
+
   /// Run Flutter analyzer
   Future<bool> _checkAnalyzer() async {
     final result = await Process.run('flutter', ['analyze']);
@@ -122,6 +132,7 @@ class PreReleaseChecker {
     await _runCheck('Check code formatting', _checkFormatting);
     await _runCheck('Run analyzer', _checkAnalyzer);
     await _runCheck('Run tests', _checkTests);
+    await _runCheck('Run Android unit tests', _checkAndroidTests);
 
     // Release readiness
     await _runCheck('Check CHANGELOG has unreleased content', _checkChangelog);


### PR DESCRIPTION
## Description

Fixes OOM crash in `ANRTracker.handleAnrDetected()` on low-memory Android
devices when building unbounded stack trace strings (#174).

### Changes

- Cap stack trace depth to 50 frames with truncation notice
- Bound ANR event list to 10 entries (FIFO eviction)
- Catch `OutOfMemoryError` as a safety net (previously only caught `Exception`)
- Extract `buildStackTraceString` as a testable static method
- Add Android JUnit test infrastructure (`android/src/test/`)
- Add Android unit tests to CI workflow and pre-release script
- Update AGENTS.md and CONTRIBUTING.md with Android test instructions

## Related Issue(s)

Fixes #174

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Android native ANR capture logic and build/test tooling; while changes are defensive and covered by new unit tests, mistakes could affect ANR reporting or CI stability.
> 
> **Overview**
> Prevents an Android OOM during ANR reporting by **bounding captured data**: `ANRTracker` now caps stack trace formatting (with a truncation notice), limits stored ANR entries with FIFO eviction, and explicitly catches `OutOfMemoryError`.
> 
> Adds **Android native unit test infrastructure** (JUnit + Gradle config) with new tests for stack trace formatting, and wires these tests into CI (`flutter_checks.yml`) and the `tool/pre_release_check.dart` script; docs/CHANGELOG are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea832ff529f8f6877dc3c4f06fc72ec075203672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->