### PR TITLE
chore: bump version to v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-04-14
+
 ### Fixed
 
 - Fix OOM crash in `ANRTracker` when capturing stack traces on low-memory Android devices (#174).
 
 ### Changed
 
+- **SDK metadata improvements**: Updated SDK identification to align with Faro Web SDK patterns and improve backend analytics
+  - Changed SDK name from `'faro-flutter-sdk'` to `'faro-mobile-flutter'` to match naming convention discussed with Faro team
+  - Removed hardcoded version `'1.3.5'` workaround and now sends actual SDK version in `meta.sdk.version`
+  - Removed `integrations` field from SDK metadata (following Faro Web SDK pattern - this field provided no actionable insights)
+  - Removed unused `Integration` model class and its export from models barrel file
+  - Backend endpoint service now properly handles Flutter SDK payloads with correct version checking
+  - Enables better SDK version analytics and distribution tracking across different Faro implementations
 - Bump Android `compileSdkVersion` from 35 to 36 (aligned with Flutter default since May 2025).
 - Reorganized iOS source files from `ios/Classes/` to `ios/faro/Sources/faro/` to support the SPM directory convention.
 - Bumped iOS deployment target from 11.0 to 13.0.
@@ -145,16 +154,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ContextScope for span context lifetime control**: New `contextScope` parameter on `startSpan()` controls how long a span remains active in zone context for auto-assignment. `ContextScope.callback` (default) deactivates the span when the callback completes, preventing timer/stream callbacks from inheriting it. `ContextScope.zone` keeps the span active for the entire zone lifetime, useful when you want timer callbacks to be children of the parent span. (Resolves #105)
 
 - **Span.noParent sentinel**: New `Span.noParent` static constant allows explicitly starting a span with no parent, ignoring the active span in zone context. Useful for timer callbacks or event-driven scenarios where you want to start a fresh, independent trace. (Resolves #105)
-
-### Changed
-
-- **SDK metadata improvements**: Updated SDK identification to align with Faro Web SDK patterns and improve backend analytics
-  - Changed SDK name from `'faro-flutter-sdk'` to `'faro-mobile-flutter'` to match naming convention discussed with Faro team
-  - Removed hardcoded version `'1.3.5'` workaround and now sends actual SDK version (`0.9.0`) in `meta.sdk.version`
-  - Removed `integrations` field from SDK metadata (following Faro Web SDK pattern - this field provided no actionable insights)
-  - Removed unused `Integration` model class and its export from models barrel file
-  - Backend endpoint service now properly handles Flutter SDK payloads with correct version checking
-  - Enables better SDK version analytics and distribution tracking across different Faro implementations
 
 ### Fixed
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,9 +52,10 @@ As you develop new features or fix bugs, add entries to the `CHANGELOG.md` under
 
    This automatically:
 
-   - Updates version in `pubspec.yaml`, `ios/faro.podspec`, and `android/build.gradle`
-   - Converts `## Unreleased` → `## 0.3.4 (2025-01-22)` in `CHANGELOG.md`
-   - Creates a new empty `## Unreleased` section
+   - Updates version in `pubspec.yaml`, `ios/faro.podspec`, `android/build.gradle`, and `lib/src/util/constants.dart`
+   - Converts `## [Unreleased]` → `## [x.y.z] - YYYY-MM-DD` in `CHANGELOG.md`
+   - Creates a new empty `## [Unreleased]` section
+   - Runs `flutter pub get` to update `example/pubspec.lock`
 
 4. **Commit Version Bump Changes**
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.13.0'
+version '0.14.0'
 
 buildscript {
     repositories {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -183,7 +183,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.13.0"
+    version: "0.14.0"
   ffi:
     dependency: transitive
     description:

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.13.0'
+  s.version          = '0.14.0'
   s.summary          = 'Grafana Faro SDK for Flutter - mobile observability and real user monitoring.'
   s.description      = <<-DESC
 Grafana Faro SDK for Flutter applications. Monitor your Flutter app with ease

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,7 +1,7 @@
 /// Constants for the Faro Flutter SDK
 class FaroConstants {
   /// The version of the Faro Flutter SDK
-  static const String sdkVersion = '0.13.0';
+  static const String sdkVersion = '0.14.0';
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-mobile-flutter';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.13.0
+version: 0.14.0
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 

--- a/tool/version_bump.dart
+++ b/tool/version_bump.dart
@@ -189,6 +189,18 @@ Future<void> main(List<String> args) async {
     await updateChangelog(newVersion.toString());
     await updateConstants(newVersion.toString());
 
+    // Resolve dependencies so example/pubspec.lock reflects the new version
+    stdout.writeln('Resolving dependencies...');
+    final pubGetResult = await Process.run(
+      'flutter',
+      ['pub', 'get'],
+      workingDirectory: Directory.current.path,
+    );
+    if (pubGetResult.exitCode != 0) {
+      stderr.writeln('Warning: flutter pub get failed:');
+      stderr.writeln(pubGetResult.stderr);
+    }
+
     stdout.writeln('Successfully updated version to $newVersion');
   } catch (e) {
     stderr.writeln('Error updating version: $e');


### PR DESCRIPTION
## Description

Release v0.14.0 — version bump and changelog update.

### What's included in this release

**Added**
- Swift Package Manager (SPM) support for the iOS plugin (#189, #35)
- Android native unit test infrastructure (JUnit) with CI and pre-release script integration

**Changed**
- SDK metadata improvements: renamed SDK to `faro-mobile-flutter`, sends real SDK version, removed `Integration` model (#135)
- Bump Android `compileSdkVersion` from 35 to 36
- Reorganized iOS source files for SPM directory convention
- Bumped iOS deployment target from 11.0 to 13.0
- Updated `faro.podspec` metadata
- Fixed pre-existing Swift compiler warnings in iOS native code

**Fixed**
- OOM crash in `ANRTracker` when capturing stack traces on low-memory Android devices (#174)

### Housekeeping
- `version_bump.dart` now runs `flutter pub get` to keep `example/pubspec.lock` in sync
- Updated `RELEASING.md` to reflect current version bump behavior
- Fixed misplaced changelog entry (SDK metadata was under [0.10.0] instead of [Unreleased])

## Type of Change

- [x] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk versioning/release automation changes; the only behavioral change is `tool/version_bump.dart` now runs `flutter pub get`, which could affect release scripting/CI environments without Flutter available.
> 
> **Overview**
> Prepares the `0.14.0` release by bumping package versions across `pubspec.yaml`, Android `build.gradle`, iOS `faro.podspec`, and `FaroConstants.sdkVersion`, and updating `example/pubspec.lock` accordingly.
> 
> Updates release documentation and finalizes the `CHANGELOG.md` by adding the `0.14.0` section and moving the SDK metadata notes into the correct release entry.
> 
> Enhances `tool/version_bump.dart` to also run `flutter pub get` so the example lockfile stays in sync after version bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d50669c05c2dc3c664619e84626c18b7480978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->