### PR TITLE
feat: add app.version span resource attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Span resource attribute `app.version` (mirrors the existing `service.version` value). Lets dashboards and Tempo metrics-generator setups that group/filter by `app_version` work without relying on `service_version`. The OTel-semconv `service.version` attribute is unchanged.
+
 ## [0.14.0] - 2026-04-14
 
 ### Fixed

--- a/lib/src/tracing/dart_otel_tracer_resources_factory.dart
+++ b/lib/src/tracing/dart_otel_tracer_resources_factory.dart
@@ -23,6 +23,14 @@ class DartOtelTracerResourcesFactory {
           otel_api.ResourceAttributes.serviceVersion,
           faro.meta.app?.version ?? unknownString,
         ),
+        // Additive duplicate of service.version under the `app.version` name
+        // so dashboards/metrics-generator setups that group or filter by
+        // `app_version` work without relying on `service_version`. The
+        // OTel-semconv `service.version` attribute above is intentionally kept.
+        otel_api.Attribute.fromString(
+          'app.version',
+          faro.meta.app?.version ?? unknownString,
+        ),
         otel_api.Attribute.fromString(
           otel_api.ResourceAttributes.serviceNamespace,
           faro.meta.app?.namespace ?? 'flutter_app',

--- a/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
+++ b/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
@@ -85,6 +85,8 @@ void main() {
                 .toString(),
             equals('1.2.3'));
         expect(
+            resource.attributes.get('app.version').toString(), equals('1.2.3'));
+        expect(
             resource.attributes
                 .get(otel_api.ResourceAttributes.serviceNamespace)
                 .toString(),
@@ -114,6 +116,8 @@ void main() {
             resource.attributes
                 .get(otel_api.ResourceAttributes.serviceVersion)
                 .toString(),
+            equals('unknown'));
+        expect(resource.attributes.get('app.version').toString(),
             equals('unknown'));
         expect(
             resource.attributes
@@ -150,11 +154,34 @@ void main() {
                 .get(otel_api.ResourceAttributes.serviceVersion)
                 .toString(),
             equals('unknown'));
+        expect(resource.attributes.get('app.version').toString(),
+            equals('unknown'));
         expect(
             resource.attributes
                 .get(otel_api.ResourceAttributes.serviceNamespace)
                 .toString(),
             equals('flutter_app'));
+      });
+
+      test('app.version should always mirror service.version', () {
+        // Arrange
+        when(() => mockMeta.app).thenReturn(mockApp);
+        when(() => mockMeta.session).thenReturn(null);
+        when(() => mockApp.name).thenReturn('TestApp');
+        when(() => mockApp.environment).thenReturn('production');
+        when(() => mockApp.version).thenReturn('9.9.9-beta');
+        when(() => mockApp.namespace).thenReturn('test.namespace');
+
+        // Act
+        final resource = factory.getTracerResource();
+
+        // Assert
+        final serviceVersion = resource.attributes
+            .get(otel_api.ResourceAttributes.serviceVersion)
+            .toString();
+        final appVersion = resource.attributes.get('app.version').toString();
+        expect(appVersion, equals(serviceVersion));
+        expect(appVersion, equals('9.9.9-beta'));
       });
 
       test('should include SDK telemetry attributes', () {


### PR DESCRIPTION
## Description

Adds a new resource attribute `app.version` on every span emitted by the Flutter SDK's OpenTelemetry tracer. Its value mirrors the existing `service.version` attribute (sourced from `faro.meta.app?.version`, with the same `'unknown'` fallback).

**Why:** Some users' dashboards and Tempo metrics-generator setups group or filter by `app_version` rather than `service_version`. With this change those dashboards work without requiring users to rename existing dashboard variables, and without depending on the OTel-semconv `service.version` attribute being promoted to a metrics label under a non-semconv name.

**What this does *not* do:**
- Does not rename or remove `service.version` — that remains the OTel-semconv source of truth and is unchanged.
- Does not add the attribute as a span attribute (per-span). It is a resource attribute, applied once per resource alongside `service.version`.
- Does not require any consumer-side configuration change in the SDK; the value is automatically populated.

**Consumer follow-up (Tempo side, not part of this PR):** for the new attribute to appear as a span metrics label, the metrics generator on the receiving side needs to include `app.version` in its promoted resource attributes config.

## Related Issue(s)

N/A

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have made corresponding changes to the documentation (none needed — resource attributes are not currently documented in README/Reference; happy to add a section in a follow-up if maintainers want one)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Screenshots (if applicable)

N/A.

## Additional Notes

- Tests: extended the three existing \`serviceVersion\` assertions in \`dart_otel_tracer_resources_factory_test.dart\` to also check \`app.version\`, and added one dedicated test (\`app.version should always mirror service.version\`) whose sole purpose is to fail loudly if the two values are ever decoupled by accident.
- \`dart tool/pre_release_check.dart\` passes locally (formatting, analyzer, all Flutter tests, Android JUnit tests, CHANGELOG check).
- Considered alternatives (and why we didn't pick them):
  - Renaming \`service.version\` → \`app.version\`: rejected — breaks OTel semconv and breaks Application Observability and any existing \`service_version\`-based queries.
  - Adding \`app.version\` as a per-span attribute: rejected for now — wasteful (one write per span vs one per resource) and the use case (filter/group-by in dashboards) is satisfied by a resource attribute via the metrics generator.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive telemetry change: adds one extra OpenTelemetry resource attribute and updates unit tests/changelog; main risk is downstream query/label cardinality changes if consumers promote the new attribute.
> 
> **Overview**
> Adds a new OpenTelemetry *resource* attribute `app.version` on tracer resources, populated from the same app version source (and `unknown` fallback) as `service.version`, while keeping the semconv `service.version` attribute unchanged.
> 
> Extends `DartOtelTracerResourcesFactory` tests to assert `app.version` is present in all relevant cases and includes a dedicated test to ensure it always mirrors `service.version`, and documents the addition in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c812b6d6d6a5e40198aa0ec60abbcc881663b866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->