### PR TITLE
Widen plus dependency ranges and raise SDK floor to Flutter 3.29 / Dart 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Widened `device_info_plus` dependency to `>=12.3.0 <14.0.0`
+  (adds v13.x support).
+- Widened `package_info_plus` dependency to `>=8.0.1 <11.0.0`
+  (adds v10.x support).
+
 ## [0.14.0] - 2026-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Raised the declared Dart SDK lower bound to `>=3.7.0` and Flutter lower
+  bound to `>=3.29.0` to match the effective `device_info_plus` dependency
+  floor.
 - Widened `device_info_plus` dependency to `>=12.3.0 <14.0.0`
   (adds v13.x support).
 - Widened `package_info_plus` dependency to `>=8.0.1 <11.0.0`

--- a/example/README.md
+++ b/example/README.md
@@ -75,6 +75,19 @@ See `lib/features/tracing/` for the reference implementation.
    flutter run --dart-define=FARO_COLLECTOR_URL=https://your-collector-url
    ```
 
+   ### Option 3: Helper scripts (Quick run)
+
+   For a faster CLI workflow, three helper scripts live in `tool/`:
+
+   ```bash
+   ./tool/list-devices.sh                      # connected devices + available emulators
+   ./tool/launch-emulator.sh <emulator-id>     # boot an emulator and wait for it
+   ./tool/run-example.sh -d <device-id>        # run the example app
+   ```
+
+   `run-example.sh` uses `example/api-config.json` and forwards any extra args
+   to `flutter run`, e.g. `./tool/run-example.sh -d emulator-5554 --release`.
+
 ## Features Demonstrated
 
 The example app showcases various Faro SDK features:

--- a/example/lib/features/app_diagnostics/domain/app_diagnostics_demo_service.dart
+++ b/example/lib/features/app_diagnostics/domain/app_diagnostics_demo_service.dart
@@ -1,10 +1,8 @@
 import 'package:faro_example/shared/models/demo_log_entry.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-typedef AppDiagnosticsLogCallback = void Function(
-  String message, {
-  DemoLogTone tone,
-});
+typedef AppDiagnosticsLogCallback =
+    void Function(String message, {DemoLogTone tone});
 
 final appDiagnosticsDemoServiceProvider = Provider<AppDiagnosticsDemoService>(
   (ref) => const AppDiagnosticsDemoService(),

--- a/example/lib/features/app_diagnostics/presentation/app_diagnostics_page.dart
+++ b/example/lib/features/app_diagnostics/presentation/app_diagnostics_page.dart
@@ -16,10 +16,7 @@ class AppDiagnosticsPage extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('App Diagnostics'),
         actions: [
-          TextButton(
-            onPressed: actions.clearLog,
-            child: const Text('Clear'),
-          ),
+          TextButton(onPressed: actions.clearLog, child: const Text('Clear')),
         ],
       ),
       body: Column(
@@ -38,10 +35,7 @@ class AppDiagnosticsPage extends ConsumerWidget {
                   ),
                   child: Row(
                     children: [
-                      Icon(
-                        Icons.warning_amber,
-                        color: Colors.orange.shade800,
-                      ),
+                      Icon(Icons.warning_amber, color: Colors.orange.shade800),
                       const SizedBox(width: 8),
                       const Expanded(
                         child: Text(
@@ -56,10 +50,7 @@ class AppDiagnosticsPage extends ConsumerWidget {
                 const SizedBox(height: 16),
                 const Text(
                   'Failure and ANR demos',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 8),
                 const Text(

--- a/example/lib/features/app_diagnostics/presentation/app_diagnostics_page_view_model.dart
+++ b/example/lib/features/app_diagnostics/presentation/app_diagnostics_page_view_model.dart
@@ -5,10 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Immutable UI state for the app diagnostics page.
 class AppDiagnosticsPageUiState extends Equatable {
-  const AppDiagnosticsPageUiState({
-    required this.log,
-    required this.isRunning,
-  });
+  const AppDiagnosticsPageUiState({required this.log, required this.isRunning});
 
   final List<DemoLogEntry> log;
   final bool isRunning;
@@ -43,24 +40,14 @@ class _AppDiagnosticsPageViewModel extends Notifier<AppDiagnosticsPageUiState>
   AppDiagnosticsPageUiState build() {
     _service = ref.watch(appDiagnosticsDemoServiceProvider);
 
-    return const AppDiagnosticsPageUiState(
-      log: [],
-      isRunning: false,
-    );
+    return const AppDiagnosticsPageUiState(log: [], isRunning: false);
   }
 
-  void _addLog(
-    String message, {
-    DemoLogTone tone = DemoLogTone.neutral,
-  }) {
+  void _addLog(String message, {DemoLogTone tone = DemoLogTone.neutral}) {
     state = state.copyWith(
       log: [
         ...state.log,
-        DemoLogEntry(
-          message: message,
-          timestamp: DateTime.now(),
-          tone: tone,
-        ),
+        DemoLogEntry(message: message, timestamp: DateTime.now(), tone: tone),
       ],
     );
   }
@@ -93,15 +80,17 @@ class _AppDiagnosticsPageViewModel extends Notifier<AppDiagnosticsPageUiState>
 
 final _viewModelProvider =
     NotifierProvider<_AppDiagnosticsPageViewModel, AppDiagnosticsPageUiState>(
-  _AppDiagnosticsPageViewModel.new,
-);
+      _AppDiagnosticsPageViewModel.new,
+    );
 
-final appDiagnosticsPageUiStateProvider =
-    Provider<AppDiagnosticsPageUiState>((ref) {
+final appDiagnosticsPageUiStateProvider = Provider<AppDiagnosticsPageUiState>((
+  ref,
+) {
   return ref.watch(_viewModelProvider);
 });
 
-final appDiagnosticsPageActionsProvider =
-    Provider<AppDiagnosticsPageActions>((ref) {
+final appDiagnosticsPageActionsProvider = Provider<AppDiagnosticsPageActions>((
+  ref,
+) {
   return ref.read(_viewModelProvider.notifier);
 });

--- a/example/lib/features/custom_telemetry/domain/custom_telemetry_demo_service.dart
+++ b/example/lib/features/custom_telemetry/domain/custom_telemetry_demo_service.dart
@@ -2,10 +2,8 @@ import 'package:faro/faro.dart';
 import 'package:faro_example/shared/models/demo_log_entry.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-typedef CustomTelemetryLogCallback = void Function(
-  String message, {
-  DemoLogTone tone,
-});
+typedef CustomTelemetryLogCallback =
+    void Function(String message, {DemoLogTone tone});
 
 final customTelemetryDemoServiceProvider = Provider<CustomTelemetryDemoService>(
   (ref) => const CustomTelemetryDemoService(),

--- a/example/lib/features/custom_telemetry/presentation/custom_telemetry_page.dart
+++ b/example/lib/features/custom_telemetry/presentation/custom_telemetry_page.dart
@@ -19,10 +19,7 @@ class CustomTelemetryPage extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('Custom Telemetry'),
         actions: [
-          TextButton(
-            onPressed: actions.clearLog,
-            child: const Text('Clear'),
-          ),
+          TextButton(onPressed: actions.clearLog, child: const Text('Clear')),
         ],
       ),
       body: Column(
@@ -62,10 +59,7 @@ class CustomTelemetryPage extends ConsumerWidget {
                 const SizedBox(height: 16),
                 const Text(
                   'Telemetry Signals',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 8),
                 const Text(
@@ -114,12 +108,14 @@ class CustomTelemetryPage extends ConsumerWidget {
                       onPressed: actions.emitEvent,
                     ),
                     _TelemetryButton(
-                      label: uiState.isDataCollectionEnabled
-                          ? 'Disable Data Collection'
-                          : 'Enable Data Collection',
-                      icon: uiState.isDataCollectionEnabled
-                          ? Icons.toggle_on
-                          : Icons.toggle_off,
+                      label:
+                          uiState.isDataCollectionEnabled
+                              ? 'Disable Data Collection'
+                              : 'Enable Data Collection',
+                      icon:
+                          uiState.isDataCollectionEnabled
+                              ? Icons.toggle_on
+                              : Icons.toggle_off,
                       onPressed: actions.toggleDataCollection,
                     ),
                   ],

--- a/example/lib/features/custom_telemetry/presentation/custom_telemetry_page_view_model.dart
+++ b/example/lib/features/custom_telemetry/presentation/custom_telemetry_page_view_model.dart
@@ -56,18 +56,11 @@ class _CustomTelemetryPageViewModel extends Notifier<CustomTelemetryPageUiState>
     );
   }
 
-  void _addLog(
-    String message, {
-    DemoLogTone tone = DemoLogTone.neutral,
-  }) {
+  void _addLog(String message, {DemoLogTone tone = DemoLogTone.neutral}) {
     state = state.copyWith(
       log: [
         ...state.log,
-        DemoLogEntry(
-          message: message,
-          timestamp: DateTime.now(),
-          tone: tone,
-        ),
+        DemoLogEntry(message: message, timestamp: DateTime.now(), tone: tone),
       ],
     );
   }
@@ -121,15 +114,17 @@ class _CustomTelemetryPageViewModel extends Notifier<CustomTelemetryPageUiState>
 
 final _viewModelProvider =
     NotifierProvider<_CustomTelemetryPageViewModel, CustomTelemetryPageUiState>(
-  _CustomTelemetryPageViewModel.new,
+      _CustomTelemetryPageViewModel.new,
+    );
+
+final customTelemetryPageUiStateProvider = Provider<CustomTelemetryPageUiState>(
+  (ref) {
+    return ref.watch(_viewModelProvider);
+  },
 );
 
-final customTelemetryPageUiStateProvider =
-    Provider<CustomTelemetryPageUiState>((ref) {
-  return ref.watch(_viewModelProvider);
-});
-
-final customTelemetryPageActionsProvider =
-    Provider<CustomTelemetryPageActions>((ref) {
-  return ref.read(_viewModelProvider.notifier);
-});
+final customTelemetryPageActionsProvider = Provider<CustomTelemetryPageActions>(
+  (ref) {
+    return ref.read(_viewModelProvider.notifier);
+  },
+);

--- a/example/lib/features/feature_catalog/presentation/feature_catalog_page.dart
+++ b/example/lib/features/feature_catalog/presentation/feature_catalog_page.dart
@@ -42,9 +42,7 @@ class _FeatureCatalogPageState extends State<FeatureCatalogPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Features'),
-      ),
+      appBar: AppBar(title: const Text('Features')),
       body: ListView(
         physics: const BouncingScrollPhysics(),
         padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
@@ -135,10 +133,7 @@ class _FeatureCatalogPageState extends State<FeatureCatalogPage> {
 }
 
 class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({
-    required this.title,
-    required this.subtitle,
-  });
+  const _SectionHeader({required this.title, required this.subtitle});
 
   final String title;
   final String subtitle;
@@ -150,16 +145,16 @@ class _SectionHeader extends StatelessWidget {
       children: [
         Text(
           title,
-          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 4),
         Text(
           subtitle,
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Colors.grey.shade700,
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.bodySmall?.copyWith(color: Colors.grey.shade700),
         ),
       ],
     );

--- a/example/lib/features/network_requests/domain/network_requests_demo_service.dart
+++ b/example/lib/features/network_requests/domain/network_requests_demo_service.dart
@@ -4,10 +4,8 @@ import 'package:faro_example/shared/models/demo_log_entry.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 
-typedef NetworkRequestLogCallback = void Function(
-  String message, {
-  DemoLogTone tone,
-});
+typedef NetworkRequestLogCallback =
+    void Function(String message, {DemoLogTone tone});
 
 final networkRequestsDemoServiceProvider = Provider<NetworkRequestsDemoService>(
   (ref) => const NetworkRequestsDemoService(),
@@ -24,9 +22,7 @@ class NetworkRequestsDemoService {
       request: () {
         return http.post(
           Uri.parse('https://httpbin.io/post'),
-          body: jsonEncode(<String, String>{
-            'title': 'This is a title',
-          }),
+          body: jsonEncode(<String, String>{'title': 'This is a title'}),
         );
       },
       log: log,
@@ -40,9 +36,7 @@ class NetworkRequestsDemoService {
       request: () {
         return http.post(
           Uri.parse('https://httpbin.io/unstable'),
-          body: jsonEncode(<String, String>{
-            'title': 'This is a title',
-          }),
+          body: jsonEncode(<String, String>{'title': 'This is a title'}),
         );
       },
       log: log,
@@ -73,10 +67,7 @@ class NetworkRequestsDemoService {
     required Future<http.Response> Function() request,
     required NetworkRequestLogCallback log,
   }) async {
-    log(
-      '$label -> sending request',
-      tone: DemoLogTone.info,
-    );
+    log('$label -> sending request', tone: DemoLogTone.info);
 
     try {
       final response = await request();
@@ -92,10 +83,7 @@ class NetworkRequestsDemoService {
         tone: tone,
       );
     } catch (error) {
-      log(
-        '$label -> threw $error',
-        tone: DemoLogTone.error,
-      );
+      log('$label -> threw $error', tone: DemoLogTone.error);
     }
   }
 }

--- a/example/lib/features/network_requests/presentation/network_requests_page.dart
+++ b/example/lib/features/network_requests/presentation/network_requests_page.dart
@@ -16,10 +16,7 @@ class NetworkRequestsPage extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('Network Requests'),
         actions: [
-          TextButton(
-            onPressed: actions.clearLog,
-            child: const Text('Clear'),
-          ),
+          TextButton(onPressed: actions.clearLog, child: const Text('Clear')),
         ],
       ),
       body: Column(
@@ -31,10 +28,7 @@ class NetworkRequestsPage extends ConsumerWidget {
               children: [
                 const Text(
                   'HTTP tracking demos',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 8),
                 const Text(

--- a/example/lib/features/network_requests/presentation/network_requests_page_view_model.dart
+++ b/example/lib/features/network_requests/presentation/network_requests_page_view_model.dart
@@ -44,24 +44,14 @@ class _NetworkRequestsPageViewModel extends Notifier<NetworkRequestsPageUiState>
   NetworkRequestsPageUiState build() {
     _service = ref.watch(networkRequestsDemoServiceProvider);
 
-    return const NetworkRequestsPageUiState(
-      log: [],
-      isRunning: false,
-    );
+    return const NetworkRequestsPageUiState(log: [], isRunning: false);
   }
 
-  void _addLog(
-    String message, {
-    DemoLogTone tone = DemoLogTone.neutral,
-  }) {
+  void _addLog(String message, {DemoLogTone tone = DemoLogTone.neutral}) {
     state = state.copyWith(
       log: [
         ...state.log,
-        DemoLogEntry(
-          message: message,
-          timestamp: DateTime.now(),
-          tone: tone,
-        ),
+        DemoLogEntry(message: message, timestamp: DateTime.now(), tone: tone),
       ],
     );
   }
@@ -105,15 +95,17 @@ class _NetworkRequestsPageViewModel extends Notifier<NetworkRequestsPageUiState>
 
 final _viewModelProvider =
     NotifierProvider<_NetworkRequestsPageViewModel, NetworkRequestsPageUiState>(
-  _NetworkRequestsPageViewModel.new,
+      _NetworkRequestsPageViewModel.new,
+    );
+
+final networkRequestsPageUiStateProvider = Provider<NetworkRequestsPageUiState>(
+  (ref) {
+    return ref.watch(_viewModelProvider);
+  },
 );
 
-final networkRequestsPageUiStateProvider =
-    Provider<NetworkRequestsPageUiState>((ref) {
-  return ref.watch(_viewModelProvider);
-});
-
-final networkRequestsPageActionsProvider =
-    Provider<NetworkRequestsPageActions>((ref) {
-  return ref.read(_viewModelProvider.notifier);
-});
+final networkRequestsPageActionsProvider = Provider<NetworkRequestsPageActions>(
+  (ref) {
+    return ref.read(_viewModelProvider.notifier);
+  },
+);

--- a/example/lib/features/sampling_settings/domain/sampling_settings_service.dart
+++ b/example/lib/features/sampling_settings/domain/sampling_settings_service.dart
@@ -134,9 +134,9 @@ final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
 });
 
 /// Provider for the sampling settings service.
-final samplingSettingsServiceProvider = Provider<SamplingSettingsService>(
-  (ref) {
-    final prefs = ref.watch(sharedPreferencesProvider);
-    return SamplingSettingsService(prefs: prefs);
-  },
-);
+final samplingSettingsServiceProvider = Provider<SamplingSettingsService>((
+  ref,
+) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return SamplingSettingsService(prefs: prefs);
+});

--- a/example/lib/features/sampling_settings/presentation/sampling_settings_page.dart
+++ b/example/lib/features/sampling_settings/presentation/sampling_settings_page.dart
@@ -25,9 +25,7 @@ class SamplingSettingsPage extends ConsumerWidget {
     }
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Sampling Settings'),
-      ),
+      appBar: AppBar(title: const Text('Sampling Settings')),
       body: SingleChildScrollView(
         padding: EdgeInsets.fromLTRB(
           16.0,

--- a/example/lib/features/sampling_settings/presentation/sampling_settings_page_view_model.dart
+++ b/example/lib/features/sampling_settings/presentation/sampling_settings_page_view_model.dart
@@ -52,12 +52,12 @@ class SamplingSettingsPageUiState extends Equatable {
 
   @override
   List<Object?> get props => [
-        selectedSetting,
-        isSessionSampled,
-        currentConfigDisplay,
-        needsRestart,
-        isLoading,
-      ];
+    selectedSetting,
+    isSessionSampled,
+    currentConfigDisplay,
+    needsRestart,
+    isLoading,
+  ];
 }
 
 // =============================================================================
@@ -121,22 +121,22 @@ class _SamplingSettingsPageViewModel
 // =============================================================================
 
 final _samplingSettingsPageViewModelProvider = NotifierProvider<
-    _SamplingSettingsPageViewModel, SamplingSettingsPageUiState>(
-  _SamplingSettingsPageViewModel.new,
-);
+  _SamplingSettingsPageViewModel,
+  SamplingSettingsPageUiState
+>(_SamplingSettingsPageViewModel.new);
 
 /// Provider for the sampling settings page UI state.
 ///
 /// Use this in widgets to reactively rebuild when state changes.
 final samplingSettingsPageUiStateProvider =
     Provider<SamplingSettingsPageUiState>((ref) {
-  return ref.watch(_samplingSettingsPageViewModelProvider);
-});
+      return ref.watch(_samplingSettingsPageViewModelProvider);
+    });
 
 /// Provider for the sampling settings page actions.
 ///
 /// Use this in widgets to trigger user actions.
 final samplingSettingsPageActionsProvider =
     Provider<SamplingSettingsPageActions>((ref) {
-  return ref.read(_samplingSettingsPageViewModelProvider.notifier);
-});
+      return ref.read(_samplingSettingsPageViewModelProvider.notifier);
+    });

--- a/example/lib/features/sampling_settings/presentation/widgets/current_session_section.dart
+++ b/example/lib/features/sampling_settings/presentation/widgets/current_session_section.dart
@@ -24,19 +24,14 @@ class CurrentSessionSection extends StatelessWidget {
                 SizedBox(width: 8),
                 Text(
                   'Current Session',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                 ),
               ],
             ),
             const SizedBox(height: 16),
 
             // Sampled status - prominent display
-            SampledStatusBanner(
-              isSessionSampled: uiState.isSessionSampled,
-            ),
+            SampledStatusBanner(isSessionSampled: uiState.isSessionSampled),
             const SizedBox(height: 12),
             Text(
               'Config: ${uiState.currentConfigDisplay}',
@@ -46,9 +41,7 @@ class CurrentSessionSection extends StatelessWidget {
             // Restart warning
             if (uiState.needsRestart) ...[
               const SizedBox(height: 12),
-              RestartWarningBanner(
-                selectedSetting: uiState.selectedSetting,
-              ),
+              RestartWarningBanner(selectedSetting: uiState.selectedSetting),
             ],
           ],
         ),

--- a/example/lib/features/sampling_settings/presentation/widgets/restart_warning_banner.dart
+++ b/example/lib/features/sampling_settings/presentation/widgets/restart_warning_banner.dart
@@ -25,10 +25,7 @@ class RestartWarningBanner extends StatelessWidget {
             child: Text(
               'Sampling setting changed! Restart the app to apply '
               '"${selectedSetting.displayName}".',
-              style: TextStyle(
-                fontSize: 11,
-                color: Colors.orange.shade900,
-              ),
+              style: TextStyle(fontSize: 11, color: Colors.orange.shade900),
             ),
           ),
         ],

--- a/example/lib/features/sampling_settings/presentation/widgets/sampled_status_banner.dart
+++ b/example/lib/features/sampling_settings/presentation/widgets/sampled_status_banner.dart
@@ -35,9 +35,10 @@ class SampledStatusBanner extends StatelessWidget {
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.bold,
-                    color: isSessionSampled
-                        ? Colors.green.shade800
-                        : Colors.grey.shade700,
+                    color:
+                        isSessionSampled
+                            ? Colors.green.shade800
+                            : Colors.grey.shade700,
                   ),
                 ),
                 const SizedBox(height: 4),
@@ -47,9 +48,10 @@ class SampledStatusBanner extends StatelessWidget {
                       : 'No telemetry collected this session',
                   style: TextStyle(
                     fontSize: 12,
-                    color: isSessionSampled
-                        ? Colors.green.shade700
-                        : Colors.grey.shade600,
+                    color:
+                        isSessionSampled
+                            ? Colors.green.shade700
+                            : Colors.grey.shade600,
                   ),
                 ),
               ],

--- a/example/lib/features/sampling_settings/presentation/widgets/sampling_config_section.dart
+++ b/example/lib/features/sampling_settings/presentation/widgets/sampling_config_section.dart
@@ -31,10 +31,7 @@ class SamplingConfigSection extends StatelessWidget {
                 Expanded(
                   child: Text(
                     'Sampling Configuration',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                    ),
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                   ),
                 ),
               ],
@@ -61,15 +58,12 @@ class SamplingConfigSection extends StatelessWidget {
                   // Fixed Rate Options
                   const Text(
                     'Fixed Rate (SamplingRate)',
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                    ),
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
                   ),
                   const SizedBox(height: 8),
-                  ...SamplingSetting.values.where((s) => !s.isFunction).map(
-                        (setting) => SamplingRadioTile(setting: setting),
-                      ),
+                  ...SamplingSetting.values
+                      .where((s) => !s.isFunction)
+                      .map((setting) => SamplingRadioTile(setting: setting)),
 
                   const SizedBox(height: 16),
                   const Divider(),
@@ -78,10 +72,7 @@ class SamplingConfigSection extends StatelessWidget {
                   // Function-based Options
                   const Text(
                     'Dynamic (SamplingFunction)',
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                    ),
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
                   ),
                   const SizedBox(height: 4),
                   const Text(
@@ -89,9 +80,9 @@ class SamplingConfigSection extends StatelessWidget {
                     style: TextStyle(fontSize: 11, color: Colors.grey),
                   ),
                   const SizedBox(height: 8),
-                  ...SamplingSetting.values.where((s) => s.isFunction).map(
-                        (setting) => SamplingRadioTile(setting: setting),
-                      ),
+                  ...SamplingSetting.values
+                      .where((s) => s.isFunction)
+                      .map((setting) => SamplingRadioTile(setting: setting)),
                 ],
               ),
             ),

--- a/example/lib/features/sampling_settings/presentation/widgets/sampling_radio_tile.dart
+++ b/example/lib/features/sampling_settings/presentation/widgets/sampling_radio_tile.dart
@@ -12,10 +12,7 @@ class SamplingRadioTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return RadioListTile<SamplingSetting>(
       title: Text(setting.displayName),
-      subtitle: Text(
-        setting.subtitle,
-        style: const TextStyle(fontSize: 11),
-      ),
+      subtitle: Text(setting.subtitle, style: const TextStyle(fontSize: 11)),
       value: setting,
       contentPadding: EdgeInsets.zero,
       dense: true,

--- a/example/lib/features/tracing/domain/tracing_service.dart
+++ b/example/lib/features/tracing/domain/tracing_service.dart
@@ -19,15 +19,14 @@ class TracingService {
     log('Starting simple span...');
 
     try {
-      final result = await Faro().startSpan<String>(
-        'simple-test-span',
-        (span) async {
-          log('Inside span, doing work...');
-          await Future.delayed(const Duration(milliseconds: 500));
-          span.addEvent('work-completed');
-          return 'success';
-        },
-      );
+      final result = await Faro().startSpan<String>('simple-test-span', (
+        span,
+      ) async {
+        log('Inside span, doing work...');
+        await Future.delayed(const Duration(milliseconds: 500));
+        span.addEvent('work-completed');
+        return 'success';
+      });
       log('Span completed with result: $result');
     } catch (error) {
       log('Error: $error', isError: true);
@@ -47,16 +46,13 @@ class TracingService {
             'user.email': 'john@example.com',
             'action': 'test-action',
           });
-          span.addEvent('user-action', attributes: {
-            'button': 'submit',
-            'page': 'checkout',
-          });
+          span.addEvent(
+            'user-action',
+            attributes: {'button': 'submit', 'page': 'checkout'},
+          );
           await Future.delayed(const Duration(milliseconds: 300));
         },
-        attributes: {
-          'environment': 'test',
-          'version': '1.0.0',
-        },
+        attributes: {'environment': 'test', 'version': '1.0.0'},
       );
       log('String attributes span completed');
     } catch (error) {
@@ -86,18 +82,19 @@ class TracingService {
           });
 
           log('Set attributes: account_count=$accountCount (int)');
-          log(
-            'Set attributes: balance=${balance.toStringAsFixed(2)} (double)',
-          );
+          log('Set attributes: balance=${balance.toStringAsFixed(2)} (double)');
           log('Set attributes: is_premium=$isPremium (bool)');
 
           // Add event with typed attributes
-          span.addEvent('purchase-completed', attributes: {
-            'item_count': random.nextInt(10) + 1,
-            'total_amount': random.nextDouble() * 500,
-            'used_coupon': random.nextBool(),
-            'payment_method': 'credit_card',
-          });
+          span.addEvent(
+            'purchase-completed',
+            attributes: {
+              'item_count': random.nextInt(10) + 1,
+              'total_amount': random.nextDouble() * 500,
+              'used_coupon': random.nextBool(),
+              'payment_method': 'credit_card',
+            },
+          );
 
           await Future.delayed(const Duration(milliseconds: 400));
         },
@@ -148,40 +145,30 @@ class TracingService {
     log('Starting nested spans demo...');
 
     try {
-      await Faro().startSpan<void>(
-        'parent-span',
-        (parentSpan) async {
-          log('Parent span started');
-          parentSpan.setAttributes({'level': 0, 'type': 'parent'});
+      await Faro().startSpan<void>('parent-span', (parentSpan) async {
+        log('Parent span started');
+        parentSpan.setAttributes({'level': 0, 'type': 'parent'});
 
-          await Faro().startSpan<void>(
-            'child-span-1',
-            (childSpan) async {
-              log('  Child span 1 started');
-              childSpan.setAttributes({'level': 1, 'type': 'child'});
-              await Future.delayed(const Duration(milliseconds: 200));
-              log('  Child span 1 completed');
-            },
-          );
+        await Faro().startSpan<void>('child-span-1', (childSpan) async {
+          log('  Child span 1 started');
+          childSpan.setAttributes({'level': 1, 'type': 'child'});
+          await Future.delayed(const Duration(milliseconds: 200));
+          log('  Child span 1 completed');
+        });
 
-          await Faro().startSpan<void>(
-            'child-span-2',
-            (childSpan) async {
-              log('  Child span 2 started');
-              childSpan.setAttributes({
-                'level': 1,
-                'items_processed': 42,
-                'success_rate': 0.95,
-              });
-              await Future.delayed(const Duration(milliseconds: 300));
-              log('  Child span 2 completed');
-            },
-          );
+        await Faro().startSpan<void>('child-span-2', (childSpan) async {
+          log('  Child span 2 started');
+          childSpan.setAttributes({
+            'level': 1,
+            'items_processed': 42,
+            'success_rate': 0.95,
+          });
+          await Future.delayed(const Duration(milliseconds: 300));
+          log('  Child span 2 completed');
+        });
 
-          log('Parent span completing');
-        },
-        attributes: {'test_type': 'nested'},
-      );
+        log('Parent span completing');
+      }, attributes: {'test_type': 'nested'});
       log('All nested spans completed');
     } catch (error) {
       log('Error: $error', isError: true);
@@ -193,26 +180,20 @@ class TracingService {
     log('Starting span that will record an error...');
 
     try {
-      await Faro().startSpan<void>(
-        'error-demo-span',
-        (span) async {
-          span.setAttributes({
-            'operation': 'risky-operation',
-            'attempt': 1,
-          });
+      await Faro().startSpan<void>('error-demo-span', (span) async {
+        span.setAttributes({'operation': 'risky-operation', 'attempt': 1});
 
-          await Future.delayed(const Duration(milliseconds: 200));
+        await Future.delayed(const Duration(milliseconds: 200));
 
-          // Record an exception
-          try {
-            throw Exception('Simulated error for testing');
-          } catch (error, stackTrace) {
-            span.recordException(error, stackTrace: stackTrace);
-            span.setStatus(SpanStatusCode.error, message: 'Operation failed');
-            log('Recorded exception in span');
-          }
-        },
-      );
+        // Record an exception
+        try {
+          throw Exception('Simulated error for testing');
+        } catch (error, stackTrace) {
+          span.recordException(error, stackTrace: stackTrace);
+          span.setStatus(SpanStatusCode.error, message: 'Operation failed');
+          log('Recorded exception in span');
+        }
+      });
       log('Error span completed (error was recorded, not thrown)');
     } catch (error) {
       log('Unexpected error: $error', isError: true);
@@ -228,45 +209,43 @@ class TracingService {
     log('This shows how to start independent traces.');
 
     try {
-      await Faro().startSpan<void>(
-        'outer-context-span',
-        (outerSpan) async {
-          outerSpan.setAttributes({'type': 'outer-context'});
-          log('Outer span started (traceId: ${outerSpan.traceId.substring(0, 8)}...)');
+      await Faro().startSpan<void>('outer-context-span', (outerSpan) async {
+        outerSpan.setAttributes({'type': 'outer-context'});
+        log(
+          'Outer span started (traceId: ${outerSpan.traceId.substring(0, 8)}...)',
+        );
 
-          // Simulate a "timer callback" scenario
-          // In real code, this might be Timer.periodic or a stream listener
-          log('Simulating timer callback scenario...');
-          await Future.delayed(const Duration(milliseconds: 300));
+        // Simulate a "timer callback" scenario
+        // In real code, this might be Timer.periodic or a stream listener
+        log('Simulating timer callback scenario...');
+        await Future.delayed(const Duration(milliseconds: 300));
 
-          // WITHOUT Span.noParent - would inherit outer span as parent
-          await Faro().startSpan<void>(
-            'child-with-parent',
-            (childSpan) async {
-              log('  Child WITH parent (traceId: ${childSpan.traceId.substring(0, 8)}...)');
-              log('  ^ Same traceId = same trace');
-              await Future.delayed(const Duration(milliseconds: 200));
-            },
+        // WITHOUT Span.noParent - would inherit outer span as parent
+        await Faro().startSpan<void>('child-with-parent', (childSpan) async {
+          log(
+            '  Child WITH parent (traceId: ${childSpan.traceId.substring(0, 8)}...)',
           );
+          log('  ^ Same traceId = same trace');
+          await Future.delayed(const Duration(milliseconds: 200));
+        });
 
-          // WITH Span.noParent - starts a completely new trace
-          await Faro().startSpan<void>(
-            'independent-trace',
-            (independentSpan) async {
-              independentSpan.setAttributes({
-                'type': 'independent',
-                'reason': 'timer-callback',
-              });
-              log('  Independent span (traceId: ${independentSpan.traceId.substring(0, 8)}...)');
-              log('  ^ Different traceId = new trace!');
-              await Future.delayed(const Duration(milliseconds: 200));
-            },
-            parentSpan: Span.noParent,
+        // WITH Span.noParent - starts a completely new trace
+        await Faro().startSpan<void>('independent-trace', (
+          independentSpan,
+        ) async {
+          independentSpan.setAttributes({
+            'type': 'independent',
+            'reason': 'timer-callback',
+          });
+          log(
+            '  Independent span (traceId: ${independentSpan.traceId.substring(0, 8)}...)',
           );
+          log('  ^ Different traceId = new trace!');
+          await Future.delayed(const Duration(milliseconds: 200));
+        }, parentSpan: Span.noParent);
 
-          log('Outer span completing');
-        },
-      );
+        log('Outer span completing');
+      });
       log('Span.noParent demo completed!');
       log('Check backend: you should see 2 separate traces.');
     } catch (error) {
@@ -281,7 +260,9 @@ class TracingService {
   Future<void> runContextScopeDemo(LogCallback log) async {
     log('Starting ContextScope demo...');
     log('');
-    log('ContextScope controls whether timer callbacks inherit the parent span.');
+    log(
+      'ContextScope controls whether timer callbacks inherit the parent span.',
+    );
     log('');
 
     try {
@@ -297,17 +278,20 @@ class TracingService {
         'parent-callback-scope',
         (parentSpan) async {
           parentTraceId1 = parentSpan.traceId;
-          log('Parent span started (traceId: ${parentSpan.traceId.substring(0, 8)}...)');
+          log(
+            'Parent span started (traceId: ${parentSpan.traceId.substring(0, 8)}...)',
+          );
 
           // Schedule a timer that fires after parent callback ends
           Timer(const Duration(milliseconds: 100), () async {
-            await Faro().startSpan<void>(
-              'timer-child-callback',
-              (timerSpan) async {
-                timerSpanTraceId1 = timerSpan.traceId;
-                log('  Timer span (traceId: ${timerSpan.traceId.substring(0, 8)}...)');
-              },
-            );
+            await Faro().startSpan<void>('timer-child-callback', (
+              timerSpan,
+            ) async {
+              timerSpanTraceId1 = timerSpan.traceId;
+              log(
+                '  Timer span (traceId: ${timerSpan.traceId.substring(0, 8)}...)',
+              );
+            });
             completer1.complete();
           });
 
@@ -337,17 +321,18 @@ class TracingService {
         'parent-zone-scope',
         (parentSpan) async {
           parentTraceId = parentSpan.traceId;
-          log('Parent span started (traceId: ${parentSpan.traceId.substring(0, 8)}...)');
+          log(
+            'Parent span started (traceId: ${parentSpan.traceId.substring(0, 8)}...)',
+          );
 
           // Schedule a timer that fires after parent callback ends
           Timer(const Duration(milliseconds: 100), () async {
-            await Faro().startSpan<void>(
-              'timer-child-zone',
-              (timerSpan) async {
-                timerSpanTraceId2 = timerSpan.traceId;
-                log('  Timer span (traceId: ${timerSpan.traceId.substring(0, 8)}...)');
-              },
-            );
+            await Faro().startSpan<void>('timer-child-zone', (timerSpan) async {
+              timerSpanTraceId2 = timerSpan.traceId;
+              log(
+                '  Timer span (traceId: ${timerSpan.traceId.substring(0, 8)}...)',
+              );
+            });
             completer2.complete();
           });
 

--- a/example/lib/features/tracing/presentation/tracing_page.dart
+++ b/example/lib/features/tracing/presentation/tracing_page.dart
@@ -42,10 +42,7 @@ class TracingPage extends ConsumerWidget {
 // =============================================================================
 
 class _ButtonsSection extends StatelessWidget {
-  const _ButtonsSection({
-    required this.uiState,
-    required this.actions,
-  });
+  const _ButtonsSection({required this.uiState, required this.actions});
 
   final TracingPageUiState uiState;
   final TracingPageActions actions;
@@ -59,10 +56,7 @@ class _ButtonsSection extends StatelessWidget {
         children: [
           const Text(
             'Test Span Operations',
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.bold,
-            ),
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 8),
           const Text(
@@ -164,21 +158,22 @@ class _LogSection extends StatelessWidget {
     return Expanded(
       child: Container(
         color: Colors.grey.shade100,
-        child: spanLog.isEmpty
-            ? const Center(
-                child: Text(
-                  'Run a span operation to see the log',
-                  style: TextStyle(color: Colors.grey),
+        child:
+            spanLog.isEmpty
+                ? const Center(
+                  child: Text(
+                    'Run a span operation to see the log',
+                    style: TextStyle(color: Colors.grey),
+                  ),
+                )
+                : ListView.builder(
+                  padding: const EdgeInsets.all(8),
+                  itemCount: spanLog.length,
+                  itemBuilder: (context, index) {
+                    final entry = spanLog[index];
+                    return _LogEntryRow(entry: entry);
+                  },
                 ),
-              )
-            : ListView.builder(
-                padding: const EdgeInsets.all(8),
-                itemCount: spanLog.length,
-                itemBuilder: (context, index) {
-                  final entry = spanLog[index];
-                  return _LogEntryRow(entry: entry);
-                },
-              ),
       ),
     );
   }

--- a/example/lib/features/tracing/presentation/tracing_page_view_model.dart
+++ b/example/lib/features/tracing/presentation/tracing_page_view_model.dart
@@ -12,10 +12,7 @@ import '../models/span_log_entry.dart';
 ///
 /// Contains all data needed to render the tracing page UI.
 class TracingPageUiState extends Equatable {
-  const TracingPageUiState({
-    required this.spanLog,
-    required this.isRunning,
-  });
+  const TracingPageUiState({required this.spanLog, required this.isRunning});
 
   /// Log entries to display in the log view.
   final List<SpanLogEntry> spanLog;
@@ -24,10 +21,7 @@ class TracingPageUiState extends Equatable {
   final bool isRunning;
 
   /// Creates a copy of this state with the given fields replaced.
-  TracingPageUiState copyWith({
-    List<SpanLogEntry>? spanLog,
-    bool? isRunning,
-  }) {
+  TracingPageUiState copyWith({List<SpanLogEntry>? spanLog, bool? isRunning}) {
     return TracingPageUiState(
       spanLog: spanLog ?? this.spanLog,
       isRunning: isRunning ?? this.isRunning,
@@ -99,10 +93,7 @@ class _TracingPageViewModel extends Notifier<TracingPageUiState>
     // Initialize dependencies
     _tracingService = ref.watch(tracingServiceProvider);
 
-    return const TracingPageUiState(
-      spanLog: [],
-      isRunning: false,
-    );
+    return const TracingPageUiState(spanLog: [], isRunning: false);
   }
 
   // ---------------------------------------------------------------------------
@@ -199,8 +190,8 @@ class _TracingPageViewModel extends Notifier<TracingPageUiState>
 
 final _tracingPageViewModelProvider =
     NotifierProvider<_TracingPageViewModel, TracingPageUiState>(
-  _TracingPageViewModel.new,
-);
+      _TracingPageViewModel.new,
+    );
 
 /// Provider for the tracing page UI state.
 ///

--- a/example/lib/features/user_actions/domain/user_actions_demo_service.dart
+++ b/example/lib/features/user_actions/domain/user_actions_demo_service.dart
@@ -6,11 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 
 /// Callback for logging messages to the UI.
-typedef LogCallback = void Function(
-  String message, {
-  bool isError,
-  bool isHighlight,
-});
+typedef LogCallback =
+    void Function(String message, {bool isError, bool isHighlight});
 
 /// Callback invoked on each state-poll tick so the view model can capture
 /// intermediate state changes.
@@ -50,10 +47,7 @@ class UserActionsDemoService {
 
     await _pollUntilTerminal(run.action, log, onTick);
 
-    log(
-      'Final state: ${run.action.getState().name}',
-      isHighlight: true,
-    );
+    log('Final state: ${run.action.getState().name}', isHighlight: true);
   }
 
   // ---------------------------------------------------------------------------
@@ -98,10 +92,7 @@ class UserActionsDemoService {
     await Future<void>.delayed(const Duration(milliseconds: 350));
     await _pollUntilTerminal(run.action, log, onTick);
 
-    log(
-      'Final state: ${run.action.getState().name}',
-      isHighlight: true,
-    );
+    log('Final state: ${run.action.getState().name}', isHighlight: true);
   }
 
   // ---------------------------------------------------------------------------
@@ -183,10 +174,10 @@ class UserActionsDemoService {
           'Started custom parent span '
           '(traceId=${parentSpan.traceId}, spanId=${parentSpan.spanId})',
         );
-        parentSpan.addEvent('parallel_http.requests.started', attributes: {
-          'runId': run.runId,
-          'requestCount': 4,
-        });
+        parentSpan.addEvent(
+          'parallel_http.requests.started',
+          attributes: {'runId': run.runId, 'requestCount': 4},
+        );
 
         final requestFutures = <Future<void>>[
           _runHttpGet(
@@ -229,10 +220,13 @@ class UserActionsDemoService {
         await Faro().startSpan<void>(
           'ua.parallel_http.late_span',
           (lateSpan) {
-            lateSpan.addEvent('parallel_http.late_span.created', attributes: {
-              'runId': run.runId,
-              'actionStateAtCreation': stateAtLateSpan.name,
-            });
+            lateSpan.addEvent(
+              'parallel_http.late_span.created',
+              attributes: {
+                'runId': run.runId,
+                'actionStateAtCreation': stateAtLateSpan.name,
+              },
+            );
             log(
               'Created late span (spanId=${lateSpan.spanId}) while '
               'action state=${stateAtLateSpan.name}.',
@@ -247,14 +241,12 @@ class UserActionsDemoService {
 
         await Future.wait(requestFutures);
 
-        parentSpan.addEvent('parallel_http.requests.completed', attributes: {
-          'runId': run.runId,
-        });
+        parentSpan.addEvent(
+          'parallel_http.requests.completed',
+          attributes: {'runId': run.runId},
+        );
       },
-      attributes: {
-        'scenario': 'parallel_http',
-        'runId': run.runId,
-      },
+      attributes: {'scenario': 'parallel_http', 'runId': run.runId},
     );
     onTick();
 
@@ -289,15 +281,10 @@ class UserActionsDemoService {
       return;
     }
 
-    log(
-      'Emitting pre-halt telemetry + fast navigation + long HTTP request.',
-    );
+    log('Emitting pre-halt telemetry + fast navigation + long HTTP request.');
     onTick();
 
-    Faro().pushEvent(
-      'ua.pre_halt.event',
-      attributes: {'runId': run.runId},
-    );
+    Faro().pushEvent('ua.pre_halt.event', attributes: {'runId': run.runId});
     Faro().pushLog(
       'ua.pre_halt.log',
       level: LogLevel.debug,
@@ -319,10 +306,7 @@ class UserActionsDemoService {
     onTick();
 
     await Future<void>.delayed(const Duration(milliseconds: 250));
-    Faro().pushEvent(
-      'ua.post_halt.event',
-      attributes: {'runId': run.runId},
-    );
+    Faro().pushEvent('ua.post_halt.event', attributes: {'runId': run.runId});
     Faro().pushLog(
       'ua.post_halt.log',
       level: LogLevel.warn,
@@ -339,10 +323,7 @@ class UserActionsDemoService {
     await requestFuture;
     await _pollUntilTerminal(run.action, log, onTick);
 
-    log(
-      'Final state: ${run.action.getState().name}',
-      isHighlight: true,
-    );
+    log('Final state: ${run.action.getState().name}', isHighlight: true);
     log(
       'Grafana hint: query runId=${run.runId} and compare '
       'ua.pre_halt.* vs ua.post_halt.* action linkage.',
@@ -423,8 +404,10 @@ class UserActionsDemoService {
     );
 
     await _pollUntilTerminal(run.action, log, onTick);
-    log('Primary final state: ${run.action.getState().name}',
-        isHighlight: true);
+    log(
+      'Primary final state: ${run.action.getState().name}',
+      isHighlight: true,
+    );
 
     final startAfterTermination = Faro().startUserAction(
       'ua-concurrent-after-release',
@@ -494,8 +477,10 @@ class UserActionsDemoService {
     );
 
     if (action == null) {
-      log('Could not start. Another user action is already active.',
-          isError: true);
+      log(
+        'Could not start. Another user action is already active.',
+        isError: true,
+      );
       return null;
     }
 
@@ -595,10 +580,7 @@ class UserActionsDemoService {
 }
 
 class _ScenarioRun {
-  const _ScenarioRun({
-    required this.action,
-    required this.runId,
-  });
+  const _ScenarioRun({required this.action, required this.runId});
 
   final UserActionHandle action;
   final String runId;

--- a/example/lib/features/user_actions/presentation/user_actions_page.dart
+++ b/example/lib/features/user_actions/presentation/user_actions_page.dart
@@ -61,18 +61,12 @@ class _UserActionsPageState extends ConsumerState<UserActionsPage> {
       appBar: AppBar(
         title: const Text('User Actions'),
         actions: [
-          TextButton(
-            onPressed: actions.clearLog,
-            child: const Text('Clear'),
-          ),
+          TextButton(onPressed: actions.clearLog, child: const Text('Clear')),
         ],
       ),
       body: Column(
         children: [
-          _StatusBanner(
-            actionName: _actionName,
-            actionState: _actionState,
-          ),
+          _StatusBanner(actionName: _actionName, actionState: _actionState),
           _ScenariosSection(
             isRunning: uiState.isRunning,
             actions: actions,
@@ -91,10 +85,7 @@ class _UserActionsPageState extends ConsumerState<UserActionsPage> {
 // =============================================================================
 
 class _StatusBanner extends StatelessWidget {
-  const _StatusBanner({
-    required this.actionName,
-    required this.actionState,
-  });
+  const _StatusBanner({required this.actionName, required this.actionState});
 
   final String? actionName;
   final UserActionState? actionState;
@@ -129,10 +120,7 @@ class _StatusBanner extends StatelessWidget {
           Expanded(
             child: Text(
               _label,
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                color: _color,
-              ),
+              style: TextStyle(fontWeight: FontWeight.bold, color: _color),
             ),
           ),
         ],
@@ -176,9 +164,9 @@ class _ScenariosSection extends StatelessWidget {
             children: [
               Text(
                 title,
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
+                style: Theme.of(
+                  context,
+                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 12),
               Text(details),
@@ -214,7 +202,8 @@ class _ScenariosSection extends StatelessWidget {
                   _showScenarioInfo(
                     context,
                     title: 'No follow-up (cancel)',
-                    details: '- Starts one user action.\n'
+                    details:
+                        '- Starts one user action.\n'
                         '- Emits no follow-up activity.\n'
                         '- After follow-up timeout, expected: '
                         'started -> cancelled.\n'
@@ -235,7 +224,8 @@ class _ScenariosSection extends StatelessWidget {
                   _showScenarioInfo(
                     context,
                     title: 'Concurrent start guard',
-                    details: '- Starts one primary user action.\n'
+                    details:
+                        '- Starts one primary user action.\n'
                         '- Immediately tries to start a second action.\n'
                         '- Expected while primary is active: second start returns null.\n'
                         '- Uses a short navigation pulse so primary ends (not cancelled).\n'
@@ -257,7 +247,8 @@ class _ScenariosSection extends StatelessWidget {
                   _showScenarioInfo(
                     context,
                     title: 'Fast view push+pop',
-                    details: '- Starts one user action.\n'
+                    details:
+                        '- Starts one user action.\n'
                         '- Triggers quick route push and pop.\n'
                         '- Navigation observer emits activity signals.\n'
                         '- Expected: started -> ended (no halted).',
@@ -277,7 +268,8 @@ class _ScenariosSection extends StatelessWidget {
                   _showScenarioInfo(
                     context,
                     title: 'Single HTTP (halt)',
-                    details: '- Starts one user action.\n'
+                    details:
+                        '- Starts one user action.\n'
                         '- Sends one request to /delay/3.\n'
                         '- Pending operation causes halt after follow-up.\n'
                         '- Expected: started -> halted -> ended.',
@@ -297,7 +289,8 @@ class _ScenariosSection extends StatelessWidget {
                   _showScenarioInfo(
                     context,
                     title: 'Parallel HTTP (1/2/3/6s)',
-                    details: '- Starts one user action.\n'
+                    details:
+                        '- Starts one user action.\n'
                         '- Wraps the whole flow in custom span '
                         '`ua.parallel_http.parent_span`.\n'
                         '- Fires 4 requests in parallel (1s, 2s, 3s, 6s).\n'
@@ -321,7 +314,8 @@ class _ScenariosSection extends StatelessWidget {
                   _showScenarioInfo(
                     context,
                     title: 'Mixed timing window',
-                    details: '- Emits these telemetry items immediately:\n'
+                    details:
+                        '- Emits these telemetry items immediately:\n'
                         '  event=`ua.pre_halt.event`, '
                         'log=`ua.pre_halt.log`, '
                         'error=`ua.pre_halt.error`.\n'
@@ -420,18 +414,19 @@ class _LogSection extends StatelessWidget {
     return Expanded(
       child: Container(
         color: Colors.grey.shade100,
-        child: log.isEmpty
-            ? const Center(
-                child: Text(
-                  'Run a scenario to see the action lifecycle log',
-                  style: TextStyle(color: Colors.grey),
+        child:
+            log.isEmpty
+                ? const Center(
+                  child: Text(
+                    'Run a scenario to see the action lifecycle log',
+                    style: TextStyle(color: Colors.grey),
+                  ),
+                )
+                : ListView.builder(
+                  padding: const EdgeInsets.all(8),
+                  itemCount: log.length,
+                  itemBuilder: (_, index) => _LogEntryRow(entry: log[index]),
                 ),
-              )
-            : ListView.builder(
-                padding: const EdgeInsets.all(8),
-                itemCount: log.length,
-                itemBuilder: (_, index) => _LogEntryRow(entry: log[index]),
-              ),
       ),
     );
   }

--- a/example/lib/features/user_actions/presentation/user_actions_page_view_model.dart
+++ b/example/lib/features/user_actions/presentation/user_actions_page_view_model.dart
@@ -12,10 +12,7 @@ import 'auto_pop_page.dart';
 
 /// Immutable UI state for the User Actions demo page.
 class UserActionsPageUiState extends Equatable {
-  const UserActionsPageUiState({
-    required this.log,
-    required this.isRunning,
-  });
+  const UserActionsPageUiState({required this.log, required this.isRunning});
 
   final List<ActionLogEntry> log;
   final bool isRunning;
@@ -74,10 +71,7 @@ class _UserActionsPageViewModel extends Notifier<UserActionsPageUiState>
   @override
   UserActionsPageUiState build() {
     _service = ref.watch(userActionsDemoServiceProvider);
-    return const UserActionsPageUiState(
-      log: [],
-      isRunning: false,
-    );
+    return const UserActionsPageUiState(log: [], isRunning: false);
   }
 
   // ---------------------------------------------------------------------------
@@ -105,10 +99,7 @@ class _UserActionsPageViewModel extends Notifier<UserActionsPageUiState>
   void _noop() {}
 
   Future<void> _run(
-    Future<void> Function(
-      LogCallback log,
-      StatePollCallback onTick,
-    ) operation,
+    Future<void> Function(LogCallback log, StatePollCallback onTick) operation,
   ) async {
     state = state.copyWith(isRunning: true);
     try {
@@ -142,11 +133,12 @@ class _UserActionsPageViewModel extends Notifier<UserActionsPageUiState>
         navigator: navigator,
         route: MaterialPageRoute(
           settings: const RouteSettings(name: '/ua-fast-nav'),
-          builder: (_) => const AutoPopPage(
-            title: 'Fast View Transition',
-            description: 'Generating push/pop view signals.',
-            autoPopDelay: Duration(milliseconds: 40),
-          ),
+          builder:
+              (_) => const AutoPopPage(
+                title: 'Fast View Transition',
+                description: 'Generating push/pop view signals.',
+                autoPopDelay: Duration(milliseconds: 40),
+              ),
         ),
       );
     } finally {
@@ -174,11 +166,12 @@ class _UserActionsPageViewModel extends Notifier<UserActionsPageUiState>
         navigator: navigator,
         route: MaterialPageRoute(
           settings: const RouteSettings(name: '/ua-mixed-nav'),
-          builder: (_) => const AutoPopPage(
-            title: 'Mixed Timing Navigation',
-            description: 'Fast view change while HTTP is in-flight.',
-            autoPopDelay: Duration(milliseconds: 60),
-          ),
+          builder:
+              (_) => const AutoPopPage(
+                title: 'Mixed Timing Navigation',
+                description: 'Fast view change while HTTP is in-flight.',
+                autoPopDelay: Duration(milliseconds: 60),
+              ),
         ),
       );
     } finally {
@@ -197,11 +190,12 @@ class _UserActionsPageViewModel extends Notifier<UserActionsPageUiState>
         routeFactory: () {
           return MaterialPageRoute(
             settings: const RouteSettings(name: '/ua-concurrent-nav'),
-            builder: (_) => const AutoPopPage(
-              title: 'Concurrent Guard Navigation',
-              description: 'Small view pulse to mark activity.',
-              autoPopDelay: Duration(milliseconds: 40),
-            ),
+            builder:
+                (_) => const AutoPopPage(
+                  title: 'Concurrent Guard Navigation',
+                  description: 'Small view pulse to mark activity.',
+                  autoPopDelay: Duration(milliseconds: 40),
+                ),
           );
         },
       );
@@ -217,8 +211,8 @@ class _UserActionsPageViewModel extends Notifier<UserActionsPageUiState>
 
 final _viewModelProvider =
     NotifierProvider<_UserActionsPageViewModel, UserActionsPageUiState>(
-  _UserActionsPageViewModel.new,
-);
+      _UserActionsPageViewModel.new,
+    );
 
 /// Watch this to rebuild when UI state changes.
 final userActionsPageUiStateProvider = Provider<UserActionsPageUiState>((ref) {

--- a/example/lib/features/user_settings/test_users.dart
+++ b/example/lib/features/user_settings/test_users.dart
@@ -7,10 +7,7 @@ abstract class TestUsers {
     id: 'user-123',
     username: 'john.doe',
     email: 'john.doe@example.com',
-    attributes: {
-      'role': 'user',
-      'department': 'design',
-    },
+    attributes: {'role': 'user', 'department': 'design'},
   );
 
   /// Jane Smith - an engineer with admin role.
@@ -18,9 +15,6 @@ abstract class TestUsers {
     id: 'user-456',
     username: 'jane.smith',
     email: 'jane.smith@example.com',
-    attributes: {
-      'role': 'admin',
-      'department': 'engineering',
-    },
+    attributes: {'role': 'admin', 'department': 'engineering'},
   );
 }

--- a/example/lib/features/user_settings/user_settings_page.dart
+++ b/example/lib/features/user_settings/user_settings_page.dart
@@ -71,9 +71,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
     }
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('User Settings'),
-      ),
+      appBar: AppBar(title: const Text('User Settings')),
       body: SingleChildScrollView(
         padding: EdgeInsets.fromLTRB(
           16.0,
@@ -109,10 +107,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                 SizedBox(width: 8),
                 Text(
                   'Current Session User',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                 ),
               ],
             ),
@@ -121,9 +116,10 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
               _currentUserDisplay,
               style: TextStyle(
                 fontSize: 16,
-                color: _currentUserDisplay == 'Not set'
-                    ? Colors.grey
-                    : Colors.green,
+                color:
+                    _currentUserDisplay == 'Not set'
+                        ? Colors.grey
+                        : Colors.green,
                 fontWeight: FontWeight.w500,
               ),
             ),
@@ -143,8 +139,11 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                 ),
                 child: Row(
                   children: [
-                    Icon(Icons.warning_amber,
-                        size: 20, color: Colors.orange.shade700),
+                    Icon(
+                      Icons.warning_amber,
+                      size: 20,
+                      color: Colors.orange.shade700,
+                    ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
@@ -212,10 +211,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                 Expanded(
                   child: Text(
                     'FaroConfig Settings',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                    ),
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                   ),
                 ),
               ],
@@ -248,10 +244,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
             // Initial User Setting
             const Text(
               'Initial User',
-              style: TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w600,
-              ),
+              style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
             ),
             const SizedBox(height: 4),
             RadioGroup<InitialUserSetting>(
@@ -262,18 +255,19 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                 }
               },
               child: Column(
-                children: InitialUserSetting.values.map((setting) {
-                  return RadioListTile<InitialUserSetting>(
-                    title: Text(setting.displayName),
-                    subtitle: Text(
-                      setting.subtitle,
-                      style: const TextStyle(fontSize: 11),
-                    ),
-                    value: setting,
-                    contentPadding: EdgeInsets.zero,
-                    dense: true,
-                  );
-                }).toList(),
+                children:
+                    InitialUserSetting.values.map((setting) {
+                      return RadioListTile<InitialUserSetting>(
+                        title: Text(setting.displayName),
+                        subtitle: Text(
+                          setting.subtitle,
+                          style: const TextStyle(fontSize: 11),
+                        ),
+                        value: setting,
+                        contentPadding: EdgeInsets.zero,
+                        dense: true,
+                      );
+                    }).toList(),
               ),
             ),
             const SizedBox(height: 8),
@@ -285,8 +279,11 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
               ),
               child: Row(
                 children: [
-                  Icon(Icons.info_outline,
-                      size: 20, color: Colors.blue.shade700),
+                  Icon(
+                    Icons.info_outline,
+                    size: 20,
+                    color: Colors.blue.shade700,
+                  ),
                   const SizedBox(width: 8),
                   const Expanded(
                     child: Text(

--- a/example/lib/features/webview_handoff/domain/webview_handoff_service.dart
+++ b/example/lib/features/webview_handoff/domain/webview_handoff_service.dart
@@ -14,8 +14,9 @@ class WebViewHandoffService {
 
   static final WebViewHandoffService instance = WebViewHandoffService._();
 
-  static const _webViewDemoUrl =
-      String.fromEnvironment('FARO_WEBVIEW_DEMO_URL');
+  static const _webViewDemoUrl = String.fromEnvironment(
+    'FARO_WEBVIEW_DEMO_URL',
+  );
 
   /// Returns `true` when a demo URL has been configured.
   bool get isConfigured => _webViewDemoUrl.isNotEmpty;

--- a/example/lib/features/webview_handoff/presentation/webview_handoff_page.dart
+++ b/example/lib/features/webview_handoff/presentation/webview_handoff_page.dart
@@ -16,9 +16,7 @@ class WebViewHandoffPage extends ConsumerWidget {
     final actions = ref.watch(webViewHandoffPageActionsProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('WebView Tracing'),
-      ),
+      appBar: AppBar(title: const Text('WebView Tracing')),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
@@ -29,9 +27,10 @@ class WebViewHandoffPage extends ConsumerWidget {
           ],
           const SizedBox(height: 16),
           ElevatedButton.icon(
-            onPressed: uiState.isConfigured
-                ? () => _openWebView(context, actions)
-                : null,
+            onPressed:
+                uiState.isConfigured
+                    ? () => _openWebView(context, actions)
+                    : null,
             icon: const Icon(Icons.open_in_new),
             label: const Text('Open React demo in WebView'),
           ),
@@ -55,7 +54,8 @@ class WebViewHandoffPage extends ConsumerWidget {
 
     if (result != null) {
       final ok = result['ok'] == true;
-      final message = result['message'] as String? ??
+      final message =
+          result['message'] as String? ??
           (ok ? 'Login successful' : 'Login failed');
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -80,9 +80,9 @@ class _OverviewCard extends StatelessWidget {
           children: [
             Text(
               'Cross-boundary tracing',
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
             const Text(
@@ -116,9 +116,9 @@ class _MissingConfigCard extends StatelessWidget {
                 const SizedBox(width: 8),
                 Text(
                   'Setup required',
-                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
+                  style: Theme.of(
+                    context,
+                  ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
                 ),
               ],
             ),

--- a/example/lib/features/webview_handoff/presentation/webview_handoff_page_view_model.dart
+++ b/example/lib/features/webview_handoff/presentation/webview_handoff_page_view_model.dart
@@ -4,9 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// UI state for the WebView tracing landing page.
 class WebViewHandoffPageUiState extends Equatable {
-  const WebViewHandoffPageUiState({
-    required this.isConfigured,
-  });
+  const WebViewHandoffPageUiState({required this.isConfigured});
 
   final bool isConfigured;
 
@@ -26,9 +24,7 @@ class _WebViewHandoffPageViewModel extends Notifier<WebViewHandoffPageUiState>
   @override
   WebViewHandoffPageUiState build() {
     _service = ref.watch(webViewHandoffServiceProvider);
-    return WebViewHandoffPageUiState(
-      isConfigured: _service.isConfigured,
-    );
+    return WebViewHandoffPageUiState(isConfigured: _service.isConfigured);
   }
 
   @override
@@ -37,15 +33,17 @@ class _WebViewHandoffPageViewModel extends Notifier<WebViewHandoffPageUiState>
 
 final _webViewHandoffPageViewModelProvider =
     NotifierProvider<_WebViewHandoffPageViewModel, WebViewHandoffPageUiState>(
-  _WebViewHandoffPageViewModel.new,
-);
+      _WebViewHandoffPageViewModel.new,
+    );
 
-final webViewHandoffPageUiStateProvider =
-    Provider<WebViewHandoffPageUiState>((ref) {
+final webViewHandoffPageUiStateProvider = Provider<WebViewHandoffPageUiState>((
+  ref,
+) {
   return ref.watch(_webViewHandoffPageViewModelProvider);
 });
 
-final webViewHandoffPageActionsProvider =
-    Provider<WebViewHandoffPageActions>((ref) {
+final webViewHandoffPageActionsProvider = Provider<WebViewHandoffPageActions>((
+  ref,
+) {
   return ref.read(_webViewHandoffPageViewModelProvider.notifier);
 });

--- a/example/lib/features/webview_handoff/presentation/webview_handoff_webview_page.dart
+++ b/example/lib/features/webview_handoff/presentation/webview_handoff_webview_page.dart
@@ -17,10 +17,7 @@ import 'package:webview_flutter/webview_flutter.dart';
 ///   `session.linked` event with `session.child_*` attributes.
 /// - `login_result` — login result data; auto-pops the page.
 class WebViewHandoffWebViewPage extends StatefulWidget {
-  const WebViewHandoffWebViewPage({
-    required this.url,
-    super.key,
-  });
+  const WebViewHandoffWebViewPage({required this.url, super.key});
 
   final Uri url;
 
@@ -44,38 +41,39 @@ class _WebViewHandoffWebViewPageState extends State<WebViewHandoffWebViewPage> {
     _bridge = FaroWebViewBridge();
     final instrumentedUrl = _bridge.instrumentedUrl(widget.url);
 
-    _controller = WebViewController()
-      ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      // The React app calls window.HandoffBridge.postMessage(json) to
-      // send login results back to Flutter.
-      ..addJavaScriptChannel(
-        'HandoffBridge',
-        onMessageReceived: _handleBridgeMessage,
-      )
-      ..setNavigationDelegate(
-        NavigationDelegate(
-          onPageStarted: (url) {
-            if (!mounted) return;
-            setState(() {
-              _status = 'Loading\u2026';
-              _hasLoadError = false;
-            });
-          },
-          onPageFinished: (url) {
-            if (!mounted) return;
-            setState(() => _status = 'Loaded');
-          },
-          onWebResourceError: (error) {
-            if (!mounted) return;
-            if (error.isForMainFrame != true) return;
-            setState(() {
-              _status = 'Failed to load';
-              _hasLoadError = true;
-            });
-          },
-        ),
-      )
-      ..loadRequest(instrumentedUrl);
+    _controller =
+        WebViewController()
+          ..setJavaScriptMode(JavaScriptMode.unrestricted)
+          // The React app calls window.HandoffBridge.postMessage(json) to
+          // send login results back to Flutter.
+          ..addJavaScriptChannel(
+            'HandoffBridge',
+            onMessageReceived: _handleBridgeMessage,
+          )
+          ..setNavigationDelegate(
+            NavigationDelegate(
+              onPageStarted: (url) {
+                if (!mounted) return;
+                setState(() {
+                  _status = 'Loading\u2026';
+                  _hasLoadError = false;
+                });
+              },
+              onPageFinished: (url) {
+                if (!mounted) return;
+                setState(() => _status = 'Loaded');
+              },
+              onWebResourceError: (error) {
+                if (!mounted) return;
+                if (error.isForMainFrame != true) return;
+                setState(() {
+                  _status = 'Failed to load';
+                  _hasLoadError = true;
+                });
+              },
+            ),
+          )
+          ..loadRequest(instrumentedUrl);
   }
 
   @override
@@ -107,9 +105,7 @@ class _WebViewHandoffWebViewPageState extends State<WebViewHandoffWebViewPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('WebView Login Demo'),
-      ),
+      appBar: AppBar(title: const Text('WebView Login Demo')),
       body: Column(
         children: [
           Material(
@@ -121,9 +117,10 @@ class _WebViewHandoffWebViewPageState extends State<WebViewHandoffWebViewPage> {
             ),
           ),
           Expanded(
-            child: _hasLoadError
-                ? const _LoadErrorHint()
-                : WebViewWidget(controller: _controller),
+            child:
+                _hasLoadError
+                    ? const _LoadErrorHint()
+                    : WebViewWidget(controller: _controller),
           ),
         ],
       ),
@@ -142,11 +139,7 @@ class _LoadErrorHint extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              Icons.cloud_off,
-              size: 48,
-              color: Colors.grey.shade400,
-            ),
+            Icon(Icons.cloud_off, size: 48, color: Colors.grey.shade400),
             const SizedBox(height: 16),
             Text(
               'Could not load the web app',
@@ -160,9 +153,9 @@ class _LoadErrorHint extends StatelessWidget {
               'And verify that FARO_WEBVIEW_DEMO_URL in '
               'api-config.json points to the correct address\n'
               '(e.g. http://10.0.2.2:5173 for Android emulator).',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Colors.grey.shade600,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: Colors.grey.shade600),
               textAlign: TextAlign.center,
             ),
           ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,9 +32,7 @@ void main() async {
   // Create ProviderContainer with SharedPreferences override
   // This is Riverpod's root and allows us to access providers before runApp()
   final container = ProviderContainer(
-    overrides: [
-      sharedPreferencesProvider.overrideWithValue(sharedPreferences),
-    ],
+    overrides: [sharedPreferencesProvider.overrideWithValue(sharedPreferences)],
   );
 
   // Load user settings service (still using singleton pattern)
@@ -42,8 +40,9 @@ void main() async {
   await userSettingsService.init();
 
   // Get sampling settings from Riverpod
-  final samplingSettingsService =
-      container.read(samplingSettingsServiceProvider);
+  final samplingSettingsService = container.read(
+    samplingSettingsServiceProvider,
+  );
 
   const faroCollectorUrl = String.fromEnvironment('FARO_COLLECTOR_URL');
   final faroApiKey = faroCollectorUrl.split('/').last;
@@ -59,13 +58,14 @@ void main() async {
     if (qaConfig.hasRunId) 'qa_run_id': qaConfig.runId!,
   };
 
-  final initialUser = qaConfig.hasInitialUser
-      ? qaConfig.initialUser
-      : userSettingsService.initialUser;
+  final initialUser =
+      qaConfig.hasInitialUser
+          ? qaConfig.initialUser
+          : userSettingsService.initialUser;
 
-  Faro().transports.add(OfflineTransport(
-        maxCacheDuration: const Duration(days: 3),
-      ));
+  Faro().transports.add(
+    OfflineTransport(maxCacheDuration: const Duration(days: 3)),
+  );
 
   await Faro().runApp(
     optionsConfiguration: FaroConfig(
@@ -133,9 +133,7 @@ class _MyAppState extends State<MyApp> {
         '/webview-handoff': (context) => const WebViewHandoffPage(),
       },
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Faro Test App'),
-        ),
+        appBar: AppBar(title: const Text('Faro Test App')),
         body: const HomePage(),
       ),
     );

--- a/example/lib/qa_config.dart
+++ b/example/lib/qa_config.dart
@@ -38,8 +38,9 @@ class QaConfig {
   static QaConfig fromEnvironment() {
     return parse(
       qaRunId: const String.fromEnvironment('FARO_QA_RUN_ID'),
-      qaInitialUserJson:
-          const String.fromEnvironment('FARO_QA_INITIAL_USER_JSON'),
+      qaInitialUserJson: const String.fromEnvironment(
+        'FARO_QA_INITIAL_USER_JSON',
+      ),
     );
   }
 
@@ -48,10 +49,7 @@ class QaConfig {
   /// Empty strings are treated as "not provided".
   /// Invalid JSON in [qaInitialUserJson] is silently ignored (returns
   /// a config with no initial user).
-  static QaConfig parse({
-    String qaRunId = '',
-    String qaInitialUserJson = '',
-  }) {
+  static QaConfig parse({String qaRunId = '', String qaInitialUserJson = ''}) {
     final runId = qaRunId.isNotEmpty ? qaRunId : null;
     final user = _parseUser(qaInitialUserJson);
     return QaConfig._(runId: runId, initialUser: user);
@@ -66,9 +64,10 @@ class QaConfig {
 
       return FaroUser(
         id: decoded['id'] is String ? decoded['id'] as String : null,
-        username: decoded['username'] is String
-            ? decoded['username'] as String
-            : null,
+        username:
+            decoded['username'] is String
+                ? decoded['username'] as String
+                : null,
         email: decoded['email'] is String ? decoded['email'] as String : null,
         attributes: _parseAttributes(decoded['attributes']),
       );

--- a/example/lib/shared/models/demo_log_entry.dart
+++ b/example/lib/shared/models/demo_log_entry.dart
@@ -1,14 +1,7 @@
 import 'package:equatable/equatable.dart';
 
 /// Visual style used when rendering a demo log entry.
-enum DemoLogTone {
-  neutral,
-  info,
-  success,
-  warning,
-  error,
-  highlight,
-}
+enum DemoLogTone { neutral, info, success, warning, error, highlight }
 
 /// A timestamped entry shown in example feature log panels.
 class DemoLogEntry extends Equatable {

--- a/example/lib/shared/presentation/widgets/demo_log_section.dart
+++ b/example/lib/shared/presentation/widgets/demo_log_section.dart
@@ -17,21 +17,22 @@ class DemoLogSection extends StatelessWidget {
     return Expanded(
       child: Container(
         color: Colors.grey.shade100,
-        child: entries.isEmpty
-            ? Center(
-                child: Text(
-                  emptyMessage,
-                  style: const TextStyle(color: Colors.grey),
-                  textAlign: TextAlign.center,
+        child:
+            entries.isEmpty
+                ? Center(
+                  child: Text(
+                    emptyMessage,
+                    style: const TextStyle(color: Colors.grey),
+                    textAlign: TextAlign.center,
+                  ),
+                )
+                : ListView.builder(
+                  padding: const EdgeInsets.all(8),
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) {
+                    return _DemoLogEntryRow(entry: entries[index]);
+                  },
                 ),
-              )
-            : ListView.builder(
-                padding: const EdgeInsets.all(8),
-                itemCount: entries.length,
-                itemBuilder: (context, index) {
-                  return _DemoLogEntryRow(entry: entries[index]);
-                },
-              ),
       ),
     );
   }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,8 @@ description: Demonstrates how to use the faro plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/example/test/qa_config_test.dart
+++ b/example/test/qa_config_test.dart
@@ -15,10 +15,7 @@ void main() {
     });
 
     test('returns empty config when QA vars are empty strings', () {
-      final config = QaConfig.parse(
-        qaRunId: '',
-        qaInitialUserJson: '',
-      );
+      final config = QaConfig.parse(qaRunId: '', qaInitialUserJson: '');
 
       expect(config.hasRunId, isFalse);
       expect(config.hasInitialUser, isFalse);
@@ -113,27 +110,21 @@ void main() {
       });
 
       test('returns null user for invalid JSON', () {
-        final config = QaConfig.parse(
-          qaInitialUserJson: 'not valid json {{{',
-        );
+        final config = QaConfig.parse(qaInitialUserJson: 'not valid json {{{');
 
         expect(config.hasInitialUser, isFalse);
         expect(config.initialUser, isNull);
       });
 
       test('returns null user for JSON array instead of object', () {
-        final config = QaConfig.parse(
-          qaInitialUserJson: '[1, 2, 3]',
-        );
+        final config = QaConfig.parse(qaInitialUserJson: '[1, 2, 3]');
 
         expect(config.hasInitialUser, isFalse);
         expect(config.initialUser, isNull);
       });
 
       test('returns null user for JSON string literal', () {
-        final config = QaConfig.parse(
-          qaInitialUserJson: '"just a string"',
-        );
+        final config = QaConfig.parse(qaInitialUserJson: '"just a string"');
 
         expect(config.hasInitialUser, isFalse);
         expect(config.initialUser, isNull);
@@ -158,10 +149,7 @@ void main() {
 
     group('combined', () {
       test('both run ID and user can be provided together', () {
-        final userJson = jsonEncode({
-          'id': 'qa-user',
-          'username': 'qa-bot',
-        });
+        final userJson = jsonEncode({'id': 'qa-user', 'username': 'qa-bot'});
 
         final config = QaConfig.parse(
           qaRunId: 'run-99',

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -10,13 +10,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('features are grouped into dedicated destinations',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: MyApp(),
-      ),
-    );
+  testWidgets('features are grouped into dedicated destinations', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
 
     expect(find.text('Change Route'), findsOneWidget);
 
@@ -27,16 +24,10 @@ void main() {
     expect(find.text('Explore Telemetry'), findsOneWidget);
     expect(find.text('Custom Telemetry'), findsOneWidget);
     expect(find.text('Network Requests'), findsOneWidget);
-    await tester.scrollUntilVisible(
-      find.text('WebView Tracing'),
-      200,
-    );
+    await tester.scrollUntilVisible(find.text('WebView Tracing'), 200);
     await tester.pumpAndSettle();
     expect(find.text('WebView Tracing'), findsOneWidget);
-    await tester.scrollUntilVisible(
-      find.text('App Diagnostics'),
-      300,
-    );
+    await tester.scrollUntilVisible(find.text('App Diagnostics'), 300);
     await tester.pumpAndSettle();
     expect(find.text('Stress Runtime Behavior'), findsOneWidget);
     expect(find.text('App Diagnostics'), findsOneWidget);
@@ -44,13 +35,10 @@ void main() {
     expect(find.text('HTTP POST Request - success'), findsNothing);
   });
 
-  testWidgets('custom telemetry page is reachable from the catalog',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: MyApp(),
-      ),
-    );
+  testWidgets('custom telemetry page is reachable from the catalog', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
 
     await tester.tap(find.text('Change Route'));
     await tester.pumpAndSettle();
@@ -64,21 +52,15 @@ void main() {
     expect(find.textContaining('Data Collection'), findsOneWidget);
   });
 
-  testWidgets('webview tracing page is reachable from the catalog',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: MyApp(),
-      ),
-    );
+  testWidgets('webview tracing page is reachable from the catalog', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
 
     await tester.tap(find.text('Change Route'));
     await tester.pumpAndSettle();
 
-    await tester.scrollUntilVisible(
-      find.text('WebView Tracing'),
-      200,
-    );
+    await tester.scrollUntilVisible(find.text('WebView Tracing'), 200);
     await tester.pumpAndSettle();
     await tester.tap(find.text('WebView Tracing'));
     await tester.pumpAndSettle();

--- a/lib/src/configurations/batch_config.dart
+++ b/lib/src/configurations/batch_config.dart
@@ -1,8 +1,9 @@
 class BatchConfig {
-  BatchConfig(
-      {this.sendTimeout = const Duration(milliseconds: 300),
-      this.payloadItemLimit = 30,
-      this.enabled = true});
+  BatchConfig({
+    this.sendTimeout = const Duration(milliseconds: 300),
+    this.payloadItemLimit = 30,
+    this.enabled = true,
+  });
   Duration sendTimeout;
   int payloadItemLimit;
   bool enabled;

--- a/lib/src/configurations/faro_config.dart
+++ b/lib/src/configurations/faro_config.dart
@@ -28,11 +28,11 @@ class FaroConfig {
     this.initialUser,
     this.persistUser = true,
     this.sampling,
-  })  : assert(appName.isNotEmpty, 'appName cannot be empty'),
-        assert(appEnv.isNotEmpty, 'appEnv cannot be empty'),
-        assert(apiKey.isNotEmpty, 'apiKey cannot be empty'),
-        assert(maxBufferLimit > 0, 'maxBufferLimit must be greater than 0'),
-        batchConfig = batchConfig ?? BatchConfig();
+  }) : assert(appName.isNotEmpty, 'appName cannot be empty'),
+       assert(appEnv.isNotEmpty, 'appEnv cannot be empty'),
+       assert(apiKey.isNotEmpty, 'apiKey cannot be empty'),
+       assert(maxBufferLimit > 0, 'maxBufferLimit must be greater than 0'),
+       batchConfig = batchConfig ?? BatchConfig();
   final String appName;
   final String appEnv;
   final String apiKey;

--- a/lib/src/data_collection_policy.dart
+++ b/lib/src/data_collection_policy.dart
@@ -2,9 +2,8 @@ import 'dart:developer';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class DataCollectionPolicy {
-  DataCollectionPolicy({
-    required SharedPreferences sharedPreferences,
-  }) : _sharedPreferences = sharedPreferences {
+  DataCollectionPolicy({required SharedPreferences sharedPreferences})
+    : _sharedPreferences = sharedPreferences {
     _initialize();
   }
 

--- a/lib/src/device_info/device_id_provider.dart
+++ b/lib/src/device_info/device_id_provider.dart
@@ -6,8 +6,8 @@ class DeviceIdProvider {
   DeviceIdProvider({
     required SharedPreferences sharedPreferences,
     required UuidProvider uuidProvider,
-  })  : _sharedPreferences = sharedPreferences,
-        _uuidProvider = uuidProvider;
+  }) : _sharedPreferences = sharedPreferences,
+       _uuidProvider = uuidProvider;
 
   final String _deviceIdPrefsKey = 'device_id';
 

--- a/lib/src/device_info/device_info_provider.dart
+++ b/lib/src/device_info/device_info_provider.dart
@@ -6,8 +6,8 @@ class DeviceInfoProvider {
   DeviceInfoProvider({
     required DeviceInfoPlugin deviceInfoPlugin,
     required PlatformInfoProvider platformInfoProvider,
-  })  : _deviceInfoPlugin = deviceInfoPlugin,
-        _platformInfoProvider = platformInfoProvider;
+  }) : _deviceInfoPlugin = deviceInfoPlugin,
+       _platformInfoProvider = platformInfoProvider;
 
   final DeviceInfoPlugin _deviceInfoPlugin;
   final PlatformInfoProvider _platformInfoProvider;

--- a/lib/src/device_info/session_attributes_provider.dart
+++ b/lib/src/device_info/session_attributes_provider.dart
@@ -5,8 +5,8 @@ class SessionAttributesProvider {
   SessionAttributesProvider({
     required DeviceIdProvider deviceIdProvider,
     required DeviceInfoProvider deviceInfoProvider,
-  })  : _deviceIdProvider = deviceIdProvider,
-        _deviceInfoProvider = deviceInfoProvider;
+  }) : _deviceIdProvider = deviceIdProvider,
+       _deviceInfoProvider = deviceInfoProvider;
 
   final DeviceIdProvider _deviceIdProvider;
   final DeviceInfoProvider _deviceInfoProvider;

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -184,9 +184,10 @@ class Faro {
     );
 
     // Make sampling decision (once per session)
-    _isSampled = SessionSamplingProviderFactory()
-        .create(sampling: optionsConfiguration.sampling, meta: meta)
-        .isSampled;
+    _isSampled =
+        SessionSamplingProviderFactory()
+            .create(sampling: optionsConfiguration.sampling, meta: meta)
+            .isSampled;
 
     if (!_isSampled) {
       log('Faro: Session not sampled. Telemetry will be dropped.');
@@ -203,14 +204,14 @@ class Faro {
 
     if (config?.transports == null) {
       Faro()._transports.add(
-            FaroTransport(
-              collectorUrl: optionsConfiguration.collectorUrl ?? '',
-              apiKey: optionsConfiguration.apiKey,
-              maxBufferLimit: config?.maxBufferLimit,
-              sessionId: meta.session?.id,
-              headers: optionsConfiguration.collectorHeaders,
-            ),
-          );
+        FaroTransport(
+          collectorUrl: optionsConfiguration.collectorUrl ?? '',
+          apiKey: optionsConfiguration.apiKey,
+          maxBufferLimit: config?.maxBufferLimit,
+          sessionId: meta.session?.id,
+          headers: optionsConfiguration.collectorHeaders,
+        ),
+      );
     } else {
       Faro()._transports.addAll(config?.transports ?? []);
     }
@@ -336,9 +337,10 @@ class Faro {
     'To clear, use setUser(FaroUser.cleared()).',
   )
   void setUserMeta({String? userId, String? userName, String? userEmail}) {
-    final user = (userId == null && userName == null && userEmail == null)
-        ? const FaroUser.cleared()
-        : FaroUser(id: userId, username: userName, email: userEmail);
+    final user =
+        (userId == null && userName == null && userEmail == null)
+            ? const FaroUser.cleared()
+            : FaroUser(id: userId, username: userName, email: userEmail);
     setUser(user);
   }
 

--- a/lib/src/faro_asset_bundle.dart
+++ b/lib/src/faro_asset_bundle.dart
@@ -9,16 +9,15 @@ import 'package:faro/src/util/short_id.dart';
 import 'package:flutter/services.dart';
 
 /// Provides the platform's default [AssetBundle] ([rootBundle]).
-final rootAssetBundleProvider = Provider<AssetBundle>(
-  (pod) => rootBundle,
-);
+final rootAssetBundleProvider = Provider<AssetBundle>((pod) => rootBundle);
 
 /// Provides a [FaroAssetBundle] wired with its required dependencies.
 final faroAssetBundleProvider = Provider<AssetBundle>((pod) {
   return FaroAssetBundle(
     bundle: pod.resolve(rootAssetBundleProvider),
-    lifecycleSignalChannel:
-        pod.resolve(userActionLifecycleSignalChannelProvider),
+    lifecycleSignalChannel: pod.resolve(
+      userActionLifecycleSignalChannelProvider,
+    ),
   );
 });
 
@@ -33,8 +32,8 @@ class FaroAssetBundle extends AssetBundle {
   FaroAssetBundle({
     required AssetBundle bundle,
     required UserActionLifecycleSignalChannel lifecycleSignalChannel,
-  })  : _bundle = bundle,
-        _lifecycleSignalChannel = lifecycleSignalChannel;
+  }) : _bundle = bundle,
+       _lifecycleSignalChannel = lifecycleSignalChannel;
 
   final AssetBundle _bundle;
   final UserActionLifecycleSignalChannel _lifecycleSignalChannel;
@@ -55,27 +54,25 @@ class FaroAssetBundle extends AssetBundle {
   Future<T> loadStructuredData<T>(
     String key,
     Future<T> Function(String value) parser,
-  ) =>
-      _trackParsedLoad(
-        key,
-        (reportSize) => _bundle.loadStructuredData<T>(key, (raw) {
-          reportSize(raw.length);
-          return parser(raw);
-        }),
-      );
+  ) => _trackParsedLoad(
+    key,
+    (reportSize) => _bundle.loadStructuredData<T>(key, (raw) {
+      reportSize(raw.length);
+      return parser(raw);
+    }),
+  );
 
   @override
   Future<T> loadStructuredBinaryData<T>(
     String key,
     FutureOr<T> Function(ByteData data) parser,
-  ) =>
-      _trackParsedLoad(
-        key,
-        (reportSize) => _bundle.loadStructuredBinaryData<T>(key, (raw) {
-          reportSize(raw.lengthInBytes);
-          return parser(raw);
-        }),
-      );
+  ) => _trackParsedLoad(
+    key,
+    (reportSize) => _bundle.loadStructuredBinaryData<T>(key, (raw) {
+      reportSize(raw.lengthInBytes);
+      return parser(raw);
+    }),
+  );
 
   Future<T> _trackParsedLoad<T>(
     String key,
@@ -94,11 +91,10 @@ class FaroAssetBundle extends AssetBundle {
       final afterLoad = DateTime.now().millisecondsSinceEpoch;
       final duration = afterLoad - beforeLoad;
 
-      Faro().pushEvent('Asset-load', attributes: {
-        'name': key,
-        'size': '$rawSize',
-        'duration': '$duration',
-      });
+      Faro().pushEvent(
+        'Asset-load',
+        attributes: {'name': key, 'size': '$rawSize', 'duration': '$duration'},
+      );
       return data;
     } finally {
       _lifecycleSignalChannel.emitPendingEnd(
@@ -108,10 +104,7 @@ class FaroAssetBundle extends AssetBundle {
     }
   }
 
-  Future<T> _trackAssetLoad<T>(
-    String key,
-    Future<T> Function() loader,
-  ) async {
+  Future<T> _trackAssetLoad<T>(String key, Future<T> Function() loader) async {
     final operationId = generateShortId();
     _lifecycleSignalChannel.emitPendingStart(
       source: UserActionConstants.resourceAssetSignalSource,
@@ -124,11 +117,10 @@ class FaroAssetBundle extends AssetBundle {
       final afterLoad = DateTime.now().millisecondsSinceEpoch;
       final duration = afterLoad - beforeLoad;
       final dataSize = _getDataLength(data);
-      Faro().pushEvent('Asset-load', attributes: {
-        'name': key,
-        'size': '$dataSize',
-        'duration': '$duration',
-      });
+      Faro().pushEvent(
+        'Asset-load',
+        attributes: {'name': key, 'size': '$dataSize', 'duration': '$duration'},
+      );
       return data;
     } finally {
       _lifecycleSignalChannel.emitPendingEnd(

--- a/lib/src/faro_navigation_observer.dart
+++ b/lib/src/faro_navigation_observer.dart
@@ -6,8 +6,9 @@ import 'package:flutter/widgets.dart';
 class FaroNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
   factory FaroNavigationObserver() {
     return FaroNavigationObserver._(
-      lifecycleSignalChannel:
-          pod.resolve(userActionLifecycleSignalChannelProvider),
+      lifecycleSignalChannel: pod.resolve(
+        userActionLifecycleSignalChannelProvider,
+      ),
     );
   }
 
@@ -21,10 +22,13 @@ class FaroNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
     Faro().setViewMeta(name: previousRoute?.settings.name);
-    Faro().pushEvent('view_changed', attributes: {
-      'fromView': route.settings.name,
-      'toView': previousRoute?.settings.name,
-    });
+    Faro().pushEvent(
+      'view_changed',
+      attributes: {
+        'fromView': route.settings.name,
+        'toView': previousRoute?.settings.name,
+      },
+    );
     _lifecycleSignalChannel.emitActivity(source: 'navigation.pop');
   }
 
@@ -32,10 +36,13 @@ class FaroNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
     Faro().setViewMeta(name: route.settings.name);
-    Faro().pushEvent('view_changed', attributes: {
-      'fromView': previousRoute?.settings.name,
-      'toView': route.settings.name,
-    });
+    Faro().pushEvent(
+      'view_changed',
+      attributes: {
+        'fromView': previousRoute?.settings.name,
+        'toView': route.settings.name,
+      },
+    );
     _lifecycleSignalChannel.emitActivity(source: 'navigation.push');
   }
 
@@ -43,10 +50,13 @@ class FaroNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
     Faro().setViewMeta(name: newRoute?.settings.name);
-    Faro().pushEvent('view_changed', attributes: {
-      'fromView': oldRoute?.settings.name,
-      'toView': newRoute?.settings.name,
-    });
+    Faro().pushEvent(
+      'view_changed',
+      attributes: {
+        'fromView': oldRoute?.settings.name,
+        'toView': newRoute?.settings.name,
+      },
+    );
     _lifecycleSignalChannel.emitActivity(source: 'navigation.replace');
   }
 }

--- a/lib/src/faro_user_interaction_widget.dart
+++ b/lib/src/faro_user_interaction_widget.dart
@@ -7,8 +7,12 @@ Element? _clickTrackerElement;
 const _tapAreaSizeSquared = 20 * 20.0;
 
 class UserInteractionProperties {
-  UserInteractionProperties(
-      {this.element, this.elementType, this.description, this.eventType});
+  UserInteractionProperties({
+    this.element,
+    this.elementType,
+    this.description,
+    this.eventType,
+  });
   Element? element;
   String? elementType;
   String? description;
@@ -53,8 +57,9 @@ class _FaroUserInteractionWidgetState extends State<FaroUserInteractionWidget> {
   void _onPointerUp(PointerUpEvent event) {
     if (_lastPointerDownLocation != null && event.pointer == _lastPointerId) {
       final distanceOffset = Offset(
-          _lastPointerDownLocation!.dx - event.localPosition.dx,
-          _lastPointerDownLocation!.dy - event.localPosition.dy);
+        _lastPointerDownLocation!.dx - event.localPosition.dx,
+        _lastPointerDownLocation!.dy - event.localPosition.dy,
+      );
 
       final distanceSquared = distanceOffset.distanceSquared;
       if (distanceSquared < _tapAreaSizeSquared) {
@@ -66,12 +71,15 @@ class _FaroUserInteractionWidgetState extends State<FaroUserInteractionWidget> {
   void _onTapped(Offset localPosition, String tap) {
     final tappedElement = _findElementTapped(localPosition);
     if (tappedElement != null) {
-      Faro().pushEvent('user_interaction', attributes: {
-        'element_type': tappedElement.elementType,
-        'element_description': tappedElement.description,
-        'event_type': tappedElement.eventType,
-        'event': 'onClick'
-      });
+      Faro().pushEvent(
+        'user_interaction',
+        attributes: {
+          'element_type': tappedElement.elementType,
+          'element_description': tappedElement.description,
+          'event_type': tappedElement.eventType,
+          'event': 'onClick',
+        },
+      );
     }
   }
 
@@ -102,8 +110,10 @@ class _FaroUserInteractionWidgetState extends State<FaroUserInteractionWidget> {
         hitFound = renderObject.hitTest(hitTest, position: position);
       }
       final transform = renderObject.getTransformTo(rootElement.renderObject);
-      final paintBounds =
-          MatrixUtils.transformRect(transform, renderObject.paintBounds);
+      final paintBounds = MatrixUtils.transformRect(
+        transform,
+        renderObject.paintBounds,
+      );
 
       if (!paintBounds.contains(position)) {
         return;
@@ -160,58 +170,65 @@ class _FaroUserInteractionWidgetState extends State<FaroUserInteractionWidget> {
     if (widget is ButtonStyleButton) {
       if (widget.enabled) {
         return UserInteractionProperties(
-            element: element,
-            elementType: 'ButtonStyleButton',
-            description: _getElementDescription(element),
-            eventType: 'onClick');
+          element: element,
+          elementType: 'ButtonStyleButton',
+          description: _getElementDescription(element),
+          eventType: 'onClick',
+        );
       }
     } else if (widget is MaterialButton) {
       if (widget.enabled) {
         return UserInteractionProperties(
-            element: element,
-            elementType: 'MaterialButton',
-            description: _getElementDescription(element),
-            eventType: 'onClick');
+          element: element,
+          elementType: 'MaterialButton',
+          description: _getElementDescription(element),
+          eventType: 'onClick',
+        );
       }
     } else if (widget is CupertinoButton) {
       if (widget.enabled) {
         return UserInteractionProperties(
-            element: element,
-            elementType: 'CupertinoButton',
-            description: _getElementDescription(element),
-            eventType: 'onPressed');
+          element: element,
+          elementType: 'CupertinoButton',
+          description: _getElementDescription(element),
+          eventType: 'onPressed',
+        );
       }
     } else if (widget is PopupMenuButton) {
       if (widget.enabled) {
         return UserInteractionProperties(
-            element: element,
-            elementType: 'PopupMenuButton',
-            description: _getElementDescription(element),
-            eventType: 'onTap');
+          element: element,
+          elementType: 'PopupMenuButton',
+          description: _getElementDescription(element),
+          eventType: 'onTap',
+        );
       }
     } else if (widget is PopupMenuItem) {
       if (widget.enabled) {
         return UserInteractionProperties(
-            element: element,
-            elementType: 'PopupMenuItem',
-            description: _getElementDescription(element),
-            eventType: 'onTap');
+          element: element,
+          elementType: 'PopupMenuItem',
+          description: _getElementDescription(element),
+          eventType: 'onTap',
+        );
       }
     } else if (widget is InkWell) {
       if (widget.onTap != null) {
         return UserInteractionProperties(
-            element: element,
-            elementType: 'InkWell',
-            description: _getElementDescription(element),
-            eventType: 'onTap');
+          element: element,
+          elementType: 'InkWell',
+          description: _getElementDescription(element),
+          eventType: 'onTap',
+        );
       }
     } else if (widget is IconButton) {
       if (widget.onPressed != null) {
         return UserInteractionProperties(
-            element: element,
-            elementType: 'IconButton',
-            description: _getElementDescription(element),
-            eventType: 'onPressed');
+          element: element,
+          elementType: 'IconButton',
+          description: _getElementDescription(element),
+          eventType: 'onPressed',
+        );
       }
     }
     return null;

--- a/lib/src/faro_widgets_binding_observer.dart
+++ b/lib/src/faro_widgets_binding_observer.dart
@@ -15,10 +15,13 @@ class FaroWidgetsBindingObserver extends WidgetsBindingObserver {
       NativeIntegration.instance.setWarmStart();
     }
 
-    Faro().pushEvent('app_lifecycle_changed', attributes: {
-      'fromState': _previousState?.name ?? '',
-      'toState': state.name,
-    });
+    Faro().pushEvent(
+      'app_lifecycle_changed',
+      attributes: {
+        'fromState': _previousState?.name ?? '',
+        'toState': state.name,
+      },
+    );
     _previousState = state;
   }
 }

--- a/lib/src/integrations/flutter_error_integration.dart
+++ b/lib/src/integrations/flutter_error_integration.dart
@@ -11,9 +11,10 @@ class FlutterErrorIntegration {
     _onErrorIntegration = (details) async {
       if (details.stack != null) {
         Faro().pushError(
-            type: 'flutter_error',
-            value: details.exceptionAsString(),
-            stacktrace: details.stack);
+          type: 'flutter_error',
+          value: details.exceptionAsString(),
+          stacktrace: details.stack,
+        );
       }
 
       if (_defaultOnError != null) {

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -15,7 +15,8 @@ class FaroHttpOverrides extends HttpOverrides {
 
   @override
   HttpClient createHttpClient(SecurityContext? context) {
-    final innerClient = existingOverrides?.createHttpClient(context) ??
+    final innerClient =
+        existingOverrides?.createHttpClient(context) ??
         super.createHttpClient(context);
     return FaroHttpTrackingClient(
       innerClient,
@@ -88,15 +89,9 @@ class FaroHttpTrackingClient implements HttpClient {
     try {
       // ignore: close_sinks
       final request = await innerClient.openUrl(method, url);
-      return FaroTrackingHttpClientRequest(
-        request,
-        httpSpan: httpSpan,
-      );
+      return FaroTrackingHttpClientRequest(request, httpSpan: httpSpan);
     } catch (error, stackTrace) {
-      httpSpan.setStatus(
-        SpanStatusCode.error,
-        message: error.toString(),
-      );
+      httpSpan.setStatus(SpanStatusCode.error, message: error.toString());
       httpSpan.recordException(error, stackTrace: stackTrace);
       httpSpan.end();
       rethrow;
@@ -105,10 +100,13 @@ class FaroHttpTrackingClient implements HttpClient {
 
   @override
   set connectionFactory(
-          Future<ConnectionTask<Socket>> Function(
-                  Uri url, String? proxyHost, int? proxyPort)?
-              f) =>
-      innerClient.connectionFactory = f;
+    Future<ConnectionTask<Socket>> Function(
+      Uri url,
+      String? proxyHost,
+      int? proxyPort,
+    )?
+    f,
+  ) => innerClient.connectionFactory = f;
 
   @override
   set keyLog(void Function(String line)? callback) =>
@@ -143,33 +141,38 @@ class FaroHttpTrackingClient implements HttpClient {
 
   @override
   void addCredentials(
-      Uri url, String realm, HttpClientCredentials credentials) {
+    Uri url,
+    String realm,
+    HttpClientCredentials credentials,
+  ) {
     innerClient.addCredentials(url, realm, credentials);
   }
 
   @override
   void addProxyCredentials(
-      String host, int port, String realm, HttpClientCredentials credentials) {
+    String host,
+    int port,
+    String realm,
+    HttpClientCredentials credentials,
+  ) {
     innerClient.addProxyCredentials(host, port, realm, credentials);
   }
 
   @override
   set authenticate(
-          Future<bool> Function(Uri url, String scheme, String? realm)? f) =>
-      innerClient.authenticate = f;
+    Future<bool> Function(Uri url, String scheme, String? realm)? f,
+  ) => innerClient.authenticate = f;
 
   @override
   set authenticateProxy(
-          Future<bool> Function(
-                  String host, int port, String scheme, String? realm)?
-              f) =>
-      innerClient.authenticateProxy = f;
+    Future<bool> Function(String host, int port, String scheme, String? realm)?
+    f,
+  ) => innerClient.authenticateProxy = f;
 
   @override
   set badCertificateCallback(
-          bool Function(X509Certificate cert, String host, int port)?
-              callback) =>
-      innerClient.badCertificateCallback = callback;
+    bool Function(X509Certificate cert, String host, int port)? callback,
+  ) => innerClient.badCertificateCallback = callback;
 
   @override
   void close({bool force = false}) {
@@ -227,10 +230,8 @@ class FaroHttpTrackingClient implements HttpClient {
 }
 
 class FaroTrackingHttpClientRequest implements HttpClientRequest {
-  FaroTrackingHttpClientRequest(
-    this.innerContext, {
-    required Span httpSpan,
-  }) : _httpSpan = httpSpan {
+  FaroTrackingHttpClientRequest(this.innerContext, {required Span httpSpan})
+    : _httpSpan = httpSpan {
     innerContext.headers.add('traceparent', _httpSpan.traceparent);
   }
 
@@ -246,14 +247,8 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
     _httpSpan.end();
   }
 
-  void _recordOperationError(
-    Object error, [
-    StackTrace? stackTrace,
-  ]) {
-    _httpSpan.setStatus(
-      SpanStatusCode.error,
-      message: error.toString(),
-    );
+  void _recordOperationError(Object error, [StackTrace? stackTrace]) {
+    _httpSpan.setStatus(SpanStatusCode.error, message: error.toString());
     _httpSpan.recordException(error, stackTrace: stackTrace);
   }
 
@@ -403,8 +398,8 @@ class FaroTrackingHttpResponse extends Stream<List<int>>
     this.userAttributes, {
     required void Function() onFinish,
     required void Function(Object error, StackTrace stackTrace) onStreamError,
-  })  : _onFinish = onFinish,
-        _onStreamError = onStreamError;
+  }) : _onFinish = onFinish,
+       _onStreamError = onStreamError;
   final HttpClientResponse innerResponse;
   final Map<String, Object?> userAttributes;
   final void Function() _onFinish;
@@ -421,8 +416,12 @@ class FaroTrackingHttpResponse extends Stream<List<int>>
   }
 
   @override
-  StreamSubscription<List<int>> listen(void Function(List<int> event)? onData,
-      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
     return _FaroResponseSubscription(
       innerResponse.listen(
         onData,
@@ -491,8 +490,11 @@ class FaroTrackingHttpResponse extends Stream<List<int>>
   String get reasonPhrase => innerResponse.reasonPhrase;
 
   @override
-  Future<HttpClientResponse> redirect(
-      [String? method, Uri? url, bool? followLoops]) {
+  Future<HttpClientResponse> redirect([
+    String? method,
+    Uri? url,
+    bool? followLoops,
+  ]) {
     return innerResponse.redirect(method, url, followLoops);
   }
 
@@ -508,8 +510,8 @@ class _FaroResponseSubscription implements StreamSubscription<List<int>> {
     this._inner, {
     required void Function() onCancel,
     required void Function(Object error, StackTrace stackTrace) onStreamError,
-  })  : _onCancel = onCancel,
-        _onStreamError = onStreamError;
+  }) : _onCancel = onCancel,
+       _onStreamError = onStreamError;
 
   final StreamSubscription<List<int>> _inner;
   final void Function() _onCancel;

--- a/lib/src/integrations/native_integration.dart
+++ b/lib/src/integrations/native_integration.dart
@@ -55,9 +55,10 @@ class NativeIntegration {
     try {
       final appStart = await Faro().nativeChannel?.getAppStart();
       if (appStart != null) {
-        Faro().pushMeasurement(
-            {'appStartDuration': appStart['appStartDuration'], 'coldStart': 1},
-            'app_startup');
+        Faro().pushMeasurement({
+          'appStartDuration': appStart['appStartDuration'],
+          'coldStart': 1,
+        }, 'app_startup');
       }
     } catch (error) {
       log('Error getting app start metrics: $error');
@@ -75,9 +76,10 @@ class NativeIntegration {
       final warmStartDuration =
           DateTime.now().millisecondsSinceEpoch - warmStart;
       if (warmStartDuration > 0) {
-        Faro().pushMeasurement(
-            {'appStartDuration': warmStartDuration, 'coldStart': 0},
-            'app_startup');
+        Faro().pushMeasurement({
+          'appStartDuration': warmStartDuration,
+          'coldStart': 0,
+        }, 'app_startup');
       }
     } catch (error) {
       log('Error getting warm start metrics: $error');
@@ -185,8 +187,9 @@ class NativeIntegration {
 
           case 'onSlowFrames':
             if (call.arguments != null) {
-              Faro().pushMeasurement(
-                  {'slow_frames': call.arguments}, 'app_frames_rate');
+              Faro().pushMeasurement({
+                'slow_frames': call.arguments,
+              }, 'app_frames_rate');
             }
             break;
         }

--- a/lib/src/integrations/on_error_integration.dart
+++ b/lib/src/integrations/on_error_integration.dart
@@ -10,9 +10,10 @@ class OnErrorIntegration {
     _defaultOnError = PlatformDispatcher.instance.onError;
     _onErrorIntegration = (exception, stackTrace) {
       Faro().pushError(
-          type: 'flutter_error',
-          value: exception.toString(),
-          stacktrace: stackTrace);
+        type: 'flutter_error',
+        value: exception.toString(),
+        stacktrace: stackTrace,
+      );
       if (_defaultOnError != null) {
         _defaultOnError?.call(exception, stackTrace);
       }

--- a/lib/src/models/app.dart
+++ b/lib/src/models/app.dart
@@ -1,10 +1,5 @@
 class App {
-  App({
-    this.name,
-    this.environment,
-    this.version,
-    this.namespace,
-  });
+  App({this.name, this.environment, this.version, this.namespace});
 
   App.fromJson(dynamic json) {
     name = json['name'];

--- a/lib/src/models/browser.dart
+++ b/lib/src/models/browser.dart
@@ -1,8 +1,14 @@
 // ignore_for_file: avoid_positional_boolean_parameters
 
 class Browser {
-  Browser(this.name, this.version, this.os, this.userAgent, this.language,
-      this.mobile);
+  Browser(
+    this.name,
+    this.version,
+    this.os,
+    this.userAgent,
+    this.language,
+    this.mobile,
+  );
 
   Browser.fromJson(dynamic json) {
     name = json['name'];

--- a/lib/src/models/exception.dart
+++ b/lib/src/models/exception.dart
@@ -82,7 +82,9 @@ class FaroException {
       missingFields.add('timestamp');
     }
     if (missingFields.isNotEmpty) {
-      log('Dropping exception with missing required fields: ${missingFields.join(', ')}');
+      log(
+        'Dropping exception with missing required fields: ${missingFields.join(', ')}',
+      );
       return null;
     }
 
@@ -134,9 +136,14 @@ class FaroException {
           "${regExpMatch?.namedGroup("module")}:${regExpMatch?.namedGroup("filename")}";
       final lineno = regExpMatch?.namedGroup('lineno');
       final colno = regExpMatch?.namedGroup('colno');
-      parsedStackFrames.add(StackFrames(filename, sf[sf.length - 2],
-              int.parse(lineno ?? '0'), int.parse(colno ?? '0'))
-          .toJson());
+      parsedStackFrames.add(
+        StackFrames(
+          filename,
+          sf[sf.length - 2],
+          int.parse(lineno ?? '0'),
+          int.parse(colno ?? '0'),
+        ).toJson(),
+      );
     }
     return parsedStackFrames;
   }

--- a/lib/src/models/faro_user.dart
+++ b/lib/src/models/faro_user.dart
@@ -35,12 +35,8 @@ class FaroUser extends Equatable {
   ///
   /// Use [attributes] to attach arbitrary key-value metadata to the user.
   /// All attribute values must be strings.
-  const FaroUser({
-    this.id,
-    this.username,
-    this.email,
-    this.attributes,
-  }) : _isCleared = false;
+  const FaroUser({this.id, this.username, this.email, this.attributes})
+    : _isCleared = false;
 
   /// Creates a sentinel value that explicitly clears any persisted user.
   ///
@@ -52,11 +48,11 @@ class FaroUser extends Equatable {
   /// - Testing scenarios
   /// - Apps that detect the user was logged out externally
   const FaroUser.cleared()
-      : id = null,
-        username = null,
-        email = null,
-        attributes = null,
-        _isCleared = true;
+    : id = null,
+      username = null,
+      email = null,
+      attributes = null,
+      _isCleared = true;
 
   /// Creates a [FaroUser] from a JSON map.
   factory FaroUser.fromJson(Map<String, dynamic> json) {
@@ -64,9 +60,10 @@ class FaroUser extends Equatable {
       id: json['id'] as String?,
       username: json['username'] as String?,
       email: json['email'] as String?,
-      attributes: json['attributes'] != null
-          ? Map<String, String>.from(json['attributes'] as Map)
-          : null,
+      attributes:
+          json['attributes'] != null
+              ? Map<String, String>.from(json['attributes'] as Map)
+              : null,
     );
   }
 

--- a/lib/src/models/measurement.dart
+++ b/lib/src/models/measurement.dart
@@ -26,7 +26,9 @@ class Measurement {
       missingFields.add('timestamp');
     }
     if (missingFields.isNotEmpty) {
-      log('Dropping measurement with missing required fields: ${missingFields.join(', ')}');
+      log(
+        'Dropping measurement with missing required fields: ${missingFields.join(', ')}',
+      );
       return null;
     }
     return Measurement.fromJson(json);
@@ -52,12 +54,16 @@ class Measurement {
             // Don't add this key to sanitizedValues
           } else {
             // This shouldn't happen for regular doubles, but just in case
-            log('Sanitizing unexpected non-encodable double for key "$key": $value');
+            log(
+              'Sanitizing unexpected non-encodable double for key "$key": $value',
+            );
             sanitizedValues[key] = 0.0;
           }
         } else {
           // For non-numeric types that can't be encoded, convert to string representation
-          log('Converting non-encodable value for key "$key" of type ${value.runtimeType} to string');
+          log(
+            'Converting non-encodable value for key "$key" of type ${value.runtimeType} to string',
+          );
           sanitizedValues[key] = value.toString();
         }
       }

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -5,9 +5,8 @@ import 'package:faro/src/tracing/extensions.dart';
 import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
 class SpanRecord {
-  SpanRecord({
-    required otel_sdk.ReadOnlySpan otelReadOnlySpan,
-  }) : _otelReadOnlySpan = otelReadOnlySpan;
+  SpanRecord({required otel_sdk.ReadOnlySpan otelReadOnlySpan})
+    : _otelReadOnlySpan = otelReadOnlySpan;
 
   final otel_sdk.ReadOnlySpan _otelReadOnlySpan;
 

--- a/lib/src/models/trace/trace_attribute.dart
+++ b/lib/src/models/trace/trace_attribute.dart
@@ -3,11 +3,9 @@
 /// Each attribute has a key and a typed value that can be a string, int,
 /// double, or bool. This follows the OTLP specification for attribute values.
 class TraceAttribute {
-  TraceAttribute({
-    required String key,
-    required TraceAttributeValue value,
-  })  : _key = key,
-        _value = value;
+  TraceAttribute({required String key, required TraceAttributeValue value})
+    : _key = key,
+      _value = value;
 
   TraceAttribute.fromJson(dynamic json) {
     if (json['key'] != null) {
@@ -46,39 +44,39 @@ class TraceAttributeValue {
   ///
   /// This is the legacy constructor maintained for backward compatibility.
   TraceAttributeValue({required String stringValue})
-      : _stringValue = stringValue,
-        _intValue = null,
-        _doubleValue = null,
-        _boolValue = null;
+    : _stringValue = stringValue,
+      _intValue = null,
+      _doubleValue = null,
+      _boolValue = null;
 
   /// Creates a TraceAttributeValue with a string value.
   TraceAttributeValue.string(String value)
-      : _stringValue = value,
-        _intValue = null,
-        _doubleValue = null,
-        _boolValue = null;
+    : _stringValue = value,
+      _intValue = null,
+      _doubleValue = null,
+      _boolValue = null;
 
   /// Creates a TraceAttributeValue with an integer value.
   TraceAttributeValue.int(int value)
-      : _stringValue = null,
-        _intValue = value,
-        _doubleValue = null,
-        _boolValue = null;
+    : _stringValue = null,
+      _intValue = value,
+      _doubleValue = null,
+      _boolValue = null;
 
   /// Creates a TraceAttributeValue with a double value.
   TraceAttributeValue.double(double value)
-      : _stringValue = null,
-        _intValue = null,
-        _doubleValue = value,
-        _boolValue = null;
+    : _stringValue = null,
+      _intValue = null,
+      _doubleValue = value,
+      _boolValue = null;
 
   /// Creates a TraceAttributeValue with a boolean value.
   // ignore: avoid_positional_boolean_parameters
   TraceAttributeValue.bool(bool value)
-      : _stringValue = null,
-        _intValue = null,
-        _doubleValue = null,
-        _boolValue = value;
+    : _stringValue = null,
+      _intValue = null,
+      _doubleValue = null,
+      _boolValue = value;
 
   /// Creates a TraceAttributeValue from a dynamic value.
   ///
@@ -108,10 +106,10 @@ class TraceAttributeValue {
   /// Supports deserializing any of the typed value fields:
   /// `stringValue`, `intValue`, `doubleValue`, `boolValue`.
   TraceAttributeValue.fromJson(dynamic json)
-      : _stringValue = json['stringValue'] as String?,
-        _intValue = json['intValue'] as int?,
-        _doubleValue = _parseDouble(json['doubleValue']),
-        _boolValue = json['boolValue'] as bool?;
+    : _stringValue = json['stringValue'] as String?,
+      _intValue = json['intValue'] as int?,
+      _doubleValue = _parseDouble(json['doubleValue']),
+      _boolValue = json['boolValue'] as bool?;
 
   final String? _stringValue;
   final int? _intValue;

--- a/lib/src/models/trace/trace_resource.dart
+++ b/lib/src/models/trace/trace_resource.dart
@@ -1,9 +1,8 @@
 import 'package:faro/src/models/trace/trace_attribute.dart';
 
 class TraceResource {
-  TraceResource({
-    required List<TraceAttribute> attributes,
-  }) : _attributes = attributes;
+  TraceResource({required List<TraceAttribute> attributes})
+    : _attributes = attributes;
 
   TraceResource.fromJson(dynamic json) {
     if (json['attributes'] != null) {

--- a/lib/src/models/trace/trace_resource_spans.dart
+++ b/lib/src/models/trace/trace_resource_spans.dart
@@ -34,8 +34,10 @@ class TraceResourceSpans {
   }
 
   int numberSpans() {
-    return _scopeSpansMap.values
-        .fold(0, (total, spanScope) => total + spanScope.numberSpans);
+    return _scopeSpansMap.values.fold(
+      0,
+      (total, spanScope) => total + spanScope.numberSpans,
+    );
   }
 
   void resetSpans() {

--- a/lib/src/models/trace/trace_scope_spans.dart
+++ b/lib/src/models/trace/trace_scope_spans.dart
@@ -1,11 +1,9 @@
 import 'package:faro/src/models/trace/trace_span.dart';
 
 class TraceScopeSpans {
-  TraceScopeSpans({
-    required TraceScope scope,
-    required List<TraceSpan> spans,
-  })  : _scope = scope,
-        _spans = spans;
+  TraceScopeSpans({required TraceScope scope, required List<TraceSpan> spans})
+    : _scope = scope,
+      _spans = spans;
 
   TraceScopeSpans.fromJson(dynamic json) {
     if (json['scope'] != null) {
@@ -41,11 +39,9 @@ class TraceScopeSpans {
 }
 
 class TraceScope {
-  TraceScope({
-    required String name,
-    required String version,
-  })  : _name = name,
-        _version = version;
+  TraceScope({required String name, required String version})
+    : _name = name,
+      _version = version;
 
   TraceScope.fromJson(dynamic json) {
     if (json['name'] != null) {

--- a/lib/src/models/trace/trace_span.dart
+++ b/lib/src/models/trace/trace_span.dart
@@ -18,18 +18,18 @@ class TraceSpan {
     required List<TraceSpanEvent> events,
     required int droppedEventsCount,
     required List<TraceSpanLink> links,
-  })  : _traceId = traceId,
-        _spanId = spanId,
-        _parentSpanId = parentSpanId,
-        _name = name,
-        _kind = kind,
-        _startTimeUnixNano = startTimeUnixNano.toString(),
-        _endTimeUnixNano = endTimeUnixNano.toString(),
-        _attributes = attributes,
-        _status = status,
-        _events = events,
-        _droppedEventsCount = droppedEventsCount,
-        _links = links;
+  }) : _traceId = traceId,
+       _spanId = spanId,
+       _parentSpanId = parentSpanId,
+       _name = name,
+       _kind = kind,
+       _startTimeUnixNano = startTimeUnixNano.toString(),
+       _endTimeUnixNano = endTimeUnixNano.toString(),
+       _attributes = attributes,
+       _status = status,
+       _events = events,
+       _droppedEventsCount = droppedEventsCount,
+       _links = links;
 
   TraceSpan.fromJson(dynamic json) {
     if (json['traceId'] != null) {

--- a/lib/src/models/trace/trace_span_event.dart
+++ b/lib/src/models/trace/trace_span_event.dart
@@ -7,10 +7,10 @@ class TraceSpanEvent {
     required Int64 timeUnixNano,
     required int droppedAttributesCount,
     required List<TraceAttribute> attributes,
-  })  : _name = name,
-        _timeUnixNano = timeUnixNano.toString(),
-        _droppedAttributesCount = droppedAttributesCount,
-        _attributes = attributes;
+  }) : _name = name,
+       _timeUnixNano = timeUnixNano.toString(),
+       _droppedAttributesCount = droppedAttributesCount,
+       _attributes = attributes;
 
   TraceSpanEvent.fromJson(dynamic json) {
     if (json['name'] != null) {

--- a/lib/src/models/trace/trace_span_link.dart
+++ b/lib/src/models/trace/trace_span_link.dart
@@ -6,10 +6,10 @@ class TraceSpanLink {
     required String spanId,
     required String traceState,
     required List<TraceAttribute> attributes,
-  })  : _traceId = traceId,
-        _spanId = spanId,
-        _traceState = traceState,
-        _attributes = attributes;
+  }) : _traceId = traceId,
+       _spanId = spanId,
+       _traceState = traceState,
+       _attributes = attributes;
 
   TraceSpanLink.fromJson(dynamic json) {
     if (json['traceId'] != null) {

--- a/lib/src/models/trace/trace_span_status.dart
+++ b/lib/src/models/trace/trace_span_status.dart
@@ -1,9 +1,7 @@
 class TraceSpanStatus {
-  TraceSpanStatus({
-    required int code,
-    required String? message,
-  })  : _code = code,
-        _message = message;
+  TraceSpanStatus({required int code, required String? message})
+    : _code = code,
+      _message = message;
 
   TraceSpanStatus.fromJson(dynamic json) {
     if (json['code'] != null) {

--- a/lib/src/models/user_action_context.dart
+++ b/lib/src/models/user_action_context.dart
@@ -3,11 +3,7 @@
 /// Mirrors the Faro Web SDK `UserAction` type used on transport payloads.
 class UserActionContext {
   /// Creates an action context for enriching telemetry items.
-  const UserActionContext({
-    required this.name,
-    this.id,
-    this.parentId,
-  });
+  const UserActionContext({required this.name, this.id, this.parentId});
 
   /// Creates an action context from a JSON map.
   factory UserActionContext.fromJson(Map<String, dynamic> json) {

--- a/lib/src/native_platform_interaction/faro_sdk_method_channel.dart
+++ b/lib/src/native_platform_interaction/faro_sdk_method_channel.dart
@@ -15,15 +15,17 @@ class MethodChannelFaroSdk extends FaroSdkPlatform {
 
   @override
   Future<Map<String, dynamic>?> getAppStart() async {
-    final appStart =
-        await methodChannel.invokeMapMethod<String, dynamic>('getAppStart');
+    final appStart = await methodChannel.invokeMapMethod<String, dynamic>(
+      'getAppStart',
+    );
     return appStart;
   }
 
   @override
   Future<Map<String, dynamic>?> getWarmStart() async {
-    final appStart =
-        await methodChannel.invokeMapMethod<String, dynamic>('getWarmStart');
+    final appStart = await methodChannel.invokeMapMethod<String, dynamic>(
+      'getWarmStart',
+    );
     return appStart;
   }
 
@@ -35,8 +37,9 @@ class MethodChannelFaroSdk extends FaroSdkPlatform {
 
   @override
   Future<double?> getRefreshRate() async {
-    final refreshRate =
-        await methodChannel.invokeMethod<double?>('getRefreshRate');
+    final refreshRate = await methodChannel.invokeMethod<double?>(
+      'getRefreshRate',
+    );
     return refreshRate;
   }
 
@@ -69,8 +72,9 @@ class MethodChannelFaroSdk extends FaroSdkPlatform {
 
   @override
   Future<List<String>?> getCrashReport() async {
-    final crashInfo =
-        await methodChannel.invokeListMethod<String>('getCrashReport');
+    final crashInfo = await methodChannel.invokeListMethod<String>(
+      'getCrashReport',
+    );
     return crashInfo;
   }
 }

--- a/lib/src/native_platform_interaction/faro_sdk_platform_interface.dart
+++ b/lib/src/native_platform_interaction/faro_sdk_platform_interface.dart
@@ -58,7 +58,7 @@ abstract class FaroSdkPlatform extends PlatformInterface {
     throw UnimplementedError('getANRStatus() has not been implemented.');
   }
 
-// Test
+  // Test
   Future<Map<String, dynamic>?> stopFramesTracker() {
     throw UnimplementedError('stopFramesTracker() has not been implemented.');
   }

--- a/lib/src/offline_transport/internet_connectivity_service.dart
+++ b/lib/src/offline_transport/internet_connectivity_service.dart
@@ -7,8 +7,8 @@ class InternetConnectivityService {
   InternetConnectivityService({
     required ConnectivityChecker connectivity,
     required String internetConnectionCheckerUrl,
-  })  : _connectivity = connectivity,
-        _internetConnectionCheckerUrl = internetConnectionCheckerUrl {
+  }) : _connectivity = connectivity,
+       _internetConnectionCheckerUrl = internetConnectionCheckerUrl {
     _checkConnectivity();
     _monitorConnectivity();
   }
@@ -17,7 +17,7 @@ class InternetConnectivityService {
   final _connectivityController = StreamController<bool>.broadcast();
   final String _internetConnectionCheckerUrl;
   StreamSubscription<List<ConnectivityResult>>?
-      _connectivityChangedSubscription;
+  _connectivityChangedSubscription;
   bool _isOnline = true;
 
   bool get isOnline => _isOnline;
@@ -40,8 +40,8 @@ class InternetConnectivityService {
 
   void _monitorConnectivity() {
     _connectivityChangedSubscription?.cancel();
-    _connectivityChangedSubscription =
-        _connectivity.onConnectivityChanged.listen(_handleConnectivityResults);
+    _connectivityChangedSubscription = _connectivity.onConnectivityChanged
+        .listen(_handleConnectivityResults);
   }
 
   void _setOnline(bool value) {
@@ -52,7 +52,8 @@ class InternetConnectivityService {
   }
 
   Future<void> _handleConnectivityResults(
-      List<ConnectivityResult> results) async {
+    List<ConnectivityResult> results,
+  ) async {
     final result = results.firstOrNull ?? ConnectivityResult.none;
     if (result == ConnectivityResult.none) {
       _setOnline(false);
@@ -74,9 +75,7 @@ class InternetConnectivityService {
 }
 
 class InternetConnectivityServiceFactory {
-  InternetConnectivityService create({
-    String? internetConnectionCheckerUrl,
-  }) {
+  InternetConnectivityService create({String? internetConnectionCheckerUrl}) {
     final checkerUrl = internetConnectionCheckerUrl ?? 'one.one.one.one';
     return InternetConnectivityService(
       connectivity: ConnectivityCheckerFactory().create(),

--- a/lib/src/offline_transport/offline_transport.dart
+++ b/lib/src/offline_transport/offline_transport.dart
@@ -17,10 +17,12 @@ class OfflineTransport extends BaseTransport {
     Duration? maxCacheDuration,
     String? internetConnectionCheckerUrl,
     InternetConnectivityService? internetConnectivityService,
-  })  : _connectivityService = internetConnectivityService ??
-            InternetConnectivityServiceFactory().create(
-                internetConnectionCheckerUrl: internetConnectionCheckerUrl),
-        _maxCacheDuration = maxCacheDuration {
+  }) : _connectivityService =
+           internetConnectivityService ??
+           InternetConnectivityServiceFactory().create(
+             internetConnectionCheckerUrl: internetConnectionCheckerUrl,
+           ),
+       _maxCacheDuration = maxCacheDuration {
     _connectivityService.onConnectivityChanged.listen((isOnline) {
       if (isOnline) {
         try {
@@ -80,10 +82,13 @@ class OfflineTransport extends BaseTransport {
       final file = await _getCacheFile();
       final logJson = {
         'timestamp': DateTime.now().millisecondsSinceEpoch,
-        'payload': payload.toJson()
+        'payload': payload.toJson(),
       };
-      await file.writeAsString('${jsonEncode(logJson)}\n',
-          mode: FileMode.append, flush: true);
+      await file.writeAsString(
+        '${jsonEncode(logJson)}\n',
+        mode: FileMode.append,
+        flush: true,
+      );
     });
   }
 
@@ -106,7 +111,9 @@ class OfflineTransport extends BaseTransport {
 
         final logJson = _parseJsonSafely(line);
         if (logJson == null) {
-          log('OfflineTransport: Failed to parse cached data to json. Skipping this payload.');
+          log(
+            'OfflineTransport: Failed to parse cached data to json. Skipping this payload.',
+          );
           continue;
         }
 
@@ -114,7 +121,9 @@ class OfflineTransport extends BaseTransport {
         final payload = Payload.fromJson(logJson['payload']);
 
         if (timestamp == null) {
-          log('OfflineTransport: Failed to parse timestamp in payload. Skipping this payload.');
+          log(
+            'OfflineTransport: Failed to parse timestamp in payload. Skipping this payload.',
+          );
           continue;
         }
 

--- a/lib/src/offline_transport/offline_transport.dart
+++ b/lib/src/offline_transport/offline_transport.dart
@@ -119,7 +119,7 @@ class OfflineTransport extends BaseTransport {
         }
 
         if (_maxCacheDuration != null &&
-            currentTime - timestamp > _maxCacheDuration!.inMilliseconds) {
+            currentTime - timestamp > _maxCacheDuration.inMilliseconds) {
           continue;
         }
         final sendSuccess = await _sendCachedData(payload);

--- a/lib/src/session/session_sampling_provider.dart
+++ b/lib/src/session/session_sampling_provider.dart
@@ -20,8 +20,9 @@ class SessionSamplingProvider {
     Sampling? sampling,
     required Meta meta,
     required RandomValueProvider randomValueProvider,
-  }) : isSampled = randomValueProvider.nextDouble() <
-            (sampling ?? _defaultSampling).resolve(SamplingContext(meta: meta));
+  }) : isSampled =
+           randomValueProvider.nextDouble() <
+           (sampling ?? _defaultSampling).resolve(SamplingContext(meta: meta));
 
   /// Whether this session is sampled.
   ///

--- a/lib/src/tracing/dart_otel_tracer_resources_factory.dart
+++ b/lib/src/tracing/dart_otel_tracer_resources_factory.dart
@@ -8,52 +8,45 @@ class DartOtelTracerResourcesFactory {
     final faro = Faro();
     const unknownString = 'unknown';
 
-    return otel_sdk.Resource(
-      [
-        // App info
-        otel_api.Attribute.fromString(
-          otel_api.ResourceAttributes.serviceName,
-          faro.meta.app?.name ?? unknownString,
-        ),
-        otel_api.Attribute.fromString(
-          otel_api.ResourceAttributes.deploymentEnvironment,
-          faro.meta.app?.environment ?? unknownString,
-        ),
-        otel_api.Attribute.fromString(
-          otel_api.ResourceAttributes.serviceVersion,
-          faro.meta.app?.version ?? unknownString,
-        ),
-        otel_api.Attribute.fromString(
-          otel_api.ResourceAttributes.serviceNamespace,
-          faro.meta.app?.namespace ?? 'flutter_app',
-        ),
+    return otel_sdk.Resource([
+      // App info
+      otel_api.Attribute.fromString(
+        otel_api.ResourceAttributes.serviceName,
+        faro.meta.app?.name ?? unknownString,
+      ),
+      otel_api.Attribute.fromString(
+        otel_api.ResourceAttributes.deploymentEnvironment,
+        faro.meta.app?.environment ?? unknownString,
+      ),
+      otel_api.Attribute.fromString(
+        otel_api.ResourceAttributes.serviceVersion,
+        faro.meta.app?.version ?? unknownString,
+      ),
+      otel_api.Attribute.fromString(
+        otel_api.ResourceAttributes.serviceNamespace,
+        faro.meta.app?.namespace ?? 'flutter_app',
+      ),
 
-        // Otel info
-        otel_api.Attribute.fromString(
-          'telemetry.sdk.name',
-          FaroConstants.sdkName,
-        ),
-        otel_api.Attribute.fromString(
-          'telemetry.sdk.language',
-          'dart',
-        ),
-        otel_api.Attribute.fromString(
-          'telemetry.sdk.version',
-          FaroConstants.sdkVersion,
-        ),
-        otel_api.Attribute.fromString(
-          'telemetry.sdk.platform',
-          'flutter',
-        ),
+      // Otel info
+      otel_api.Attribute.fromString(
+        'telemetry.sdk.name',
+        FaroConstants.sdkName,
+      ),
+      otel_api.Attribute.fromString('telemetry.sdk.language', 'dart'),
+      otel_api.Attribute.fromString(
+        'telemetry.sdk.version',
+        FaroConstants.sdkVersion,
+      ),
+      otel_api.Attribute.fromString('telemetry.sdk.platform', 'flutter'),
 
-        // Session attributes
-        ..._buildSessionAttributes(faro.meta.session?.attributes),
-      ],
-    );
+      // Session attributes
+      ..._buildSessionAttributes(faro.meta.session?.attributes),
+    ]);
   }
 
   List<otel_api.Attribute> _buildSessionAttributes(
-      Map<String, dynamic>? sessionAttributes) {
+    Map<String, dynamic>? sessionAttributes,
+  ) {
     if (sessionAttributes == null) return [];
 
     return sessionAttributes.entries.map((entry) {

--- a/lib/src/tracing/extensions.dart
+++ b/lib/src/tracing/extensions.dart
@@ -108,12 +108,14 @@ extension SpanLinkListX on List<otel_api.SpanLink> {
   List<TraceSpanLink> toTraceSpanLinksList() {
     final links = <TraceSpanLink>[];
     for (final link in this) {
-      links.add(TraceSpanLink(
-        traceId: link.context.traceId.toString(),
-        spanId: link.context.spanId.toString(),
-        traceState: link.context.traceState.toString(),
-        attributes: link.attributes.toTraceAttributes(),
-      ));
+      links.add(
+        TraceSpanLink(
+          traceId: link.context.traceId.toString(),
+          spanId: link.context.spanId.toString(),
+          traceState: link.context.traceState.toString(),
+          attributes: link.attributes.toTraceAttributes(),
+        ),
+      );
     }
     return links;
   }

--- a/lib/src/tracing/faro_exporter.dart
+++ b/lib/src/tracing/faro_exporter.dart
@@ -9,7 +9,7 @@ import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
 class FaroExporter implements otel_sdk.SpanExporter {
   FaroExporter({required TelemetryRouter telemetryRouter})
-      : _telemetryRouter = telemetryRouter;
+    : _telemetryRouter = telemetryRouter;
 
   final TelemetryRouter _telemetryRouter;
   var _isShutdown = false;
@@ -57,10 +57,7 @@ class FaroExporter implements otel_sdk.SpanExporter {
         );
       }
 
-      _telemetryRouter.ingest(
-        TelemetryItem.fromEvent(event),
-        skipBuffer: true,
-      );
+      _telemetryRouter.ingest(TelemetryItem.fromEvent(event), skipBuffer: true);
       _telemetryRouter.ingest(TelemetryItem.fromSpan(spanRecord));
     }
   }
@@ -68,8 +65,6 @@ class FaroExporter implements otel_sdk.SpanExporter {
 
 class FaroExporterFactory {
   FaroExporter create() {
-    return FaroExporter(
-      telemetryRouter: pod.resolve(telemetryRouterProvider),
-    );
+    return FaroExporter(telemetryRouter: pod.resolve(telemetryRouterProvider));
   }
 }

--- a/lib/src/tracing/faro_tracer.dart
+++ b/lib/src/tracing/faro_tracer.dart
@@ -14,9 +14,9 @@ class FaroTracer {
     required otel_api.Tracer otelTracer,
     required FaroZoneSpanManager faroZoneSpanManager,
     required SessionIdProvider sessionIdProvider,
-  })  : _otelTracer = otelTracer,
-        _faroZoneSpanManager = faroZoneSpanManager,
-        _sessionIdProvider = sessionIdProvider;
+  }) : _otelTracer = otelTracer,
+       _faroZoneSpanManager = faroZoneSpanManager,
+       _sessionIdProvider = sessionIdProvider;
 
   final otel_api.Tracer _otelTracer;
   final FaroZoneSpanManager _faroZoneSpanManager;
@@ -95,9 +95,10 @@ class FaroTracer {
       'session_id': sessionId,
       'session.id': sessionId,
     };
-    final otelAttributes = allAttributes.entries.map((entry) {
-      return _createOtelAttribute(entry.key, entry.value);
-    }).toList();
+    final otelAttributes =
+        allAttributes.entries.map((entry) {
+          return _createOtelAttribute(entry.key, entry.value);
+        }).toList();
 
     final otelSpan = _otelTracer.startSpan(
       name,
@@ -152,9 +153,7 @@ class FaroTracerFactory {
       processors: [faroSpanProcessor],
     );
     otel_api.registerGlobalTracerProvider(provider);
-    final otelTracer = provider.getTracer(
-      'flutter-faro-instrumentation',
-    );
+    final otelTracer = provider.getTracer('flutter-faro-instrumentation');
 
     final faroZoneSpanManager = FaroZoneSpanManagerFactory().create();
     final sessionIdProvider = SessionIdProviderFactory().create();

--- a/lib/src/tracing/faro_user_action_span_processor.dart
+++ b/lib/src/tracing/faro_user_action_span_processor.dart
@@ -26,9 +26,9 @@ class FaroUserActionSpanProcessor implements otel_sdk.SpanProcessor {
     required otel_sdk.SpanProcessor delegate,
     required ActiveUserActionResolver activeUserActionResolver,
     required UserActionLifecycleSignalChannel lifecycleSignalChannel,
-  })  : _delegate = delegate,
-        _activeUserActionResolver = activeUserActionResolver,
-        _lifecycleSignalChannel = lifecycleSignalChannel;
+  }) : _delegate = delegate,
+       _activeUserActionResolver = activeUserActionResolver,
+       _lifecycleSignalChannel = lifecycleSignalChannel;
 
   final otel_sdk.SpanProcessor _delegate;
   final ActiveUserActionResolver _activeUserActionResolver;
@@ -39,8 +39,9 @@ class FaroUserActionSpanProcessor implements otel_sdk.SpanProcessor {
 
   @override
   void onStart(otel_sdk.ReadWriteSpan span, otel_api.Context parentContext) {
-    final pendingMarkerValue =
-        span.attributes.get(UserActionConstants.pendingOperationKey);
+    final pendingMarkerValue = span.attributes.get(
+      UserActionConstants.pendingOperationKey,
+    );
     if (_isPendingOperationMarkerEnabled(pendingMarkerValue)) {
       final operationId = span.spanContext.spanId.toString();
       _pendingOperationSpanIds.add(operationId);
@@ -101,8 +102,9 @@ class FaroUserActionSpanProcessor implements otel_sdk.SpanProcessor {
 final faroSpanProcessorProvider = Provider<otel_sdk.SpanProcessor>((pod) {
   final exporter = FaroExporterFactory().create();
   final userActionsService = pod.resolve(userActionsServiceProvider);
-  final lifecycleSignalChannel =
-      pod.resolve(userActionLifecycleSignalChannelProvider);
+  final lifecycleSignalChannel = pod.resolve(
+    userActionLifecycleSignalChannelProvider,
+  );
   return FaroUserActionSpanProcessor(
     delegate: otel_sdk.SimpleSpanProcessor(exporter),
     activeUserActionResolver: userActionsService.getActiveUserAction,

--- a/lib/src/tracing/faro_zone_span_manager.dart
+++ b/lib/src/tracing/faro_zone_span_manager.dart
@@ -5,20 +5,18 @@ import 'package:faro/src/tracing/span.dart';
 export 'package:faro/src/tracing/span.dart' show ContextScope;
 
 typedef ParentSpanLookup = dynamic Function(Symbol key);
-typedef ZoneRunner = Future<T> Function<T>(
-  Future<T> Function() callback,
-  Map<Object?, Object?> zoneValues,
-);
+typedef ZoneRunner =
+    Future<T> Function<T>(
+      Future<T> Function() callback,
+      Map<Object?, Object?> zoneValues,
+    );
 
 /// Holds a span and tracks whether it's still active in context.
 ///
 /// Used internally to support deactivation when the callback completes,
 /// allowing proper separation between span lifecycle (end) and context scope.
 class SpanContextHolder {
-  SpanContextHolder({
-    required this.span,
-    required this.contextScope,
-  });
+  SpanContextHolder({required this.span, required this.contextScope});
 
   /// The span being held.
   final Span span;
@@ -46,8 +44,8 @@ class FaroZoneSpanManager {
   FaroZoneSpanManager({
     required ParentSpanLookup parentSpanLookup,
     required ZoneRunner zoneRunner,
-  })  : _parentSpanLookup = parentSpanLookup,
-        _zoneRunner = zoneRunner;
+  }) : _parentSpanLookup = parentSpanLookup,
+       _zoneRunner = zoneRunner;
 
   static const _spanContextKey = #faroSpanContext;
 
@@ -91,10 +89,7 @@ class FaroZoneSpanManager {
         return result;
       } catch (error, stackTrace) {
         if (!span.statusHasBeenSet) {
-          span.setStatus(
-            SpanStatusCode.error,
-            message: error.toString(),
-          );
+          span.setStatus(SpanStatusCode.error, message: error.toString());
         }
         span.recordException(error, stackTrace: stackTrace);
         rethrow;
@@ -105,9 +100,7 @@ class FaroZoneSpanManager {
           spanContextHolder.deactivate();
         }
       }
-    }, {
-      _spanContextKey: spanContextHolder,
-    });
+    }, {_spanContextKey: spanContextHolder});
   }
 }
 
@@ -115,8 +108,9 @@ class FaroZoneSpanManagerFactory {
   FaroZoneSpanManager create() {
     return FaroZoneSpanManager(
       parentSpanLookup: (key) => Zone.current[key],
-      zoneRunner: <T>(callback, zoneValues) =>
-          runZoned(callback, zoneValues: zoneValues),
+      zoneRunner:
+          <T>(callback, zoneValues) =>
+              runZoned(callback, zoneValues: zoneValues),
     );
   }
 }

--- a/lib/src/tracing/span.dart
+++ b/lib/src/tracing/span.dart
@@ -68,8 +68,8 @@ class InternalSpan implements Span {
   InternalSpan._({
     required otel_api.Span otelSpan,
     required otel_api.Context context,
-  })  : _otelSpan = otelSpan,
-        _context = context;
+  }) : _otelSpan = otelSpan,
+       _context = context;
 
   final otel_api.Span _otelSpan;
   final otel_api.Context _context;
@@ -85,8 +85,9 @@ class InternalSpan implements Span {
 
   @override
   String get traceparent {
-    final traceFlags =
-        _otelSpan.spanContext.traceFlags.toRadixString(16).padLeft(2, '0');
+    final traceFlags = _otelSpan.spanContext.traceFlags
+        .toRadixString(16)
+        .padLeft(2, '0');
     return '00-$traceId-$spanId-$traceFlags';
   }
 
@@ -141,8 +142,10 @@ class InternalSpan implements Span {
 
   @override
   void recordException(dynamic exception, {StackTrace? stackTrace}) {
-    _otelSpan.recordException(exception,
-        stackTrace: stackTrace ?? StackTrace.current);
+    _otelSpan.recordException(
+      exception,
+      stackTrace: stackTrace ?? StackTrace.current,
+    );
   }
 
   @override
@@ -153,7 +156,8 @@ class InternalSpan implements Span {
 
   /// Converts a map of typed attributes to OpenTelemetry Attributes.
   List<otel_api.Attribute> _convertToOtelAttributes(
-      Map<String, Object> attributes) {
+    Map<String, Object> attributes,
+  ) {
     return attributes.entries.map((entry) {
       return _createOtelAttribute(entry.key, entry.value);
     }).toList();

--- a/lib/src/transport/batch_transport.dart
+++ b/lib/src/transport/batch_transport.dart
@@ -28,9 +28,9 @@ class BatchTransport {
     required Payload payload,
     required BatchConfig batchConfig,
     required List<BaseTransport> transports,
-  })  : _payload = payload,
-        _batchConfig = batchConfig,
-        _transports = transports {
+  }) : _payload = payload,
+       _batchConfig = batchConfig,
+       _transports = transports {
     if (_batchConfig.enabled) {
       _flushTimer = Timer.periodic(_batchConfig.sendTimeout, (_) {
         flush(_payload);

--- a/lib/src/user/user_manager.dart
+++ b/lib/src/user/user_manager.dart
@@ -30,9 +30,9 @@ class UserManager {
     required UserPersistence? persistence,
     required OnUserMetaApplied onUserMetaApplied,
     required OnPushEvent onPushEvent,
-  })  : _persistence = persistence,
-        _onUserMetaApplied = onUserMetaApplied,
-        _onPushEvent = onPushEvent;
+  }) : _persistence = persistence,
+       _onUserMetaApplied = onUserMetaApplied,
+       _onPushEvent = onPushEvent;
 
   final UserPersistence? _persistence;
   final OnUserMetaApplied _onUserMetaApplied;

--- a/lib/src/user/user_persistence.dart
+++ b/lib/src/user/user_persistence.dart
@@ -10,9 +10,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// it can be restored on the next app start, ensuring early telemetry
 /// events include user identification.
 class UserPersistence {
-  UserPersistence({
-    required SharedPreferences sharedPreferences,
-  }) : _sharedPreferences = sharedPreferences;
+  UserPersistence({required SharedPreferences sharedPreferences})
+    : _sharedPreferences = sharedPreferences;
 
   final SharedPreferences _sharedPreferences;
   static const String _userDataKey = 'faro_persisted_user';

--- a/lib/src/user_actions/telemetry_router.dart
+++ b/lib/src/user_actions/telemetry_router.dart
@@ -9,8 +9,8 @@ class TelemetryRouter {
   TelemetryRouter({
     required BatchTransportResolver transportResolver,
     required UserActionsService userActionsService,
-  })  : _transportResolver = transportResolver,
-        _userActionsService = userActionsService;
+  }) : _transportResolver = transportResolver,
+       _userActionsService = userActionsService;
 
   final BatchTransportResolver _transportResolver;
   final UserActionsService _userActionsService;

--- a/lib/src/user_actions/user_action.dart
+++ b/lib/src/user_actions/user_action.dart
@@ -33,10 +33,10 @@ class UserAction implements UserActionHandle {
     this.attributes,
     this.trigger = UserActionConstants.apiCallTrigger,
     this.importance = UserActionConstants.importanceNormal,
-  })  : id = generateShortId(),
-        startTime = DateTime.now().millisecondsSinceEpoch,
-        _state = UserActionState.started,
-        _stateController = StreamController<UserActionState>.broadcast();
+  }) : id = generateShortId(),
+       startTime = DateTime.now().millisecondsSinceEpoch,
+       _state = UserActionState.started,
+       _stateController = StreamController<UserActionState>.broadcast();
 
   /// Unique identifier for this action (8-character short ID).
   @override

--- a/lib/src/user_actions/user_action_controller.dart
+++ b/lib/src/user_actions/user_action_controller.dart
@@ -32,10 +32,7 @@ class UserActionLifecycleController {
   ///
   /// - [userAction]: The user action to manage
   /// - [signalStream]: Stream of user action lifecycle signals
-  UserActionLifecycleController(
-    this._userAction,
-    this._signalStream,
-  );
+  UserActionLifecycleController(this._userAction, this._signalStream);
 
   final UserAction _userAction;
   final Stream<UserActionSignal> _signalStream;
@@ -54,9 +51,11 @@ class UserActionLifecycleController {
   void attach() {
     _signalSubscription?.cancel();
     _signalSubscription = _signalStream
-        .where((_) =>
-            _userAction.getState() == UserActionState.started ||
-            _userAction.getState() == UserActionState.halted)
+        .where(
+          (_) =>
+              _userAction.getState() == UserActionState.started ||
+              _userAction.getState() == UserActionState.halted,
+        )
         .where(_shouldProcessSignal)
         .listen(_handleSignal);
 
@@ -161,13 +160,15 @@ class UserActionLifecycleController {
   }
 }
 
-typedef UserActionLifecycleControllerFactory = UserActionLifecycleController
-    Function(UserAction userAction);
+typedef UserActionLifecycleControllerFactory =
+    UserActionLifecycleController Function(UserAction userAction);
 
 final userActionLifecycleControllerFactoryProvider =
     Provider<UserActionLifecycleControllerFactory>((pod) {
-  final signalChannel = pod.resolve(userActionLifecycleSignalChannelProvider);
-  return (UserAction userAction) {
-    return UserActionLifecycleController(userAction, signalChannel.stream);
-  };
-});
+      final signalChannel = pod.resolve(
+        userActionLifecycleSignalChannelProvider,
+      );
+      return (UserAction userAction) {
+        return UserActionLifecycleController(userAction, signalChannel.stream);
+      };
+    });

--- a/lib/src/user_actions/user_action_lifecycle_signal_channel.dart
+++ b/lib/src/user_actions/user_action_lifecycle_signal_channel.dart
@@ -10,33 +10,19 @@ class UserActionLifecycleSignalChannel implements Disposable {
 
   Stream<UserActionSignal> get stream => _controller.stream;
 
-  void emitActivity({
-    required String source,
-  }) {
+  void emitActivity({required String source}) {
     _emit(UserActionSignal.activity(source: source));
   }
 
-  void emitPendingStart({
-    required String source,
-    required String operationId,
-  }) {
+  void emitPendingStart({required String source, required String operationId}) {
     _emit(
-      UserActionSignal.pendingStart(
-        source: source,
-        operationId: operationId,
-      ),
+      UserActionSignal.pendingStart(source: source, operationId: operationId),
     );
   }
 
-  void emitPendingEnd({
-    required String source,
-    required String operationId,
-  }) {
+  void emitPendingEnd({required String source, required String operationId}) {
     _emit(
-      UserActionSignal.pendingEnd(
-        source: source,
-        operationId: operationId,
-      ),
+      UserActionSignal.pendingEnd(source: source, operationId: operationId),
     );
   }
 
@@ -52,5 +38,5 @@ class UserActionLifecycleSignalChannel implements Disposable {
 
 final userActionLifecycleSignalChannelProvider =
     Provider<UserActionLifecycleSignalChannel>(
-  (pod) => UserActionLifecycleSignalChannel(),
-);
+      (pod) => UserActionLifecycleSignalChannel(),
+    );

--- a/lib/src/user_actions/user_action_signal.dart
+++ b/lib/src/user_actions/user_action_signal.dart
@@ -33,9 +33,7 @@ class UserActionSignal {
   final String? operationId;
 
   /// Creates an activity signal.
-  factory UserActionSignal.activity({
-    required String source,
-  }) {
+  factory UserActionSignal.activity({required String source}) {
     return UserActionSignal._(
       type: UserActionSignalType.activity,
       source: source,

--- a/lib/src/user_actions/user_action_types.dart
+++ b/lib/src/user_actions/user_action_types.dart
@@ -3,27 +3,15 @@ import 'package:faro/src/models/span_record.dart';
 import 'package:faro/src/models/user_action_context.dart';
 
 /// Type of telemetry item being transported.
-enum TelemetryItemType {
-  event,
-  log,
-  exception,
-  measurement,
-  span,
-}
+enum TelemetryItemType { event, log, exception, measurement, span }
 
 /// Represents a telemetry item that can be buffered during a user action.
 class TelemetryItem {
-  TelemetryItem({
-    required this.type,
-    required this.payload,
-  });
+  TelemetryItem({required this.type, required this.payload});
 
   /// Creates a telemetry item from a SpanRecord.
   factory TelemetryItem.fromSpan(SpanRecord span) {
-    return TelemetryItem(
-      type: TelemetryItemType.span,
-      payload: span,
-    );
+    return TelemetryItem(type: TelemetryItemType.span, payload: span);
   }
 
   /// Creates a telemetry item from a Measurement.
@@ -36,26 +24,17 @@ class TelemetryItem {
 
   /// Creates a telemetry item from a FaroException.
   factory TelemetryItem.fromException(FaroException exception) {
-    return TelemetryItem(
-      type: TelemetryItemType.exception,
-      payload: exception,
-    );
+    return TelemetryItem(type: TelemetryItemType.exception, payload: exception);
   }
 
   /// Creates a telemetry item from an Event.
   factory TelemetryItem.fromEvent(Event event) {
-    return TelemetryItem(
-      type: TelemetryItemType.event,
-      payload: event,
-    );
+    return TelemetryItem(type: TelemetryItemType.event, payload: event);
   }
 
   /// Creates a telemetry item from a FaroLog.
   factory TelemetryItem.fromLog(FaroLog log) {
-    return TelemetryItem(
-      type: TelemetryItemType.log,
-      payload: log,
-    );
+    return TelemetryItem(type: TelemetryItemType.log, payload: log);
   }
 
   final TelemetryItemType type;

--- a/lib/src/user_actions/user_action_ui_activity_monitor.dart
+++ b/lib/src/user_actions/user_action_ui_activity_monitor.dart
@@ -21,10 +21,10 @@ class UserActionUiActivityMonitor {
     required UserActionHandle? Function() activeUserActionResolver,
     required SchedulerBinding schedulerBinding,
     required WidgetsBinding widgetsBinding,
-  })  : _lifecycleSignalChannel = lifecycleSignalChannel,
-        _activeUserActionResolver = activeUserActionResolver,
-        _schedulerBinding = schedulerBinding,
-        _widgetsBinding = widgetsBinding;
+  }) : _lifecycleSignalChannel = lifecycleSignalChannel,
+       _activeUserActionResolver = activeUserActionResolver,
+       _schedulerBinding = schedulerBinding,
+       _widgetsBinding = widgetsBinding;
 
   final UserActionLifecycleSignalChannel _lifecycleSignalChannel;
   final UserActionHandle? Function() _activeUserActionResolver;
@@ -187,12 +187,14 @@ class UserActionUiActivityMonitor {
 
 final userActionUiActivityMonitorProvider =
     Provider<UserActionUiActivityMonitor>((pod) {
-  final signalChannel = pod.resolve(userActionLifecycleSignalChannelProvider);
-  final userActionsService = pod.resolve(userActionsServiceProvider);
-  return UserActionUiActivityMonitor(
-    lifecycleSignalChannel: signalChannel,
-    activeUserActionResolver: userActionsService.getActiveUserAction,
-    schedulerBinding: SchedulerBinding.instance,
-    widgetsBinding: WidgetsBinding.instance,
-  );
-});
+      final signalChannel = pod.resolve(
+        userActionLifecycleSignalChannelProvider,
+      );
+      final userActionsService = pod.resolve(userActionsServiceProvider);
+      return UserActionUiActivityMonitor(
+        lifecycleSignalChannel: signalChannel,
+        activeUserActionResolver: userActionsService.getActiveUserAction,
+        schedulerBinding: SchedulerBinding.instance,
+        widgetsBinding: WidgetsBinding.instance,
+      );
+    });

--- a/lib/src/user_actions/user_actions_service.dart
+++ b/lib/src/user_actions/user_actions_service.dart
@@ -16,8 +16,8 @@ class UserActionsService {
   UserActionsService({
     required BatchTransportResolver transportResolver,
     required UserActionLifecycleControllerFactory lifecycleControllerFactory,
-  })  : _transportResolver = transportResolver,
-        _lifecycleControllerFactory = lifecycleControllerFactory;
+  }) : _transportResolver = transportResolver,
+       _lifecycleControllerFactory = lifecycleControllerFactory;
 
   final BatchTransportResolver _transportResolver;
   final UserActionLifecycleControllerFactory _lifecycleControllerFactory;
@@ -40,8 +40,10 @@ class UserActionsService {
     }
 
     if (_transportResolver() == null) {
-      log('Faro: Cannot start user action'
-          ' - Faro not initialized');
+      log(
+        'Faro: Cannot start user action'
+        ' - Faro not initialized',
+      );
       return null;
     }
 
@@ -62,9 +64,11 @@ class UserActionsService {
 
     _stateSubscription?.cancel();
     _stateSubscription = userAction.stateChanges
-        .where((state) =>
-            state == UserActionState.ended ||
-            state == UserActionState.cancelled)
+        .where(
+          (state) =>
+              state == UserActionState.ended ||
+              state == UserActionState.cancelled,
+        )
         .take(1)
         .listen((_) => _onActionTerminated(userAction));
 
@@ -120,7 +124,8 @@ class UserActionsService {
 final userActionsServiceProvider = Provider<UserActionsService>((pod) {
   return UserActionsService(
     transportResolver: pod.resolve(batchTransportResolverProvider),
-    lifecycleControllerFactory:
-        pod.resolve(userActionLifecycleControllerFactoryProvider),
+    lifecycleControllerFactory: pod.resolve(
+      userActionLifecycleControllerFactoryProvider,
+    ),
   );
 });

--- a/lib/src/util/timestamp_extension.dart
+++ b/lib/src/util/timestamp_extension.dart
@@ -18,8 +18,10 @@ extension TimestampExtension on String {
 
     try {
       final timestampMs = int.parse(this);
-      final dateTime =
-          DateTime.fromMillisecondsSinceEpoch(timestampMs, isUtc: true);
+      final dateTime = DateTime.fromMillisecondsSinceEpoch(
+        timestampMs,
+        isUtc: true,
+      );
       return dateTime.toIso8601String();
     } catch (error) {
       return 'Invalid timestamp format';

--- a/lib/src/webview/faro_webview_bridge.dart
+++ b/lib/src/webview/faro_webview_bridge.dart
@@ -55,12 +55,14 @@ class FaroWebViewBridge {
     );
     _activeSpan = span;
 
-    return url.replace(queryParameters: {
-      ...url.queryParametersAll,
-      'traceparent': span.traceparent,
-      'session.parent_id': faro.meta.session?.id ?? '',
-      'session.parent_app': faro.meta.app?.name ?? '',
-    });
+    return url.replace(
+      queryParameters: {
+        ...url.queryParametersAll,
+        'traceparent': span.traceparent,
+        'session.parent_id': faro.meta.session?.id ?? '',
+        'session.parent_app': faro.meta.app?.name ?? '',
+      },
+    );
   }
 
   /// Pushes a `session.linked` event that correlates the web app's
@@ -73,18 +75,18 @@ class FaroWebViewBridge {
   /// Call this when the web app sends its Faro session information back
   /// to Flutter (e.g. via a JavaScript channel).
   void linkChildSession({required String sessionId, String? appName}) {
-    Faro().pushEvent('session.linked', attributes: {
-      'session.child_id': sessionId,
-      if (appName != null) 'session.child_app': appName,
-    });
+    Faro().pushEvent(
+      'session.linked',
+      attributes: {
+        'session.child_id': sessionId,
+        if (appName != null) 'session.child_app': appName,
+      },
+    );
   }
 
   /// Ends the active span. Call this when the WebView is disposed or
   /// popped from the navigation stack.
-  void end({
-    SpanStatusCode status = SpanStatusCode.ok,
-    String? message,
-  }) {
+  void end({SpanStatusCode status = SpanStatusCode.ok, String? message}) {
     _endActiveSpan(status, message: message);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"
 
 dependencies:
   connectivity_plus: ">=6.1.2 <8.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,14 +11,14 @@ environment:
 dependencies:
   connectivity_plus: ">=6.1.2 <8.0.0"
   dartypod: ^0.2.0
-  device_info_plus: ^12.3.0
+  device_info_plus: ">=12.3.0 <14.0.0"
   equatable: ^2.0.8
   fixnum: ^1.1.1
   flutter:
     sdk: flutter
   http: ^1.2.2
   opentelemetry: ^0.18.10
-  package_info_plus: ">=8.0.1 <10.0.0"
+  package_info_plus: ">=8.0.1 <11.0.0"
   path_provider: ^2.1.5
   plugin_platform_interface: ^2.0.2
   shared_preferences: ^2.3.3

--- a/test/src/configurations/sampling_test.dart
+++ b/test/src/configurations/sampling_test.dart
@@ -87,10 +87,7 @@ void main() {
 
         // Beta user
         final betaMeta = Meta(
-          user: const FaroUser(
-            id: 'user-123',
-            attributes: {'role': 'beta'},
-          ),
+          user: const FaroUser(id: 'user-123', attributes: {'role': 'beta'}),
         );
         final betaContext = SamplingContext(meta: betaMeta);
         expect(sampling.resolve(betaContext), equals(1.0));

--- a/test/src/data_collection_policy_test.dart
+++ b/test/src/data_collection_policy_test.dart
@@ -16,79 +16,98 @@ void main() {
 
   group('DataCollectionPolicy:', () {
     test('should default to enabled when no previous value is stored', () {
-      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .thenReturn(null);
-      when(() => mockSharedPreferences.setBool(any(), any()))
-          .thenAnswer((_) async => true);
+      when(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).thenReturn(null);
+      when(
+        () => mockSharedPreferences.setBool(any(), any()),
+      ).thenAnswer((_) async => true);
 
       sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
 
       expect(sut.isEnabled, isTrue);
-      verify(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .called(1);
+      verify(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).called(1);
     });
 
     test('should load persisted disabled state', () {
-      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .thenReturn(false);
-      when(() => mockSharedPreferences.setBool(any(), any()))
-          .thenAnswer((_) async => true);
+      when(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).thenReturn(false);
+      when(
+        () => mockSharedPreferences.setBool(any(), any()),
+      ).thenAnswer((_) async => true);
 
       sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
 
       expect(sut.isEnabled, isFalse);
-      verify(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .called(1);
+      verify(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).called(1);
     });
 
     test('should load persisted enabled state', () {
-      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .thenReturn(true);
-      when(() => mockSharedPreferences.setBool(any(), any()))
-          .thenAnswer((_) async => true);
+      when(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).thenReturn(true);
+      when(
+        () => mockSharedPreferences.setBool(any(), any()),
+      ).thenAnswer((_) async => true);
 
       sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
 
       expect(sut.isEnabled, isTrue);
-      verify(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .called(1);
+      verify(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).called(1);
     });
 
     test('should persist enabled state when calling enable()', () async {
-      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .thenReturn(null);
-      when(() => mockSharedPreferences.setBool(any(), any()))
-          .thenAnswer((_) async => true);
+      when(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).thenReturn(null);
+      when(
+        () => mockSharedPreferences.setBool(any(), any()),
+      ).thenAnswer((_) async => true);
 
       sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
 
       await sut.enable();
 
       expect(sut.isEnabled, isTrue);
-      verify(() => mockSharedPreferences.setBool(
-          'faro_enable_data_collection', true)).called(1);
+      verify(
+        () =>
+            mockSharedPreferences.setBool('faro_enable_data_collection', true),
+      ).called(1);
     });
 
     test('should persist disabled state when calling disable()', () async {
-      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .thenReturn(null);
-      when(() => mockSharedPreferences.setBool(any(), any()))
-          .thenAnswer((_) async => true);
+      when(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).thenReturn(null);
+      when(
+        () => mockSharedPreferences.setBool(any(), any()),
+      ).thenAnswer((_) async => true);
 
       sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
 
       await sut.disable();
 
       expect(sut.isEnabled, isFalse);
-      verify(() => mockSharedPreferences.setBool(
-          'faro_enable_data_collection', false)).called(1);
+      verify(
+        () =>
+            mockSharedPreferences.setBool('faro_enable_data_collection', false),
+      ).called(1);
     });
 
     test('should persist state change from enabled to disabled', () async {
-      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .thenReturn(true);
-      when(() => mockSharedPreferences.setBool(any(), any()))
-          .thenAnswer((_) async => true);
+      when(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).thenReturn(true);
+      when(
+        () => mockSharedPreferences.setBool(any(), any()),
+      ).thenAnswer((_) async => true);
 
       sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
 
@@ -97,15 +116,19 @@ void main() {
       await sut.disable();
 
       expect(sut.isEnabled, isFalse);
-      verify(() => mockSharedPreferences.setBool(
-          'faro_enable_data_collection', false)).called(1);
+      verify(
+        () =>
+            mockSharedPreferences.setBool('faro_enable_data_collection', false),
+      ).called(1);
     });
 
     test('should persist state change from disabled to enabled', () async {
-      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .thenReturn(false);
-      when(() => mockSharedPreferences.setBool(any(), any()))
-          .thenAnswer((_) async => true);
+      when(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).thenReturn(false);
+      when(
+        () => mockSharedPreferences.setBool(any(), any()),
+      ).thenAnswer((_) async => true);
 
       sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
 
@@ -114,15 +137,19 @@ void main() {
       await sut.enable();
 
       expect(sut.isEnabled, isTrue);
-      verify(() => mockSharedPreferences.setBool(
-          'faro_enable_data_collection', true)).called(1);
+      verify(
+        () =>
+            mockSharedPreferences.setBool('faro_enable_data_collection', true),
+      ).called(1);
     });
 
     test('should handle SharedPreferences setBool errors gracefully', () async {
-      when(() => mockSharedPreferences.getBool('faro_enable_data_collection'))
-          .thenReturn(null);
-      when(() => mockSharedPreferences.setBool(any(), any()))
-          .thenThrow(Exception('Storage failed'));
+      when(
+        () => mockSharedPreferences.getBool('faro_enable_data_collection'),
+      ).thenReturn(null);
+      when(
+        () => mockSharedPreferences.setBool(any(), any()),
+      ).thenThrow(Exception('Storage failed'));
 
       sut = DataCollectionPolicy(sharedPreferences: mockSharedPreferences);
 
@@ -131,8 +158,10 @@ void main() {
 
       // State should still be updated in memory
       expect(sut.isEnabled, isTrue);
-      verify(() => mockSharedPreferences.setBool(
-          'faro_enable_data_collection', true)).called(1);
+      verify(
+        () =>
+            mockSharedPreferences.setBool('faro_enable_data_collection', true),
+      ).called(1);
     });
   });
 

--- a/test/src/device_info/device_id_provider_test.dart
+++ b/test/src/device_info/device_id_provider_test.dart
@@ -19,8 +19,9 @@ void main() {
     mockUuidProvider = MockUuidProvider();
 
     when(() => mockSharedPreferences.getString(any())).thenReturn(null);
-    when(() => mockSharedPreferences.setString(any(), any()))
-        .thenAnswer((_) async => true);
+    when(
+      () => mockSharedPreferences.setString(any(), any()),
+    ).thenAnswer((_) async => true);
 
     sut = DeviceIdProvider(
       sharedPreferences: mockSharedPreferences,
@@ -44,9 +45,9 @@ void main() {
 
     test('should return stored uuid when stored before', () async {
       const expectedUuid = 'stored-some-random-uuid';
-      when(() => mockSharedPreferences.getString(any())).thenReturn(
-        expectedUuid,
-      );
+      when(
+        () => mockSharedPreferences.getString(any()),
+      ).thenReturn(expectedUuid);
 
       final deviceId = await sut.getDeviceId();
 
@@ -56,18 +57,19 @@ void main() {
     });
 
     test(
-        'should return cached version of stored uuid when called a second time',
-        () async {
-      const expectedUuid = 'cached-stored-some-random-uuid';
-      when(() => mockSharedPreferences.getString(any())).thenReturn(
-        expectedUuid,
-      );
+      'should return cached version of stored uuid when called a second time',
+      () async {
+        const expectedUuid = 'cached-stored-some-random-uuid';
+        when(
+          () => mockSharedPreferences.getString(any()),
+        ).thenReturn(expectedUuid);
 
-      var deviceId = await sut.getDeviceId();
-      deviceId = await sut.getDeviceId();
+        var deviceId = await sut.getDeviceId();
+        deviceId = await sut.getDeviceId();
 
-      expect('$deviceId', expectedUuid);
-      verify(() => mockSharedPreferences.getString(any())).called(1);
-    });
+        expect('$deviceId', expectedUuid);
+        verify(() => mockSharedPreferences.getString(any())).called(1);
+      },
+    );
   });
 }

--- a/test/src/device_info/device_info_provider_test.dart
+++ b/test/src/device_info/device_info_provider_test.dart
@@ -30,18 +30,20 @@ void main() {
     mockIosDeviceInfo = MockIosDeviceInfo();
     mockPlatformInfoProvider = MockPlatformInfoProvider();
 
-    when(() => mockDeviceInfoPlugin.androidInfo).thenAnswer(
-      (_) async => mockAndroidDeviceInfo,
-    );
-    when(() => mockDeviceInfoPlugin.iosInfo).thenAnswer(
-      (_) async => mockIosDeviceInfo,
-    );
+    when(
+      () => mockDeviceInfoPlugin.androidInfo,
+    ).thenAnswer((_) async => mockAndroidDeviceInfo);
+    when(
+      () => mockDeviceInfoPlugin.iosInfo,
+    ).thenAnswer((_) async => mockIosDeviceInfo);
 
-    when(() => mockPlatformInfoProvider.dartVersion)
-        .thenReturn('Some-dart-version');
+    when(
+      () => mockPlatformInfoProvider.dartVersion,
+    ).thenReturn('Some-dart-version');
     when(() => mockPlatformInfoProvider.operatingSystem).thenReturn('Some-OS');
-    when(() => mockPlatformInfoProvider.operatingSystemVersion)
-        .thenReturn('Some-OS-version');
+    when(
+      () => mockPlatformInfoProvider.operatingSystemVersion,
+    ).thenReturn('Some-OS-version');
 
     sut = DeviceInfoProvider(
       deviceInfoPlugin: mockDeviceInfoPlugin,
@@ -58,8 +60,9 @@ void main() {
       when(() => mockAndroidBuildVersion.release).thenReturn('11');
       when(() => mockAndroidBuildVersion.sdkInt).thenReturn(30);
 
-      when(() => mockAndroidDeviceInfo.version)
-          .thenReturn(mockAndroidBuildVersion);
+      when(
+        () => mockAndroidDeviceInfo.version,
+      ).thenReturn(mockAndroidBuildVersion);
       when(() => mockAndroidDeviceInfo.manufacturer).thenReturn('Google');
       when(() => mockAndroidDeviceInfo.model).thenReturn('Pixel 4');
       when(() => mockAndroidDeviceInfo.brand).thenReturn('Google');
@@ -106,22 +109,24 @@ void main() {
       expect(deviceInfo.deviceIsPhysical, true);
     });
 
-    test('should return correct device info when not iOS and not Android',
-        () async {
-      when(() => mockPlatformInfoProvider.isAndroid).thenReturn(false);
-      when(() => mockPlatformInfoProvider.isIOS).thenReturn(false);
+    test(
+      'should return correct device info when not iOS and not Android',
+      () async {
+        when(() => mockPlatformInfoProvider.isAndroid).thenReturn(false);
+        when(() => mockPlatformInfoProvider.isIOS).thenReturn(false);
 
-      final deviceInfo = await sut.getDeviceInfo();
+        final deviceInfo = await sut.getDeviceInfo();
 
-      expect(deviceInfo.dartVersion, 'Some-dart-version');
-      expect(deviceInfo.deviceOs, 'Some-OS');
-      expect(deviceInfo.deviceOsVersion, 'Some-OS-version');
-      expect(deviceInfo.deviceOsDetail, 'unknown');
-      expect(deviceInfo.deviceManufacturer, 'unknown');
-      expect(deviceInfo.deviceModel, 'unknown');
-      expect(deviceInfo.deviceModelName, 'unknown');
-      expect(deviceInfo.deviceBrand, 'unknown');
-      expect(deviceInfo.deviceIsPhysical, true);
-    });
+        expect(deviceInfo.dartVersion, 'Some-dart-version');
+        expect(deviceInfo.deviceOs, 'Some-OS');
+        expect(deviceInfo.deviceOsVersion, 'Some-OS-version');
+        expect(deviceInfo.deviceOsDetail, 'unknown');
+        expect(deviceInfo.deviceManufacturer, 'unknown');
+        expect(deviceInfo.deviceModel, 'unknown');
+        expect(deviceInfo.deviceModelName, 'unknown');
+        expect(deviceInfo.deviceBrand, 'unknown');
+        expect(deviceInfo.deviceIsPhysical, true);
+      },
+    );
   });
 }

--- a/test/src/device_info/session_attributes_provider_test.dart
+++ b/test/src/device_info/session_attributes_provider_test.dart
@@ -27,20 +27,22 @@ void main() {
 
   group('SessionAttributesProvider:', () {
     test('should return correct attributes', () async {
-      when(() => mockDeviceInfoProvider.getDeviceInfo())
-          .thenAnswer((_) async => DeviceInfo(
-                dartVersion: 'Some-dart-version',
-                deviceOs: 'Some-OS',
-                deviceOsVersion: 'Some-OS-version',
-                deviceOsDetail: 'Some-OS-detail',
-                deviceManufacturer: 'Some-manufacturer',
-                deviceModel: 'Some-model',
-                deviceModelName: 'Some-model-name',
-                deviceBrand: 'Some-brand',
-                deviceIsPhysical: true,
-              ));
-      when(() => mockDeviceIdProvider.getDeviceId())
-          .thenAnswer((_) async => DeviceId('device-id'));
+      when(() => mockDeviceInfoProvider.getDeviceInfo()).thenAnswer(
+        (_) async => DeviceInfo(
+          dartVersion: 'Some-dart-version',
+          deviceOs: 'Some-OS',
+          deviceOsVersion: 'Some-OS-version',
+          deviceOsDetail: 'Some-OS-detail',
+          deviceManufacturer: 'Some-manufacturer',
+          deviceModel: 'Some-model',
+          deviceModelName: 'Some-model-name',
+          deviceBrand: 'Some-brand',
+          deviceIsPhysical: true,
+        ),
+      );
+      when(
+        () => mockDeviceIdProvider.getDeviceId(),
+      ).thenAnswer((_) async => DeviceId('device-id'));
 
       final attributes = await sut.getAttributes();
 

--- a/test/src/faro_asset_bundle_test.dart
+++ b/test/src/faro_asset_bundle_test.dart
@@ -12,10 +12,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _FakeAssetBundle extends AssetBundle {
-  _FakeAssetBundle({
-    this.throwOnLoad = false,
-    this.throwOnLoadString = false,
-  });
+  _FakeAssetBundle({this.throwOnLoad = false, this.throwOnLoadString = false});
 
   final bool throwOnLoad;
   final bool throwOnLoadString;
@@ -182,24 +179,26 @@ void main() {
       expect(result, 'hello');
     });
 
-    test('loadString emits pending signals even when asset loading throws',
-        () async {
-      final bundle = FaroAssetBundle(
-        bundle: _FakeAssetBundle(throwOnLoadString: true),
-        lifecycleSignalChannel: signalChannel,
-      );
+    test(
+      'loadString emits pending signals even when asset loading throws',
+      () async {
+        final bundle = FaroAssetBundle(
+          bundle: _FakeAssetBundle(throwOnLoadString: true),
+          lifecycleSignalChannel: signalChannel,
+        );
 
-      await expectLater(
-        () => bundle.loadString('assets/missing.txt'),
-        throwsException,
-      );
-      await Future<void>.delayed(Duration.zero);
+        await expectLater(
+          () => bundle.loadString('assets/missing.txt'),
+          throwsException,
+        );
+        await Future<void>.delayed(Duration.zero);
 
-      expect(emittedSignals, hasLength(2));
-      expect(emittedSignals[0].type, UserActionSignalType.pendingStart);
-      expect(emittedSignals[1].type, UserActionSignalType.pendingEnd);
-      expect(emittedSignals[1].operationId, emittedSignals[0].operationId);
-    });
+        expect(emittedSignals, hasLength(2));
+        expect(emittedSignals[0].type, UserActionSignalType.pendingStart);
+        expect(emittedSignals[1].type, UserActionSignalType.pendingEnd);
+        expect(emittedSignals[1].operationId, emittedSignals[0].operationId);
+      },
+    );
 
     test('loadStructuredData emits pending lifecycle signals', () async {
       final bundle = FaroAssetBundle(
@@ -228,8 +227,7 @@ void main() {
       expect(emittedSignals[1].operationId, emittedSignals[0].operationId);
     });
 
-    test(
-        'loadStructuredData passes raw string to parser and returns '
+    test('loadStructuredData passes raw string to parser and returns '
         'the parsed result', () async {
       final bundle = FaroAssetBundle(
         bundle: _FakeAssetBundle(),
@@ -283,8 +281,7 @@ void main() {
       expect(emittedSignals[1].operationId, emittedSignals[0].operationId);
     });
 
-    test(
-        'loadStructuredBinaryData passes raw data to parser and '
+    test('loadStructuredBinaryData passes raw data to parser and '
         'returns the parsed result', () async {
       final bundle = FaroAssetBundle(
         bundle: _FakeAssetBundle(),
@@ -333,10 +330,7 @@ void main() {
     test('long asset load keeps a user action alive until completion', () {
       fakeAsync((async) {
         final loadStringCompleter = Completer<String>();
-        final action = UserAction(
-          name: 'asset-load-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'asset-load-action', trigger: 'test');
         final controller = UserActionLifecycleController(
           action,
           signalChannel.stream,

--- a/test/src/faro_asset_tracking_integration_test.dart
+++ b/test/src/faro_asset_tracking_integration_test.dart
@@ -81,8 +81,7 @@ void main() {
     BatchTransportFactory().reset();
   });
 
-  testWidgets(
-      'asset load through FaroAssetTracking pushes Asset-load event '
+  testWidgets('asset load through FaroAssetTracking pushes Asset-load event '
       'to transport', (tester) async {
     await initializeFaro();
 
@@ -115,8 +114,7 @@ void main() {
     expect(hasAssetLoadEvent, isTrue);
   });
 
-  testWidgets(
-      'asset load during active user action emits activity signal '
+  testWidgets('asset load during active user action emits activity signal '
       'that keeps the action alive', (tester) async {
     await initializeFaro();
 

--- a/test/src/integrations/flutter_error_integration_test.dart
+++ b/test/src/integrations/flutter_error_integration_test.dart
@@ -27,7 +27,8 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(
-          FlutterErrorDetails(exception: FlutterError('Fallback Error')));
+        FlutterErrorDetails(exception: FlutterError('Fallback Error')),
+      );
       registerFallbackValue(FaroException('exception', 'test exception', {}));
     });
 
@@ -35,11 +36,13 @@ void main() {
       mockBatchTransport = MockBatchTransport();
       mockFunctions = MockFunctions();
       Faro().batchTransport = mockBatchTransport;
-      when(() => mockBatchTransport.addExceptions(any()))
-          .thenAnswer((_) async {});
+      when(
+        () => mockBatchTransport.addExceptions(any()),
+      ).thenAnswer((_) async {});
       flutterErrorDetails = FlutterErrorDetails(
-          exception: FlutterError('Test Error'),
-          stack: StackTrace.fromString('Test Stack Trace'));
+        exception: FlutterError('Test Error'),
+        stack: StackTrace.fromString('Test Stack Trace'),
+      );
     });
 
     tearDown(() {});
@@ -61,13 +64,14 @@ void main() {
     });
 
     test(
-        'Closing Flutter Error Integration sets back the default error handler',
-        () {
-      final flutterErrorIntegration = FlutterErrorIntegration();
-      FlutterError.onError = mockFunctions.defaultOnError;
-      flutterErrorIntegration.call();
-      flutterErrorIntegration.close();
-      expect(FlutterError.onError, mockFunctions.defaultOnError);
-    });
+      'Closing Flutter Error Integration sets back the default error handler',
+      () {
+        final flutterErrorIntegration = FlutterErrorIntegration();
+        FlutterError.onError = mockFunctions.defaultOnError;
+        flutterErrorIntegration.call();
+        flutterErrorIntegration.close();
+        expect(FlutterError.onError, mockFunctions.defaultOnError);
+      },
+    );
   });
 }

--- a/test/src/integrations/http_tracking_client_test.dart
+++ b/test/src/integrations/http_tracking_client_test.dart
@@ -33,8 +33,9 @@ void main() {
 
       when(() => mockHttpClientRequest.method).thenReturn('GET');
       when(() => mockHttpClientRequest.headers).thenReturn(mockRequestHeaders);
-      when(() => mockHttpClientRequest.uri)
-          .thenReturn(Uri.parse('http://example.com/path'));
+      when(
+        () => mockHttpClientRequest.uri,
+      ).thenReturn(Uri.parse('http://example.com/path'));
       when(() => mockRequestHeaders.add(any(), any())).thenReturn(null);
 
       client = FaroHttpTrackingClient(
@@ -50,8 +51,9 @@ void main() {
       );
 
       final url = Uri.parse('http://example.com/path');
-      when(() => mockHttpClient.openUrl('GET', url))
-          .thenAnswer((_) async => mockHttpClientRequest);
+      when(
+        () => mockHttpClient.openUrl('GET', url),
+      ).thenAnswer((_) async => mockHttpClientRequest);
 
       final request = await client.openUrl('GET', url);
 
@@ -63,8 +65,9 @@ void main() {
       trackingFilter.configure(collectorUrl: null, ignoreUrls: null);
 
       final url = Uri.parse('http://example.com/path');
-      when(() => mockHttpClient.openUrl('GET', url))
-          .thenAnswer((_) async => mockHttpClientRequest);
+      when(
+        () => mockHttpClient.openUrl('GET', url),
+      ).thenAnswer((_) async => mockHttpClientRequest);
 
       final request = await client.openUrl('GET', url);
       await Future<void>.delayed(Duration.zero);
@@ -76,8 +79,9 @@ void main() {
       trackingFilter.configure(collectorUrl: null, ignoreUrls: null);
 
       final url = Uri.parse('http://example.com/path');
-      when(() => mockHttpClient.openUrl('GET', url))
-          .thenThrow(const SocketException('boom'));
+      when(
+        () => mockHttpClient.openUrl('GET', url),
+      ).thenThrow(const SocketException('boom'));
 
       await expectLater(
         () => client.openUrl('GET', url),
@@ -105,8 +109,9 @@ void main() {
       when(() => mockSpan.spanId).thenReturn('span-id');
       when(() => mockSpan.traceparent).thenReturn('00-trace-id-span-id-01');
       when(() => mockHttpClientRequest.method).thenReturn('GET');
-      when(() => mockHttpClientRequest.uri)
-          .thenReturn(Uri.parse('http://example.com/path'));
+      when(
+        () => mockHttpClientRequest.uri,
+      ).thenReturn(Uri.parse('http://example.com/path'));
       when(() => mockHttpClientRequest.contentLength).thenReturn(42);
       when(() => mockHttpClientRequest.headers).thenReturn(mockRequestHeaders);
 
@@ -117,11 +122,13 @@ void main() {
     });
 
     test('close should end span on success when response completes', () async {
-      when(() => mockHttpClientRequest.close())
-          .thenAnswer((_) async => mockHttpClientResponse);
+      when(
+        () => mockHttpClientRequest.close(),
+      ).thenAnswer((_) async => mockHttpClientResponse);
       when(() => mockHttpClientResponse.statusCode).thenReturn(200);
-      when(() => mockHttpClientResponse.headers)
-          .thenReturn(mockResponseHeaders);
+      when(
+        () => mockHttpClientResponse.headers,
+      ).thenReturn(mockResponseHeaders);
       when(() => mockResponseHeaders.contentLength).thenReturn(128);
       when(() => mockResponseHeaders.contentType).thenReturn(null);
       when(
@@ -148,13 +155,11 @@ void main() {
     });
 
     test('close should end span on error', () async {
-      when(() => mockHttpClientRequest.close())
-          .thenThrow(const SocketException('close failed'));
+      when(
+        () => mockHttpClientRequest.close(),
+      ).thenThrow(const SocketException('close failed'));
 
-      await expectLater(
-        trackedRequest.close,
-        throwsA(isA<Exception>()),
-      );
+      await expectLater(trackedRequest.close, throwsA(isA<Exception>()));
       await Future<void>.delayed(Duration.zero);
 
       verify(
@@ -167,11 +172,13 @@ void main() {
     });
 
     test('done should wrap response and end span on completion', () async {
-      when(() => mockHttpClientRequest.done)
-          .thenAnswer((_) async => mockHttpClientResponse);
+      when(
+        () => mockHttpClientRequest.done,
+      ).thenAnswer((_) async => mockHttpClientResponse);
       when(() => mockHttpClientResponse.statusCode).thenReturn(200);
-      when(() => mockHttpClientResponse.headers)
-          .thenReturn(mockResponseHeaders);
+      when(
+        () => mockHttpClientResponse.headers,
+      ).thenReturn(mockResponseHeaders);
       when(() => mockResponseHeaders.contentLength).thenReturn(128);
       when(() => mockResponseHeaders.contentType).thenReturn(null);
       when(
@@ -212,8 +219,9 @@ void main() {
           message: any(named: 'message'),
         ),
       ).called(1);
-      verify(() => mockSpan.recordException(error, stackTrace: stackTrace))
-          .called(1);
+      verify(
+        () => mockSpan.recordException(error, stackTrace: stackTrace),
+      ).called(1);
       verify(() => mockSpan.end()).called(1);
     });
   });
@@ -239,15 +247,18 @@ void main() {
       when(() => mockSpan.spanId).thenReturn('span-id');
       when(() => mockSpan.traceparent).thenReturn('00-trace-id-span-id-01');
       when(() => mockHttpClientRequest.method).thenReturn('GET');
-      when(() => mockHttpClientRequest.uri)
-          .thenReturn(Uri.parse('http://example.com/path'));
+      when(
+        () => mockHttpClientRequest.uri,
+      ).thenReturn(Uri.parse('http://example.com/path'));
       when(() => mockHttpClientRequest.contentLength).thenReturn(42);
       when(() => mockHttpClientRequest.headers).thenReturn(mockRequestHeaders);
-      when(() => mockHttpClientRequest.close())
-          .thenAnswer((_) async => mockHttpClientResponse);
+      when(
+        () => mockHttpClientRequest.close(),
+      ).thenAnswer((_) async => mockHttpClientResponse);
       when(() => mockHttpClientResponse.statusCode).thenReturn(200);
-      when(() => mockHttpClientResponse.headers)
-          .thenReturn(mockResponseHeaders);
+      when(
+        () => mockHttpClientResponse.headers,
+      ).thenReturn(mockResponseHeaders);
       when(() => mockResponseHeaders.contentLength).thenReturn(128);
       when(() => mockResponseHeaders.contentType).thenReturn(null);
       when(
@@ -305,41 +316,42 @@ void main() {
 
       subscription.onError(errors.add);
 
-      responseStreamController.addError(
-        StateError('boom'),
-        StackTrace.current,
-      );
+      responseStreamController.addError(StateError('boom'), StackTrace.current);
       await Future<void>.delayed(Duration.zero);
 
-      verify(() => mockSpan.setStatus(
-            SpanStatusCode.error,
-            message: any(named: 'message'),
-          )).called(1);
+      verify(
+        () => mockSpan.setStatus(
+          SpanStatusCode.error,
+          message: any(named: 'message'),
+        ),
+      ).called(1);
       verify(() => mockSpan.end()).called(1);
       expect(errors, hasLength(1));
     });
 
-    test('replacing onError with two-arg handler should forward both args',
-        () async {
-      final response = await trackedRequest.close();
-      final errors = <Object>[];
-      final traces = <StackTrace>[];
-      // ignore: cancel_subscriptions
-      final subscription = response.listen((_) {});
+    test(
+      'replacing onError with two-arg handler should forward both args',
+      () async {
+        final response = await trackedRequest.close();
+        final errors = <Object>[];
+        final traces = <StackTrace>[];
+        // ignore: cancel_subscriptions
+        final subscription = response.listen((_) {});
 
-      subscription.onError((Object e, StackTrace st) {
-        errors.add(e);
-        traces.add(st);
-      });
+        subscription.onError((Object e, StackTrace st) {
+          errors.add(e);
+          traces.add(st);
+        });
 
-      final testTrace = StackTrace.current;
-      responseStreamController.addError(StateError('boom'), testTrace);
-      await Future<void>.delayed(Duration.zero);
+        final testTrace = StackTrace.current;
+        responseStreamController.addError(StateError('boom'), testTrace);
+        await Future<void>.delayed(Duration.zero);
 
-      verify(() => mockSpan.end()).called(1);
-      expect(errors, hasLength(1));
-      expect(traces, hasLength(1));
-    });
+        verify(() => mockSpan.end()).called(1);
+        expect(errors, hasLength(1));
+        expect(traces, hasLength(1));
+      },
+    );
 
     test('replacing onDone with null should still end span', () async {
       final response = await trackedRequest.close();
@@ -357,17 +369,11 @@ void main() {
     test('replacing onError with null should still end span', () async {
       final response = await trackedRequest.close();
       // ignore: cancel_subscriptions
-      final subscription = response.listen(
-        (_) {},
-        onError: (Object e) {},
-      );
+      final subscription = response.listen((_) {}, onError: (Object e) {});
 
       subscription.onError(null);
 
-      responseStreamController.addError(
-        StateError('boom'),
-        StackTrace.current,
-      );
+      responseStreamController.addError(StateError('boom'), StackTrace.current);
       await Future<void>.delayed(Duration.zero);
 
       verify(() => mockSpan.end()).called(1);
@@ -393,16 +399,15 @@ void main() {
 
       final future = subscription.asFuture<void>();
 
-      responseStreamController.addError(
-        StateError('boom'),
-        StackTrace.current,
-      );
+      responseStreamController.addError(StateError('boom'), StackTrace.current);
 
       await expectLater(future, throwsA(isA<StateError>()));
-      verify(() => mockSpan.setStatus(
-            SpanStatusCode.error,
-            message: any(named: 'message'),
-          )).called(1);
+      verify(
+        () => mockSpan.setStatus(
+          SpanStatusCode.error,
+          message: any(named: 'message'),
+        ),
+      ).called(1);
       verify(() => mockSpan.end()).called(1);
     });
   });

--- a/test/src/integrations/http_tracking_filter_test.dart
+++ b/test/src/integrations/http_tracking_filter_test.dart
@@ -48,10 +48,7 @@ void main() {
       test('should track all URLs when collector URL is null', () {
         filter.configure(collectorUrl: null, ignoreUrls: null);
 
-        expect(
-          filter.shouldTrack(Uri.parse('https://anything.com')),
-          isTrue,
-        );
+        expect(filter.shouldTrack(Uri.parse('https://anything.com')), isTrue);
       });
     });
 
@@ -63,9 +60,7 @@ void main() {
         );
 
         expect(
-          filter.shouldTrack(
-            Uri.parse('https://analytics.example.com/track'),
-          ),
+          filter.shouldTrack(Uri.parse('https://analytics.example.com/track')),
           isFalse,
         );
       });
@@ -92,15 +87,11 @@ void main() {
         );
 
         expect(
-          filter.shouldTrack(
-            Uri.parse('https://analytics.example.com/event'),
-          ),
+          filter.shouldTrack(Uri.parse('https://analytics.example.com/event')),
           isFalse,
         );
         expect(
-          filter.shouldTrack(
-            Uri.parse('https://tracking.vendor.io/pixel'),
-          ),
+          filter.shouldTrack(Uri.parse('https://tracking.vendor.io/pixel')),
           isFalse,
         );
         expect(
@@ -112,19 +103,13 @@ void main() {
       test('should track all URLs when ignoreUrls is null', () {
         filter.configure(collectorUrl: null, ignoreUrls: null);
 
-        expect(
-          filter.shouldTrack(Uri.parse('https://anything.com')),
-          isTrue,
-        );
+        expect(filter.shouldTrack(Uri.parse('https://anything.com')), isTrue);
       });
 
       test('should track all URLs when ignoreUrls is empty', () {
         filter.configure(collectorUrl: null, ignoreUrls: []);
 
-        expect(
-          filter.shouldTrack(Uri.parse('https://anything.com')),
-          isTrue,
-        );
+        expect(filter.shouldTrack(Uri.parse('https://anything.com')), isTrue);
       });
     });
 
@@ -142,9 +127,7 @@ void main() {
           isFalse,
         );
         expect(
-          filter.shouldTrack(
-            Uri.parse('https://analytics.example.com/track'),
-          ),
+          filter.shouldTrack(Uri.parse('https://analytics.example.com/track')),
           isFalse,
         );
         expect(

--- a/test/src/integrations/native_integration_test.dart
+++ b/test/src/integrations/native_integration_test.dart
@@ -20,8 +20,9 @@ void main() {
     nativeIntegration = NativeIntegration();
 
     when(() => mockFaro.nativeChannel).thenReturn(mockNativeChannel);
-    when(() => mockNativeChannel.getMemoryUsage())
-        .thenAnswer((_) async => 50.0);
+    when(
+      () => mockNativeChannel.getMemoryUsage(),
+    ).thenAnswer((_) async => 50.0);
     when(() => mockNativeChannel.initRefreshRate()).thenAnswer((_) async {});
 
     Faro.instance = mockFaro;

--- a/test/src/integrations/on_error_integration_test.dart
+++ b/test/src/integrations/on_error_integration_test.dart
@@ -30,7 +30,7 @@ void main() {
   });
 
   test('call method sets up error integration correctly', () {
-    when(() => mockPlatformDispatcher.onError).thenReturn((_, __) => true);
+    when(() => mockPlatformDispatcher.onError).thenReturn((_, _) => true);
 
     final result = onErrorIntegration.isOnErrorSupported();
 
@@ -58,7 +58,7 @@ void main() {
   });
 
   test('isOnErrorSupported returns true when onError is supported', () {
-    when(() => mockPlatformDispatcher.onError).thenReturn((_, __) => true);
+    when(() => mockPlatformDispatcher.onError).thenReturn((_, _) => true);
 
     final result = onErrorIntegration.isOnErrorSupported();
 

--- a/test/src/integrations/on_error_integration_test.dart
+++ b/test/src/integrations/on_error_integration_test.dart
@@ -25,8 +25,9 @@ void main() {
 
   setUp(() {
     mockPlatformDispatcher = MockPlatformDispatcher();
-    onErrorIntegration =
-        OnErrorIntegration(platformDispatcher: mockPlatformDispatcher);
+    onErrorIntegration = OnErrorIntegration(
+      platformDispatcher: mockPlatformDispatcher,
+    );
   });
 
   test('call method sets up error integration correctly', () {
@@ -38,11 +39,12 @@ void main() {
   });
 
   test('isOnErrorSupported returns false when onError is not supported', () {
-    when(() => mockPlatformDispatcher.onError)
-        .thenThrow(NoSuchMethodError.withInvocation(
-      mockPlatformDispatcher,
-      Invocation.getter(#onError),
-    ));
+    when(() => mockPlatformDispatcher.onError).thenThrow(
+      NoSuchMethodError.withInvocation(
+        mockPlatformDispatcher,
+        Invocation.getter(#onError),
+      ),
+    );
 
     final result = onErrorIntegration.isOnErrorSupported();
 

--- a/test/src/models/exception_test.dart
+++ b/test/src/models/exception_test.dart
@@ -40,12 +40,9 @@ void main() {
     });
 
     test('should create a FaroException with null context', () {
-      final exception = FaroException(
-        'error_type',
-        'Error message',
-        {'frames': '[]'},
-        context: null,
-      );
+      final exception = FaroException('error_type', 'Error message', {
+        'frames': '[]',
+      }, context: null);
 
       expect(exception.type, equals('error_type'));
       expect(exception.value, equals('Error message'));

--- a/test/src/models/faro_user_test.dart
+++ b/test/src/models/faro_user_test.dart
@@ -105,11 +105,7 @@ void main() {
       });
 
       test('should create from JSON with null properties', () {
-        final json = {
-          'id': 'user-123',
-          'username': null,
-          'email': null,
-        };
+        final json = {'id': 'user-123', 'username': null, 'email': null};
 
         final user = FaroUser.fromJson(json);
 
@@ -202,15 +198,9 @@ void main() {
       });
 
       test('should include attributes in toString when present', () {
-        const user = FaroUser(
-          id: 'user-123',
-          attributes: {'role': 'admin'},
-        );
+        const user = FaroUser(id: 'user-123', attributes: {'role': 'admin'});
 
-        expect(
-          user.toString(),
-          contains('attributes: {role: admin}'),
-        );
+        expect(user.toString(), contains('attributes: {role: admin}'));
       });
     });
 
@@ -226,9 +216,7 @@ void main() {
       });
 
       test('should have hasData true with only attributes', () {
-        const user = FaroUser(
-          attributes: {'role': 'admin'},
-        );
+        const user = FaroUser(attributes: {'role': 'admin'});
 
         expect(user.id, isNull);
         expect(user.username, isNull);
@@ -238,9 +226,7 @@ void main() {
       });
 
       test('should have hasData false with empty attributes', () {
-        const user = FaroUser(
-          attributes: {},
-        );
+        const user = FaroUser(attributes: {});
 
         expect(user.hasData, isFalse);
       });
@@ -276,10 +262,7 @@ void main() {
       });
 
       test('should handle missing attributes in JSON (backward compat)', () {
-        final json = {
-          'id': 'user-123',
-          'username': 'john.doe',
-        };
+        final json = {'id': 'user-123', 'username': 'john.doe'};
 
         final user = FaroUser.fromJson(json);
 
@@ -301,18 +284,9 @@ void main() {
       });
 
       test('should compare attributes in equality', () {
-        const user1 = FaroUser(
-          id: 'user-123',
-          attributes: {'role': 'admin'},
-        );
-        const user2 = FaroUser(
-          id: 'user-123',
-          attributes: {'role': 'admin'},
-        );
-        const user3 = FaroUser(
-          id: 'user-123',
-          attributes: {'role': 'user'},
-        );
+        const user1 = FaroUser(id: 'user-123', attributes: {'role': 'admin'});
+        const user2 = FaroUser(id: 'user-123', attributes: {'role': 'admin'});
+        const user3 = FaroUser(id: 'user-123', attributes: {'role': 'user'});
 
         expect(user1, equals(user2));
         expect(user1, isNot(equals(user3)));

--- a/test/src/models/measurement_test.dart
+++ b/test/src/models/measurement_test.dart
@@ -6,10 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Measurement:', () {
     test('should create a measurement with valid values', () {
-      final measurement = Measurement(
-        {'cpu': 50.0, 'memory': 100.0},
-        'device',
-      );
+      final measurement = Measurement({'cpu': 50.0, 'memory': 100.0}, 'device');
 
       expect(measurement.values, isNotNull);
       expect(measurement.values!['cpu'], 50.0);
@@ -19,10 +16,7 @@ void main() {
     });
 
     test('should handle null values', () {
-      final measurement = Measurement(
-        null,
-        'device',
-      );
+      final measurement = Measurement(null, 'device');
 
       expect(measurement.values, isNotNull);
       expect(measurement.values, <String, dynamic>{});
@@ -31,15 +25,12 @@ void main() {
     });
 
     test('should ignore infinity and NaN values', () {
-      final measurement = Measurement(
-        {
-          'infinity': double.infinity,
-          'negativeInfinity': double.negativeInfinity,
-          'nan': double.nan,
-          'valid': 42.0,
-        },
-        'device',
-      );
+      final measurement = Measurement({
+        'infinity': double.infinity,
+        'negativeInfinity': double.negativeInfinity,
+        'nan': double.nan,
+        'valid': 42.0,
+      }, 'device');
 
       expect(measurement.values, isNotNull);
       // Infinity, negative infinity, and NaN values should be ignored
@@ -51,13 +42,10 @@ void main() {
     });
 
     test('should handle very large finite double values correctly', () {
-      final measurement = Measurement(
-        {
-          'largeValue': double.maxFinite,
-          'smallValue': double.minPositive,
-        },
-        'device',
-      );
+      final measurement = Measurement({
+        'largeValue': double.maxFinite,
+        'smallValue': double.minPositive,
+      }, 'device');
 
       expect(measurement.values, isNotNull);
       expect(measurement.values!['largeValue'], double.maxFinite);
@@ -66,30 +54,26 @@ void main() {
 
     test('should handle non-encodable objects that are not numeric types', () {
       // Create a custom class that will fail JSON encoding
-      final measurement = Measurement(
-        {
-          'nonEncodableObject': _JsonUnencodableObject(),
-          'regularInt': 42,
-        },
-        'device',
-      );
+      final measurement = Measurement({
+        'nonEncodableObject': _JsonUnencodableObject(),
+        'regularInt': 42,
+      }, 'device');
 
       expect(measurement.values, isNotNull);
       expect(
-          measurement.values!['nonEncodableObject'], 'JsonUnencodableObject');
+        measurement.values!['nonEncodableObject'],
+        'JsonUnencodableObject',
+      );
       expect(measurement.values!['regularInt'], 42);
     });
 
     test('should convert non-encodable objects to string representation', () {
       // Create a class that cannot be JSON encoded
       final nonEncodable = _NonEncodable();
-      final measurement = Measurement(
-        {
-          'nonEncodable': nonEncodable,
-          'valid': 42.0,
-        },
-        'device',
-      );
+      final measurement = Measurement({
+        'nonEncodable': nonEncodable,
+        'valid': 42.0,
+      }, 'device');
 
       expect(measurement.values, isNotNull);
       expect(measurement.values!['nonEncodable'], 'NonEncodable object');
@@ -97,15 +81,12 @@ void main() {
     });
 
     test('toJson output should be JSON encodable', () {
-      final measurement = Measurement(
-        {
-          'infinity': double.infinity,
-          'negativeInfinity': double.negativeInfinity,
-          'nan': double.nan,
-          'valid': 42.0,
-        },
-        'device',
-      );
+      final measurement = Measurement({
+        'infinity': double.infinity,
+        'negativeInfinity': double.negativeInfinity,
+        'nan': double.nan,
+        'valid': 42.0,
+      }, 'device');
 
       final json = measurement.toJson();
 

--- a/test/src/models/session_test.dart
+++ b/test/src/models/session_test.dart
@@ -8,12 +8,15 @@ void main() {
     group('toJson', () {
       test('should preserve typed attribute values', () {
         // Arrange - create session with typed attributes
-        final session = Session('test-session-id', attributes: {
-          'string_attr': 'hello',
-          'int_attr': 42,
-          'double_attr': 3.14,
-          'bool_attr': true,
-        });
+        final session = Session(
+          'test-session-id',
+          attributes: {
+            'string_attr': 'hello',
+            'int_attr': 42,
+            'double_attr': 3.14,
+            'bool_attr': true,
+          },
+        );
 
         // Act
         final json = session.toJson();
@@ -26,28 +29,33 @@ void main() {
         expect(attributes['bool_attr'], equals(true));
       });
 
-      test('toFaroJson should stringify all attribute values for Faro protocol',
-          () {
-        // Arrange - create session with typed attributes
-        final session = Session('test-session-id', attributes: {
-          'string_attr': 'hello',
-          'int_attr': 42,
-          'double_attr': 3.14,
-          'bool_attr': true,
-          'null_attr': null,
-        });
+      test(
+        'toFaroJson should stringify all attribute values for Faro protocol',
+        () {
+          // Arrange - create session with typed attributes
+          final session = Session(
+            'test-session-id',
+            attributes: {
+              'string_attr': 'hello',
+              'int_attr': 42,
+              'double_attr': 3.14,
+              'bool_attr': true,
+              'null_attr': null,
+            },
+          );
 
-        // Act
-        final json = session.toFaroJson();
+          // Act
+          final json = session.toFaroJson();
 
-        // Assert - all values should be strings
-        final attributes = json['attributes'] as Map<String, dynamic>;
-        expect(attributes['string_attr'], equals('hello'));
-        expect(attributes['int_attr'], equals('42'));
-        expect(attributes['double_attr'], equals('3.14'));
-        expect(attributes['bool_attr'], equals('true'));
-        expect(attributes['null_attr'], equals(''));
-      });
+          // Assert - all values should be strings
+          final attributes = json['attributes'] as Map<String, dynamic>;
+          expect(attributes['string_attr'], equals('hello'));
+          expect(attributes['int_attr'], equals('42'));
+          expect(attributes['double_attr'], equals('3.14'));
+          expect(attributes['bool_attr'], equals('true'));
+          expect(attributes['null_attr'], equals(''));
+        },
+      );
 
       test('should include session id in JSON', () {
         final session = Session('my-session-id');

--- a/test/src/models/span_record_test.dart
+++ b/test/src/models/span_record_test.dart
@@ -49,24 +49,26 @@ void main() {
         expect(result, 'faro.tracing.fetch');
       });
 
-      test('returns "faro.tracing.fetch" for HTTP spans with both attributes',
-          () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.name).thenReturn('HTTP GET');
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.get('http.scheme')).thenReturn('https');
-        when(() => mockAttributes.get('http.method')).thenReturn('GET');
+      test(
+        'returns "faro.tracing.fetch" for HTTP spans with both attributes',
+        () {
+          // Arrange
+          final mockSpan = MockReadOnlySpan();
+          final mockAttributes = MockAttributes();
+          when(() => mockSpan.name).thenReturn('HTTP GET');
+          when(() => mockSpan.attributes).thenReturn(mockAttributes);
+          when(() => mockAttributes.get('http.scheme')).thenReturn('https');
+          when(() => mockAttributes.get('http.method')).thenReturn('GET');
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
+          final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
 
-        // Act
-        final result = spanRecord.getFaroEventName();
+          // Act
+          final result = spanRecord.getFaroEventName();
 
-        // Assert
-        expect(result, 'faro.tracing.fetch');
-      });
+          // Assert
+          expect(result, 'faro.tracing.fetch');
+        },
+      );
 
       test('returns "span.{name}" for non-HTTP spans', () {
         // Arrange
@@ -169,8 +171,9 @@ void main() {
         final mockAttributes = MockAttributes();
         when(() => mockSpan.attributes).thenReturn(mockAttributes);
         when(() => mockAttributes.keys).thenReturn(['url', 'method', 'status']);
-        when(() => mockAttributes.get('url'))
-            .thenReturn('"https://example.com"');
+        when(
+          () => mockAttributes.get('url'),
+        ).thenReturn('"https://example.com"');
         when(() => mockAttributes.get('method')).thenReturn('GET');
         when(() => mockAttributes.get('status')).thenReturn('"200"');
         when(() => mockSpan.startTime).thenReturn(Int64(0));
@@ -255,10 +258,12 @@ void main() {
         when(() => mockSpan.attributes).thenReturn(mockAttributes);
         when(() => mockAttributes.keys).thenReturn(['test.key']);
         when(() => mockAttributes.get('test.key')).thenReturn('test.value');
-        when(() => mockSpan.startTime)
-            .thenReturn(Int64(1000000000)); // 1 second in nanoseconds
-        when(() => mockSpan.endTime)
-            .thenReturn(Int64(2500000000)); // 2.5 seconds in nanoseconds
+        when(
+          () => mockSpan.startTime,
+        ).thenReturn(Int64(1000000000)); // 1 second in nanoseconds
+        when(
+          () => mockSpan.endTime,
+        ).thenReturn(Int64(2500000000)); // 2.5 seconds in nanoseconds
 
         final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
 
@@ -267,7 +272,9 @@ void main() {
 
         // Assert
         expect(
-            result['duration_ns'], '1500000000'); // 1.5 seconds in nanoseconds
+          result['duration_ns'],
+          '1500000000',
+        ); // 1.5 seconds in nanoseconds
         expect(result['test.key'], 'test.value');
       });
 
@@ -363,10 +370,12 @@ void main() {
         when(() => mockSpan.attributes).thenReturn(mockAttributes);
         when(() => mockAttributes.keys).thenReturn(['test.key']);
         when(() => mockAttributes.get('test.key')).thenReturn('test.value');
-        when(() => mockSpan.startTime)
-            .thenReturn(Int64(2500000000)); // 2.5 seconds
-        when(() => mockSpan.endTime)
-            .thenReturn(Int64(1000000000)); // 1 second (before start time)
+        when(
+          () => mockSpan.startTime,
+        ).thenReturn(Int64(2500000000)); // 2.5 seconds
+        when(
+          () => mockSpan.endTime,
+        ).thenReturn(Int64(1000000000)); // 1 second (before start time)
 
         final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
 

--- a/test/src/models/user_action_context_test.dart
+++ b/test/src/models/user_action_context_test.dart
@@ -7,10 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('UserActionContext:', () {
     test('should round-trip JSON with id', () {
-      const context = UserActionContext(
-        name: 'checkout',
-        id: 'action-123',
-      );
+      const context = UserActionContext(name: 'checkout', id: 'action-123');
 
       final decoded = UserActionContext.fromJson(context.toJson());
 

--- a/test/src/offline_transport/internet_connectivity_service_test.dart
+++ b/test/src/offline_transport/internet_connectivity_service_test.dart
@@ -26,10 +26,12 @@ void main() {
         StreamController<List<ConnectivityResult>>.broadcast();
     fakeConnectivityResults = [ConnectivityResult.none];
 
-    when(() => mockConnectivity.checkConnectivity())
-        .thenAnswer((_) async => fakeConnectivityResults);
-    when(() => mockConnectivity.onConnectivityChanged)
-        .thenAnswer((_) => fakeConnectivityController.stream);
+    when(
+      () => mockConnectivity.checkConnectivity(),
+    ).thenAnswer((_) async => fakeConnectivityResults);
+    when(
+      () => mockConnectivity.onConnectivityChanged,
+    ).thenAnswer((_) => fakeConnectivityController.stream);
 
     service = InternetConnectivityService(
       connectivity: mockConnectivity,
@@ -76,26 +78,30 @@ void main() {
         expect(service.isOnline, false);
       });
 
-      test('returns true when has connectivity and internet check succeeds',
-          () async {
-        fakeConnectivityController.add([ConnectivityResult.wifi]);
-        await waitForAsyncWork();
-        expect(service.isOnline, true);
-      });
+      test(
+        'returns true when has connectivity and internet check succeeds',
+        () async {
+          fakeConnectivityController.add([ConnectivityResult.wifi]);
+          await waitForAsyncWork();
+          expect(service.isOnline, true);
+        },
+      );
 
-      test('returns false when has connectivity but internet check fails',
-          () async {
-        service = InternetConnectivityService(
-          connectivity: mockConnectivity,
-          internetConnectionCheckerUrl: 'invalid.domain.that.does.not.exist',
-        );
+      test(
+        'returns false when has connectivity but internet check fails',
+        () async {
+          service = InternetConnectivityService(
+            connectivity: mockConnectivity,
+            internetConnectionCheckerUrl: 'invalid.domain.that.does.not.exist',
+          );
 
-        fakeConnectivityController.add([ConnectivityResult.wifi]);
+          fakeConnectivityController.add([ConnectivityResult.wifi]);
 
-        await waitForAsyncWork();
+          await waitForAsyncWork();
 
-        expect(service.isOnline, false);
-      });
+          expect(service.isOnline, false);
+        },
+      );
     });
 
     group('onConnectivityChanged:', () {

--- a/test/src/session/sampling_context_test.dart
+++ b/test/src/session/sampling_context_test.dart
@@ -12,15 +12,8 @@ void main() {
     test('should wrap Meta object', () {
       final meta = Meta(
         session: Session('test-session-id', attributes: {'team': 'mobile'}),
-        app: App(
-          name: 'TestApp',
-          environment: 'production',
-          version: '1.0.0',
-        ),
-        user: const FaroUser(
-          id: 'user-123',
-          attributes: {'role': 'beta'},
-        ),
+        app: App(name: 'TestApp', environment: 'production', version: '1.0.0'),
+        user: const FaroUser(id: 'user-123', attributes: {'role': 'beta'}),
         sdk: Sdk('faro-mobile-flutter', '1.0.0'),
         view: ViewMeta('home'),
       );
@@ -56,11 +49,7 @@ void main() {
 
     test('should provide access to app environment', () {
       final meta = Meta(
-        app: App(
-          name: 'TestApp',
-          environment: 'production',
-          version: '1.0.0',
-        ),
+        app: App(name: 'TestApp', environment: 'production', version: '1.0.0'),
       );
 
       final context = SamplingContext(meta: meta);

--- a/test/src/session/session_id_provider_test.dart
+++ b/test/src/session/session_id_provider_test.dart
@@ -24,9 +24,11 @@ void main() {
           'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 
       for (var i = 0; i < sut.sessionId.length; i++) {
-        expect(validChars.contains(sut.sessionId[i]), isTrue,
-            reason:
-                'Character "${sut.sessionId[i]}" at position $i is not valid');
+        expect(
+          validChars.contains(sut.sessionId[i]),
+          isTrue,
+          reason: 'Character "${sut.sessionId[i]}" at position $i is not valid',
+        );
       }
     });
 
@@ -56,8 +58,11 @@ void main() {
         final sessionId = sut.sessionId;
 
         // Check pattern: exactly 10 alphanumeric characters
-        expect(RegExp(r'^[a-zA-Z0-9]{10}$').hasMatch(sessionId), isTrue,
-            reason: 'Session ID "$sessionId" does not match expected pattern');
+        expect(
+          RegExp(r'^[a-zA-Z0-9]{10}$').hasMatch(sessionId),
+          isTrue,
+          reason: 'Session ID "$sessionId" does not match expected pattern',
+        );
       }
     });
   });
@@ -77,14 +82,15 @@ void main() {
     });
 
     test(
-        'should return the same instance on multiple calls (singleton behavior)',
-        () {
-      final provider1 = sut.create();
-      final provider2 = sut.create();
+      'should return the same instance on multiple calls (singleton behavior)',
+      () {
+        final provider1 = sut.create();
+        final provider2 = sut.create();
 
-      expect(identical(provider1, provider2), isTrue);
-      expect(provider1.sessionId, equals(provider2.sessionId));
-    });
+        expect(identical(provider1, provider2), isTrue);
+        expect(provider1.sessionId, equals(provider2.sessionId));
+      },
+    );
 
     test('should return same instance across different factory instances', () {
       final factory1 = SessionIdProviderFactory();
@@ -98,27 +104,27 @@ void main() {
     });
 
     test(
-        'should maintain singleton state after multiple factory instantiations',
-        () {
-      final factory1 = SessionIdProviderFactory();
-      final provider1 = factory1.create();
+      'should maintain singleton state after multiple factory instantiations',
+      () {
+        final factory1 = SessionIdProviderFactory();
+        final provider1 = factory1.create();
 
-      final factory2 = SessionIdProviderFactory();
-      final provider2 = factory2.create();
+        final factory2 = SessionIdProviderFactory();
+        final provider2 = factory2.create();
 
-      final factory3 = SessionIdProviderFactory();
-      final provider3 = factory3.create();
+        final factory3 = SessionIdProviderFactory();
+        final provider3 = factory3.create();
 
-      expect(identical(provider1, provider2), isTrue);
-      expect(identical(provider2, provider3), isTrue);
-      expect(provider1.sessionId, equals(provider2.sessionId));
-      expect(provider2.sessionId, equals(provider3.sessionId));
-    });
+        expect(identical(provider1, provider2), isTrue);
+        expect(identical(provider2, provider3), isTrue);
+        expect(provider1.sessionId, equals(provider2.sessionId));
+        expect(provider2.sessionId, equals(provider3.sessionId));
+      },
+    );
   });
 
   group('SessionIdProvider _generateSessionID static method:', () {
-    test('should generate different IDs when called directly multiple times',
-        () {
+    test('should generate different IDs when called directly multiple times', () {
       // We can't call the private method directly, but we can test its behavior
       // through multiple SessionIdProvider instantiations
       final ids = <String>{};
@@ -130,8 +136,11 @@ void main() {
       }
 
       // All IDs should be unique (set size should equal number of generated IDs)
-      expect(ids.length, equals(20),
-          reason: 'Generated session IDs are not sufficiently random');
+      expect(
+        ids.length,
+        equals(20),
+        reason: 'Generated session IDs are not sufficiently random',
+      );
     });
 
     test('should generate IDs with good distribution of characters', () {
@@ -148,9 +157,11 @@ void main() {
       }
 
       // Should have used multiple different characters (not just a few)
-      expect(characterCounts.keys.length, greaterThan(10),
-          reason:
-              'Session ID generation should use a good variety of characters');
+      expect(
+        characterCounts.keys.length,
+        greaterThan(10),
+        reason: 'Session ID generation should use a good variety of characters',
+      );
     });
   });
 }

--- a/test/src/session/session_sampling_provider_test.dart
+++ b/test/src/session/session_sampling_provider_test.dart
@@ -18,11 +18,7 @@ void main() {
     setUp(() {
       testMeta = Meta(
         session: Session('test-session'),
-        app: App(
-          name: 'TestApp',
-          environment: 'production',
-          version: '1.0.0',
-        ),
+        app: App(name: 'TestApp', environment: 'production', version: '1.0.0'),
       );
     });
 
@@ -186,11 +182,7 @@ void main() {
       RandomValueProviderFactory().reset();
       testMeta = Meta(
         session: Session('test-session'),
-        app: App(
-          name: 'TestApp',
-          environment: 'production',
-          version: '1.0.0',
-        ),
+        app: App(name: 'TestApp', environment: 'production', version: '1.0.0'),
       );
     });
 
@@ -241,9 +233,7 @@ void main() {
     });
 
     test('should work when sampling is not provided (defaults to 100%)', () {
-      final provider = sut.create(
-        meta: testMeta,
-      );
+      final provider = sut.create(meta: testMeta);
 
       // With default sampling (1.0), should always be sampled
       expect(provider.isSampled, isTrue);

--- a/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
+++ b/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
@@ -19,8 +19,10 @@ class MockSession extends Mock implements Session {}
 String _getPackageVersionFromPubspec() {
   final pubspecFile = File('pubspec.yaml');
   final pubspecContent = pubspecFile.readAsStringSync();
-  final versionMatch =
-      RegExp(r'^version:\s*(.+)$', multiLine: true).firstMatch(pubspecContent);
+  final versionMatch = RegExp(
+    r'^version:\s*(.+)$',
+    multiLine: true,
+  ).firstMatch(pubspecContent);
 
   if (versionMatch == null) {
     throw Exception('Could not find version in pubspec.yaml');
@@ -52,44 +54,49 @@ void main() {
 
     group('getTracerResource', () {
       test(
-          'should create resource with app information when all app data is present',
-          () {
-        // Arrange
-        when(() => mockMeta.app).thenReturn(mockApp);
-        when(() => mockMeta.session).thenReturn(null);
-        when(() => mockApp.name).thenReturn('TestApp');
-        when(() => mockApp.environment).thenReturn('production');
-        when(() => mockApp.version).thenReturn('1.2.3');
-        when(() => mockApp.namespace).thenReturn('test.namespace');
+        'should create resource with app information when all app data is present',
+        () {
+          // Arrange
+          when(() => mockMeta.app).thenReturn(mockApp);
+          when(() => mockMeta.session).thenReturn(null);
+          when(() => mockApp.name).thenReturn('TestApp');
+          when(() => mockApp.environment).thenReturn('production');
+          when(() => mockApp.version).thenReturn('1.2.3');
+          when(() => mockApp.namespace).thenReturn('test.namespace');
 
-        // Act
-        final resource = factory.getTracerResource();
+          // Act
+          final resource = factory.getTracerResource();
 
-        // Assert
-        expect(resource, isNotNull);
-        expect(resource.attributes.keys, isNotEmpty);
+          // Assert
+          expect(resource, isNotNull);
+          expect(resource.attributes.keys, isNotEmpty);
 
-        expect(
+          expect(
             resource.attributes
                 .get(otel_api.ResourceAttributes.serviceName)
                 .toString(),
-            equals('TestApp'));
-        expect(
+            equals('TestApp'),
+          );
+          expect(
             resource.attributes
                 .get(otel_api.ResourceAttributes.deploymentEnvironment)
                 .toString(),
-            equals('production'));
-        expect(
+            equals('production'),
+          );
+          expect(
             resource.attributes
                 .get(otel_api.ResourceAttributes.serviceVersion)
                 .toString(),
-            equals('1.2.3'));
-        expect(
+            equals('1.2.3'),
+          );
+          expect(
             resource.attributes
                 .get(otel_api.ResourceAttributes.serviceNamespace)
                 .toString(),
-            equals('test.namespace'));
-      });
+            equals('test.namespace'),
+          );
+        },
+      );
 
       test('should use default values when app data is null', () {
         // Arrange
@@ -101,25 +108,29 @@ void main() {
 
         // Assert
         expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.serviceName)
-                .toString(),
-            equals('unknown'));
+          resource.attributes
+              .get(otel_api.ResourceAttributes.serviceName)
+              .toString(),
+          equals('unknown'),
+        );
         expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.deploymentEnvironment)
-                .toString(),
-            equals('unknown'));
+          resource.attributes
+              .get(otel_api.ResourceAttributes.deploymentEnvironment)
+              .toString(),
+          equals('unknown'),
+        );
         expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.serviceVersion)
-                .toString(),
-            equals('unknown'));
+          resource.attributes
+              .get(otel_api.ResourceAttributes.serviceVersion)
+              .toString(),
+          equals('unknown'),
+        );
         expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.serviceNamespace)
-                .toString(),
-            equals('flutter_app'));
+          resource.attributes
+              .get(otel_api.ResourceAttributes.serviceNamespace)
+              .toString(),
+          equals('flutter_app'),
+        );
       });
 
       test('should use default values when individual app fields are null', () {
@@ -136,25 +147,29 @@ void main() {
 
         // Assert
         expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.serviceName)
-                .toString(),
-            equals('unknown'));
+          resource.attributes
+              .get(otel_api.ResourceAttributes.serviceName)
+              .toString(),
+          equals('unknown'),
+        );
         expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.deploymentEnvironment)
-                .toString(),
-            equals('unknown'));
+          resource.attributes
+              .get(otel_api.ResourceAttributes.deploymentEnvironment)
+              .toString(),
+          equals('unknown'),
+        );
         expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.serviceVersion)
-                .toString(),
-            equals('unknown'));
+          resource.attributes
+              .get(otel_api.ResourceAttributes.serviceVersion)
+              .toString(),
+          equals('unknown'),
+        );
         expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.serviceNamespace)
-                .toString(),
-            equals('flutter_app'));
+          resource.attributes
+              .get(otel_api.ResourceAttributes.serviceNamespace)
+              .toString(),
+          equals('flutter_app'),
+        );
       });
 
       test('should include SDK telemetry attributes', () {
@@ -166,14 +181,22 @@ void main() {
         final resource = factory.getTracerResource();
 
         // Assert
-        expect(resource.attributes.get('telemetry.sdk.name').toString(),
-            equals('faro-mobile-flutter'));
-        expect(resource.attributes.get('telemetry.sdk.language').toString(),
-            equals('dart'));
-        expect(resource.attributes.get('telemetry.sdk.version').toString(),
-            equals(_getPackageVersionFromPubspec()));
-        expect(resource.attributes.get('telemetry.sdk.platform').toString(),
-            equals('flutter'));
+        expect(
+          resource.attributes.get('telemetry.sdk.name').toString(),
+          equals('faro-mobile-flutter'),
+        );
+        expect(
+          resource.attributes.get('telemetry.sdk.language').toString(),
+          equals('dart'),
+        );
+        expect(
+          resource.attributes.get('telemetry.sdk.version').toString(),
+          equals(_getPackageVersionFromPubspec()),
+        );
+        expect(
+          resource.attributes.get('telemetry.sdk.platform').toString(),
+          equals('flutter'),
+        );
       });
 
       test('should include session attributes when session exists', () {
@@ -183,7 +206,7 @@ void main() {
         when(() => mockSession.attributes).thenReturn({
           'session_id': '12345',
           'user_id': 'user123',
-          'custom_attr': 'value'
+          'custom_attr': 'value',
         });
 
         // Act
@@ -191,11 +214,17 @@ void main() {
 
         // Assert
         expect(
-            resource.attributes.get('session_id').toString(), equals('12345'));
+          resource.attributes.get('session_id').toString(),
+          equals('12345'),
+        );
         expect(
-            resource.attributes.get('user_id').toString(), equals('user123'));
+          resource.attributes.get('user_id').toString(),
+          equals('user123'),
+        );
         expect(
-            resource.attributes.get('custom_attr').toString(), equals('value'));
+          resource.attributes.get('custom_attr').toString(),
+          equals('value'),
+        );
       });
 
       test('should handle empty session attributes', () {
@@ -247,8 +276,10 @@ void main() {
 
         // Null and object values fall back to string representation
         expect(resource.attributes.get('null_value').toString(), equals(''));
-        expect(resource.attributes.get('object').toString(),
-            equals('{nested: value}'));
+        expect(
+          resource.attributes.get('object').toString(),
+          equals('{nested: value}'),
+        );
       });
 
       test('should handle null session', () {

--- a/test/src/tracing/extensions_test.dart
+++ b/test/src/tracing/extensions_test.dart
@@ -6,9 +6,7 @@ void main() {
   group('IterableTraceAttributeX:', () {
     group('toTraceAttributes:', () {
       test('should preserve string attribute value', () {
-        final attributes = [
-          otel_api.Attribute.fromString('name', 'test'),
-        ];
+        final attributes = [otel_api.Attribute.fromString('name', 'test')];
 
         final result = attributes.toTraceAttributes();
 
@@ -19,9 +17,7 @@ void main() {
       });
 
       test('should preserve int attribute value', () {
-        final attributes = [
-          otel_api.Attribute.fromInt('count', 42),
-        ];
+        final attributes = [otel_api.Attribute.fromInt('count', 42)];
 
         final result = attributes.toTraceAttributes();
 
@@ -32,9 +28,7 @@ void main() {
       });
 
       test('should preserve double attribute value', () {
-        final attributes = [
-          otel_api.Attribute.fromDouble('duration', 3.14),
-        ];
+        final attributes = [otel_api.Attribute.fromDouble('duration', 3.14)];
 
         final result = attributes.toTraceAttributes();
 
@@ -45,9 +39,7 @@ void main() {
       });
 
       test('should preserve bool attribute value', () {
-        final attributes = [
-          otel_api.Attribute.fromBoolean('enabled', true),
-        ];
+        final attributes = [otel_api.Attribute.fromBoolean('enabled', true)];
 
         final result = attributes.toTraceAttributes();
 
@@ -87,9 +79,7 @@ void main() {
       });
 
       test('should handle negative int values', () {
-        final attributes = [
-          otel_api.Attribute.fromInt('offset', -10),
-        ];
+        final attributes = [otel_api.Attribute.fromInt('offset', -10)];
 
         final result = attributes.toTraceAttributes();
 

--- a/test/src/tracing/faro_exporter_test.dart
+++ b/test/src/tracing/faro_exporter_test.dart
@@ -28,11 +28,11 @@ class FakeReadOnlySpan extends Fake implements otel_sdk.ReadOnlySpan {
 
   @override
   otel_api.SpanContext get spanContext => otel_api.SpanContext(
-        otel_api.TraceId.fromString('00000000000000000000000000000001'),
-        otel_api.SpanId.fromString('0000000000000001'),
-        otel_api.TraceFlags.sampled,
-        otel_api.TraceState.empty(),
-      );
+    otel_api.TraceId.fromString('00000000000000000000000000000001'),
+    otel_api.SpanId.fromString('0000000000000001'),
+    otel_api.TraceFlags.sampled,
+    otel_api.TraceState.empty(),
+  );
 
   @override
   otel_api.SpanId get parentSpanId => otel_api.SpanId.invalid();
@@ -68,9 +68,7 @@ void main() {
   late MockTelemetryRouter mockRouter;
 
   setUpAll(() {
-    registerFallbackValue(
-      TelemetryItem.fromEvent(Event('fallback')),
-    );
+    registerFallbackValue(TelemetryItem.fromEvent(Event('fallback')));
     registerFallbackValue(false);
   });
 
@@ -80,155 +78,121 @@ void main() {
 
   group('FaroExporter:', () {
     group('user action attribute mapping:', () {
-      test(
-        'should set Event.action and strip attributes '
-        'when both faro.action.user.name and faro.action.user.parentId '
-        'are present',
-        () {
-          final attrs = otel_sdk.Attributes.empty();
-          attrs.add(otel_api.Attribute.fromString('http.method', 'GET'));
-          attrs.add(otel_api.Attribute.fromString('http.scheme', 'https'));
-          attrs.add(otel_api.Attribute.fromString(
-            'faro.action.user.name',
-            'checkout',
-          ));
-          attrs.add(otel_api.Attribute.fromString(
-            'faro.action.user.parentId',
-            'abc123',
-          ));
+      test('should set Event.action and strip attributes '
+          'when both faro.action.user.name and faro.action.user.parentId '
+          'are present', () {
+        final attrs = otel_sdk.Attributes.empty();
+        attrs.add(otel_api.Attribute.fromString('http.method', 'GET'));
+        attrs.add(otel_api.Attribute.fromString('http.scheme', 'https'));
+        attrs.add(
+          otel_api.Attribute.fromString('faro.action.user.name', 'checkout'),
+        );
+        attrs.add(
+          otel_api.Attribute.fromString('faro.action.user.parentId', 'abc123'),
+        );
 
-          final span = FakeReadOnlySpan(
-            name: 'HTTP GET',
-            attributes: attrs,
-          );
+        final span = FakeReadOnlySpan(name: 'HTTP GET', attributes: attrs);
 
-          final exporter = FaroExporter(telemetryRouter: mockRouter);
-          exporter.export([span]);
+        final exporter = FaroExporter(telemetryRouter: mockRouter);
+        exporter.export([span]);
 
-          final captured = verify(
-            () => mockRouter.ingest(
-              captureAny(),
-              skipBuffer: any(named: 'skipBuffer'),
-            ),
-          ).captured;
+        final captured =
+            verify(
+              () => mockRouter.ingest(
+                captureAny(),
+                skipBuffer: any(named: 'skipBuffer'),
+              ),
+            ).captured;
 
-          // captureAny captures positional args only
-          expect(captured, hasLength(2));
+        // captureAny captures positional args only
+        expect(captured, hasLength(2));
 
-          final eventItem = captured[0] as TelemetryItem;
-          expect(eventItem.type, equals(TelemetryItemType.event));
+        final eventItem = captured[0] as TelemetryItem;
+        expect(eventItem.type, equals(TelemetryItemType.event));
 
-          final event = eventItem.asEvent!;
-          expect(event.action, isNotNull);
-          expect(event.action!.name, equals('checkout'));
-          expect(event.action!.parentId, equals('abc123'));
+        final event = eventItem.asEvent!;
+        expect(event.action, isNotNull);
+        expect(event.action!.name, equals('checkout'));
+        expect(event.action!.parentId, equals('abc123'));
 
-          expect(
-            event.attributes!.containsKey('faro.action.user.name'),
-            isFalse,
-          );
-          expect(
-            event.attributes!.containsKey('faro.action.user.parentId'),
-            isFalse,
-          );
+        expect(event.attributes!.containsKey('faro.action.user.name'), isFalse);
+        expect(
+          event.attributes!.containsKey('faro.action.user.parentId'),
+          isFalse,
+        );
 
-          expect(event.attributes!['http.method'], equals('GET'));
-          expect(event.attributes!['http.scheme'], equals('https'));
-        },
-      );
+        expect(event.attributes!['http.method'], equals('GET'));
+        expect(event.attributes!['http.scheme'], equals('https'));
+      });
 
-      test(
-        'should NOT set Event.action when only faro.action.user.name '
-        'is present (missing parentId)',
-        () {
-          final attrs = otel_sdk.Attributes.empty();
-          attrs.add(otel_api.Attribute.fromString('http.method', 'GET'));
-          attrs.add(otel_api.Attribute.fromString(
-            'faro.action.user.name',
-            'checkout',
-          ));
+      test('should NOT set Event.action when only faro.action.user.name '
+          'is present (missing parentId)', () {
+        final attrs = otel_sdk.Attributes.empty();
+        attrs.add(otel_api.Attribute.fromString('http.method', 'GET'));
+        attrs.add(
+          otel_api.Attribute.fromString('faro.action.user.name', 'checkout'),
+        );
 
-          final span = FakeReadOnlySpan(
-            name: 'HTTP GET',
-            attributes: attrs,
-          );
+        final span = FakeReadOnlySpan(name: 'HTTP GET', attributes: attrs);
 
-          final exporter = FaroExporter(telemetryRouter: mockRouter);
-          exporter.export([span]);
+        final exporter = FaroExporter(telemetryRouter: mockRouter);
+        exporter.export([span]);
 
-          final captured = verify(
-            () => mockRouter.ingest(
-              captureAny(),
-              skipBuffer: any(named: 'skipBuffer'),
-            ),
-          ).captured;
+        final captured =
+            verify(
+              () => mockRouter.ingest(
+                captureAny(),
+                skipBuffer: any(named: 'skipBuffer'),
+              ),
+            ).captured;
 
-          final eventItem = captured[0] as TelemetryItem;
-          final event = eventItem.asEvent!;
-          expect(event.action, isNull);
-          expect(
-            event.attributes!.containsKey('faro.action.user.name'),
-            isTrue,
-          );
-        },
-      );
+        final eventItem = captured[0] as TelemetryItem;
+        final event = eventItem.asEvent!;
+        expect(event.action, isNull);
+        expect(event.attributes!.containsKey('faro.action.user.name'), isTrue);
+      });
 
-      test(
-        'should NOT set Event.action when no action attributes '
-        'are present',
-        () {
-          final attrs = otel_sdk.Attributes.empty();
-          attrs.add(otel_api.Attribute.fromString('http.method', 'POST'));
+      test('should NOT set Event.action when no action attributes '
+          'are present', () {
+        final attrs = otel_sdk.Attributes.empty();
+        attrs.add(otel_api.Attribute.fromString('http.method', 'POST'));
 
-          final span = FakeReadOnlySpan(
-            name: 'HTTP POST',
-            attributes: attrs,
-          );
+        final span = FakeReadOnlySpan(name: 'HTTP POST', attributes: attrs);
 
-          final exporter = FaroExporter(telemetryRouter: mockRouter);
-          exporter.export([span]);
+        final exporter = FaroExporter(telemetryRouter: mockRouter);
+        exporter.export([span]);
 
-          final captured = verify(
-            () => mockRouter.ingest(
-              captureAny(),
-              skipBuffer: any(named: 'skipBuffer'),
-            ),
-          ).captured;
+        final captured =
+            verify(
+              () => mockRouter.ingest(
+                captureAny(),
+                skipBuffer: any(named: 'skipBuffer'),
+              ),
+            ).captured;
 
-          final eventItem = captured[0] as TelemetryItem;
-          final event = eventItem.asEvent!;
-          expect(event.action, isNull);
-        },
-      );
+        final eventItem = captured[0] as TelemetryItem;
+        final event = eventItem.asEvent!;
+        expect(event.action, isNull);
+      });
     });
 
     group('telemetry routing:', () {
-      test(
-        'should ingest span-derived event with skipBuffer: true',
-        () {
-          final attrs = otel_sdk.Attributes.empty();
-          attrs.add(otel_api.Attribute.fromString('http.method', 'GET'));
-          attrs.add(otel_api.Attribute.fromString('http.scheme', 'https'));
+      test('should ingest span-derived event with skipBuffer: true', () {
+        final attrs = otel_sdk.Attributes.empty();
+        attrs.add(otel_api.Attribute.fromString('http.method', 'GET'));
+        attrs.add(otel_api.Attribute.fromString('http.scheme', 'https'));
 
-          final span = FakeReadOnlySpan(
-            name: 'HTTP GET',
-            attributes: attrs,
-          );
+        final span = FakeReadOnlySpan(name: 'HTTP GET', attributes: attrs);
 
-          final exporter = FaroExporter(telemetryRouter: mockRouter);
-          exporter.export([span]);
+        final exporter = FaroExporter(telemetryRouter: mockRouter);
+        exporter.export([span]);
 
-          // Event should be ingested with skipBuffer: true
-          verify(
-            () => mockRouter.ingest(any(), skipBuffer: true),
-          ).called(1);
+        // Event should be ingested with skipBuffer: true
+        verify(() => mockRouter.ingest(any(), skipBuffer: true)).called(1);
 
-          // Span should be ingested with default skipBuffer (false)
-          verify(
-            () => mockRouter.ingest(any()),
-          ).called(1);
-        },
-      );
+        // Span should be ingested with default skipBuffer (false)
+        verify(() => mockRouter.ingest(any())).called(1);
+      });
     });
   });
 }

--- a/test/src/tracing/faro_tracer_test.dart
+++ b/test/src/tracing/faro_tracer_test.dart
@@ -61,19 +61,23 @@ void main() {
         var bodyExecuted = false;
         Span? receivedSpan;
 
-        when(() => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
+        when(
+          () => mockOtelTracer.startSpan(
+            any(),
+            context: any(named: 'context'),
+            kind: any(named: 'kind'),
+            attributes: any(named: 'attributes'),
+          ),
+        ).thenReturn(mockOtelSpan);
 
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
-        when(() => mockFaroZoneSpanManager.executeWithSpan<String>(
-              any(),
-              any(),
-              contextScope: any(named: 'contextScope'),
-            )).thenAnswer((invocation) async {
+        when(
+          () => mockFaroZoneSpanManager.executeWithSpan<String>(
+            any(),
+            any(),
+            contextScope: any(named: 'contextScope'),
+          ),
+        ).thenAnswer((invocation) async {
           final body = invocation.positionalArguments[1] as Function;
           final span = invocation.positionalArguments[0] as Span;
           return await body(span);
@@ -91,17 +95,21 @@ void main() {
         expect(bodyExecuted, isTrue);
         expect(receivedSpan, isA<InternalSpan>());
 
-        verify(() => mockOtelTracer.startSpan(
-              spanName,
-              context: any(named: 'context'),
-              kind: otel_api.SpanKind.client,
-              attributes: any(named: 'attributes'),
-            )).called(1);
-        verify(() => mockFaroZoneSpanManager.executeWithSpan<String>(
-              any(),
-              any(),
-              contextScope: any(named: 'contextScope'),
-            )).called(1);
+        verify(
+          () => mockOtelTracer.startSpan(
+            spanName,
+            context: any(named: 'context'),
+            kind: otel_api.SpanKind.client,
+            attributes: any(named: 'attributes'),
+          ),
+        ).called(1);
+        verify(
+          () => mockFaroZoneSpanManager.executeWithSpan<String>(
+            any(),
+            any(),
+            contextScope: any(named: 'contextScope'),
+          ),
+        ).called(1);
       });
 
       test('should set session attributes on span', () async {
@@ -110,18 +118,22 @@ void main() {
         const sessionId = 'session-123';
 
         when(() => mockSessionIdProvider.sessionId).thenReturn(sessionId);
-        when(() => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
+        when(
+          () => mockOtelTracer.startSpan(
+            any(),
+            context: any(named: 'context'),
+            kind: any(named: 'kind'),
+            attributes: any(named: 'attributes'),
+          ),
+        ).thenReturn(mockOtelSpan);
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
-        when(() => mockFaroZoneSpanManager.executeWithSpan<String>(
-              any(),
-              any(),
-              contextScope: any(named: 'contextScope'),
-            )).thenAnswer((invocation) async {
+        when(
+          () => mockFaroZoneSpanManager.executeWithSpan<String>(
+            any(),
+            any(),
+            contextScope: any(named: 'contextScope'),
+          ),
+        ).thenAnswer((invocation) async {
           final body = invocation.positionalArguments[1] as Function;
           final span = invocation.positionalArguments[0] as Span;
           return await body(span);
@@ -131,12 +143,15 @@ void main() {
         await faroTracer.startSpan<String>(spanName, (span) => 'result');
 
         // Assert
-        final captured = verify(() => mockOtelTracer.startSpan(
-              spanName,
-              context: any(named: 'context'),
-              kind: otel_api.SpanKind.client,
-              attributes: captureAny(named: 'attributes'),
-            )).captured;
+        final captured =
+            verify(
+              () => mockOtelTracer.startSpan(
+                spanName,
+                context: any(named: 'context'),
+                kind: otel_api.SpanKind.client,
+                attributes: captureAny(named: 'attributes'),
+              ),
+            ).captured;
         final attributes = captured.single as List<otel_api.Attribute>;
         final attributeMap = <String, String>{
           for (final attr in attributes) attr.key: attr.value.toString(),
@@ -145,55 +160,64 @@ void main() {
         expect(attributeMap['session.id'], sessionId);
       });
 
-      test('should include custom attributes along with session attributes',
-          () async {
-        // Arrange
-        const spanName = 'test-span';
-        const customAttributes = {
-          'custom.key1': 'value1',
-          'custom.key2': 'value2',
-        };
+      test(
+        'should include custom attributes along with session attributes',
+        () async {
+          // Arrange
+          const spanName = 'test-span';
+          const customAttributes = {
+            'custom.key1': 'value1',
+            'custom.key2': 'value2',
+          };
 
-        when(() => mockOtelTracer.startSpan(
+          when(
+            () => mockOtelTracer.startSpan(
               any(),
               context: any(named: 'context'),
               kind: any(named: 'kind'),
               attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
-        when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
-        when(() => mockFaroZoneSpanManager.executeWithSpan<String>(
+            ),
+          ).thenReturn(mockOtelSpan);
+          when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
+          when(
+            () => mockFaroZoneSpanManager.executeWithSpan<String>(
               any(),
               any(),
               contextScope: any(named: 'contextScope'),
-            )).thenAnswer((invocation) async {
-          final body = invocation.positionalArguments[1] as Function;
-          final span = invocation.positionalArguments[0] as Span;
-          return await body(span);
-        });
+            ),
+          ).thenAnswer((invocation) async {
+            final body = invocation.positionalArguments[1] as Function;
+            final span = invocation.positionalArguments[0] as Span;
+            return await body(span);
+          });
 
-        // Act
-        await faroTracer.startSpan<String>(
-          spanName,
-          (span) => 'result',
-          attributes: customAttributes,
-        );
+          // Act
+          await faroTracer.startSpan<String>(
+            spanName,
+            (span) => 'result',
+            attributes: customAttributes,
+          );
 
-        // Assert
-        final captured = verify(() => mockOtelTracer.startSpan(
-              spanName,
-              context: any(named: 'context'),
-              kind: otel_api.SpanKind.client,
-              attributes: captureAny(named: 'attributes'),
-            )).captured;
-        final attributes = captured.single as List<otel_api.Attribute>;
-        final attributeMap = <String, String>{
-          for (final attr in attributes) attr.key: attr.value.toString(),
-        };
-        expect(attributeMap['custom.key1'], 'value1');
-        expect(attributeMap['custom.key2'], 'value2');
-        expect(attributeMap['session_id'], 'test-session-id');
-        expect(attributeMap['session.id'], 'test-session-id');
-      });
+          // Assert
+          final captured =
+              verify(
+                () => mockOtelTracer.startSpan(
+                  spanName,
+                  context: any(named: 'context'),
+                  kind: otel_api.SpanKind.client,
+                  attributes: captureAny(named: 'attributes'),
+                ),
+              ).captured;
+          final attributes = captured.single as List<otel_api.Attribute>;
+          final attributeMap = <String, String>{
+            for (final attr in attributes) attr.key: attr.value.toString(),
+          };
+          expect(attributeMap['custom.key1'], 'value1');
+          expect(attributeMap['custom.key2'], 'value2');
+          expect(attributeMap['session_id'], 'test-session-id');
+          expect(attributeMap['session.id'], 'test-session-id');
+        },
+      );
     });
 
     group('startSpanManual:', () {
@@ -201,12 +225,14 @@ void main() {
         // Arrange
         const spanName = 'manual-span';
 
-        when(() => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
+        when(
+          () => mockOtelTracer.startSpan(
+            any(),
+            context: any(named: 'context'),
+            kind: any(named: 'kind'),
+            attributes: any(named: 'attributes'),
+          ),
+        ).thenReturn(mockOtelSpan);
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
 
         // Act
@@ -214,45 +240,49 @@ void main() {
 
         // Assert
         expect(result, isA<InternalSpan>());
-        verify(() => mockOtelTracer.startSpan(
-              spanName,
-              context: any(named: 'context'),
-              kind: otel_api.SpanKind.client,
-              attributes: any(named: 'attributes'),
-            )).called(1);
+        verify(
+          () => mockOtelTracer.startSpan(
+            spanName,
+            context: any(named: 'context'),
+            kind: otel_api.SpanKind.client,
+            attributes: any(named: 'attributes'),
+          ),
+        ).called(1);
 
         // Verify executeWithSpan is NOT called for manual spans
-        verifyNever(() => mockFaroZoneSpanManager.executeWithSpan<dynamic>(
-              any(),
-              any(),
-            ));
+        verifyNever(
+          () => mockFaroZoneSpanManager.executeWithSpan<dynamic>(any(), any()),
+        );
       });
 
       test('should set attributes on manual span', () {
         // Arrange
         const spanName = 'manual-span';
-        const customAttributes = {
-          'manual.key': 'manual.value',
-        };
+        const customAttributes = {'manual.key': 'manual.value'};
 
-        when(() => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
+        when(
+          () => mockOtelTracer.startSpan(
+            any(),
+            context: any(named: 'context'),
+            kind: any(named: 'kind'),
+            attributes: any(named: 'attributes'),
+          ),
+        ).thenReturn(mockOtelSpan);
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
 
         // Act
         faroTracer.startSpanManual(spanName, attributes: customAttributes);
 
         // Assert
-        final captured = verify(() => mockOtelTracer.startSpan(
-              spanName,
-              context: any(named: 'context'),
-              kind: otel_api.SpanKind.client,
-              attributes: captureAny(named: 'attributes'),
-            )).captured;
+        final captured =
+            verify(
+              () => mockOtelTracer.startSpan(
+                spanName,
+                context: any(named: 'context'),
+                kind: otel_api.SpanKind.client,
+                attributes: captureAny(named: 'attributes'),
+              ),
+            ).captured;
         final attributes = captured.single as List<otel_api.Attribute>;
         final attributeMap = <String, String>{
           for (final attr in attributes) attr.key: attr.value.toString(),
@@ -267,8 +297,9 @@ void main() {
       test('should return active span from zone span manager', () {
         // Arrange
         final mockActiveSpan = MockSpan();
-        when(() => mockFaroZoneSpanManager.getActiveSpan())
-            .thenReturn(mockActiveSpan);
+        when(
+          () => mockFaroZoneSpanManager.getActiveSpan(),
+        ).thenReturn(mockActiveSpan);
 
         // Act
         final result = faroTracer.getActiveSpan();
@@ -292,38 +323,45 @@ void main() {
     });
 
     group('session integration:', () {
-      test('should always include both session_id and session.id attributes',
-          () {
-        // Arrange
-        const spanName = 'session-test';
-        const sessionId = 'unique-session-xyz';
+      test(
+        'should always include both session_id and session.id attributes',
+        () {
+          // Arrange
+          const spanName = 'session-test';
+          const sessionId = 'unique-session-xyz';
 
-        when(() => mockSessionIdProvider.sessionId).thenReturn(sessionId);
-        when(() => mockOtelTracer.startSpan(
+          when(() => mockSessionIdProvider.sessionId).thenReturn(sessionId);
+          when(
+            () => mockOtelTracer.startSpan(
               any(),
               context: any(named: 'context'),
               kind: any(named: 'kind'),
               attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
-        when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
+            ),
+          ).thenReturn(mockOtelSpan);
+          when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
 
-        // Act
-        faroTracer.startSpanManual(spanName);
+          // Act
+          faroTracer.startSpanManual(spanName);
 
-        // Assert
-        final captured = verify(() => mockOtelTracer.startSpan(
-              spanName,
-              context: any(named: 'context'),
-              kind: otel_api.SpanKind.client,
-              attributes: captureAny(named: 'attributes'),
-            )).captured;
-        final attributes = captured.single as List<otel_api.Attribute>;
-        final attributeMap = <String, String>{
-          for (final attr in attributes) attr.key: attr.value.toString(),
-        };
-        expect(attributeMap['session_id'], sessionId);
-        expect(attributeMap['session.id'], sessionId);
-      });
+          // Assert
+          final captured =
+              verify(
+                () => mockOtelTracer.startSpan(
+                  spanName,
+                  context: any(named: 'context'),
+                  kind: otel_api.SpanKind.client,
+                  attributes: captureAny(named: 'attributes'),
+                ),
+              ).captured;
+          final attributes = captured.single as List<otel_api.Attribute>;
+          final attributeMap = <String, String>{
+            for (final attr in attributes) attr.key: attr.value.toString(),
+          };
+          expect(attributeMap['session_id'], sessionId);
+          expect(attributeMap['session.id'], sessionId);
+        },
+      );
     });
 
     group('contextScope:', () {
@@ -332,20 +370,25 @@ void main() {
         const spanName = 'scoped-span';
         ContextScope? capturedScope;
 
-        when(() => mockSessionIdProvider.sessionId)
-            .thenReturn('test-session-id');
-        when(() => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
+        when(
+          () => mockSessionIdProvider.sessionId,
+        ).thenReturn('test-session-id');
+        when(
+          () => mockOtelTracer.startSpan(
+            any(),
+            context: any(named: 'context'),
+            kind: any(named: 'kind'),
+            attributes: any(named: 'attributes'),
+          ),
+        ).thenReturn(mockOtelSpan);
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
-        when(() => mockFaroZoneSpanManager.executeWithSpan<String>(
-              any(),
-              any(),
-              contextScope: any(named: 'contextScope'),
-            )).thenAnswer((invocation) async {
+        when(
+          () => mockFaroZoneSpanManager.executeWithSpan<String>(
+            any(),
+            any(),
+            contextScope: any(named: 'contextScope'),
+          ),
+        ).thenAnswer((invocation) async {
           capturedScope =
               invocation.namedArguments[#contextScope] as ContextScope?;
           final body = invocation.positionalArguments[1] as Function;
@@ -365,20 +408,25 @@ void main() {
         const spanName = 'zone-scoped-span';
         ContextScope? capturedScope;
 
-        when(() => mockSessionIdProvider.sessionId)
-            .thenReturn('test-session-id');
-        when(() => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
+        when(
+          () => mockSessionIdProvider.sessionId,
+        ).thenReturn('test-session-id');
+        when(
+          () => mockOtelTracer.startSpan(
+            any(),
+            context: any(named: 'context'),
+            kind: any(named: 'kind'),
+            attributes: any(named: 'attributes'),
+          ),
+        ).thenReturn(mockOtelSpan);
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
-        when(() => mockFaroZoneSpanManager.executeWithSpan<String>(
-              any(),
-              any(),
-              contextScope: any(named: 'contextScope'),
-            )).thenAnswer((invocation) async {
+        when(
+          () => mockFaroZoneSpanManager.executeWithSpan<String>(
+            any(),
+            any(),
+            contextScope: any(named: 'contextScope'),
+          ),
+        ).thenAnswer((invocation) async {
           capturedScope =
               invocation.namedArguments[#contextScope] as ContextScope?;
           final body = invocation.positionalArguments[1] as Function;
@@ -399,22 +447,25 @@ void main() {
     });
 
     group('Span.noParent:', () {
-      test('should create span without parent when Span.noParent is passed',
-          () {
+      test('should create span without parent when Span.noParent is passed', () {
         // Arrange
         const spanName = 'no-parent-span';
         final mockActiveSpan = MockSpan();
 
-        when(() => mockSessionIdProvider.sessionId)
-            .thenReturn('test-session-id');
-        when(() => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
-        when(() => mockFaroZoneSpanManager.getActiveSpan())
-            .thenReturn(mockActiveSpan);
+        when(
+          () => mockSessionIdProvider.sessionId,
+        ).thenReturn('test-session-id');
+        when(
+          () => mockOtelTracer.startSpan(
+            any(),
+            context: any(named: 'context'),
+            kind: any(named: 'kind'),
+            attributes: any(named: 'attributes'),
+          ),
+        ).thenReturn(mockOtelSpan);
+        when(
+          () => mockFaroZoneSpanManager.getActiveSpan(),
+        ).thenReturn(mockActiveSpan);
 
         // Act
         faroTracer.startSpanManual(spanName, parentSpan: Span.noParent);
@@ -424,36 +475,43 @@ void main() {
         verifyNever(() => mockFaroZoneSpanManager.getActiveSpan());
 
         // Verify span was created (with default context, not parent's context)
-        verify(() => mockOtelTracer.startSpan(
-              spanName,
-              context: any(named: 'context'),
-              kind: otel_api.SpanKind.client,
-              attributes: any(named: 'attributes'),
-            )).called(1);
+        verify(
+          () => mockOtelTracer.startSpan(
+            spanName,
+            context: any(named: 'context'),
+            kind: otel_api.SpanKind.client,
+            attributes: any(named: 'attributes'),
+          ),
+        ).called(1);
       });
 
-      test(
-          'should ignore active span when Span.noParent is passed even if '
+      test('should ignore active span when Span.noParent is passed even if '
           'active span exists', () {
         // Arrange
         const spanName = 'independent-trace';
         final mockActiveSpan = MockSpan();
 
-        when(() => mockSessionIdProvider.sessionId)
-            .thenReturn('test-session-id');
-        when(() => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
+        when(
+          () => mockSessionIdProvider.sessionId,
+        ).thenReturn('test-session-id');
+        when(
+          () => mockOtelTracer.startSpan(
+            any(),
+            context: any(named: 'context'),
+            kind: any(named: 'kind'),
+            attributes: any(named: 'attributes'),
+          ),
+        ).thenReturn(mockOtelSpan);
         // Even though there's an active span available...
-        when(() => mockFaroZoneSpanManager.getActiveSpan())
-            .thenReturn(mockActiveSpan);
+        when(
+          () => mockFaroZoneSpanManager.getActiveSpan(),
+        ).thenReturn(mockActiveSpan);
 
         // Act - pass Span.noParent to explicitly request no parent
-        final span =
-            faroTracer.startSpanManual(spanName, parentSpan: Span.noParent);
+        final span = faroTracer.startSpanManual(
+          spanName,
+          parentSpan: Span.noParent,
+        );
 
         // Assert
         expect(span, isA<InternalSpan>());
@@ -461,27 +519,32 @@ void main() {
         verifyNever(() => mockFaroZoneSpanManager.getActiveSpan());
       });
 
-      test('should use active span when parentSpan is null (default behavior)',
-          () {
-        // Arrange
-        const spanName = 'child-span';
+      test(
+        'should use active span when parentSpan is null (default behavior)',
+        () {
+          // Arrange
+          const spanName = 'child-span';
 
-        when(() => mockSessionIdProvider.sessionId)
-            .thenReturn('test-session-id');
-        when(() => mockOtelTracer.startSpan(
+          when(
+            () => mockSessionIdProvider.sessionId,
+          ).thenReturn('test-session-id');
+          when(
+            () => mockOtelTracer.startSpan(
               any(),
               context: any(named: 'context'),
               kind: any(named: 'kind'),
               attributes: any(named: 'attributes'),
-            )).thenReturn(mockOtelSpan);
-        when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
+            ),
+          ).thenReturn(mockOtelSpan);
+          when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
 
-        // Act - no parentSpan provided, should check for active span
-        faroTracer.startSpanManual(spanName);
+          // Act - no parentSpan provided, should check for active span
+          faroTracer.startSpanManual(spanName);
 
-        // Assert - should call getActiveSpan to check for parent
-        verify(() => mockFaroZoneSpanManager.getActiveSpan()).called(1);
-      });
+          // Assert - should call getActiveSpan to check for parent
+          verify(() => mockFaroZoneSpanManager.getActiveSpan()).called(1);
+        },
+      );
     });
   });
 }

--- a/test/src/tracing/faro_user_action_span_processor_test.dart
+++ b/test/src/tracing/faro_user_action_span_processor_test.dart
@@ -41,149 +41,128 @@ void main() {
 
   group('FaroUserActionSpanProcessor:', () {
     group('onStart:', () {
-      test(
-        'should set action attributes on span '
-        'when action is in started state',
-        () {
-          final action = UserAction(name: 'checkout');
-          final processor = FaroUserActionSpanProcessor(
-            delegate: mockDelegate,
-            activeUserActionResolver: () => action,
-            lifecycleSignalChannel: lifecycleSignalChannel,
-          );
+      test('should set action attributes on span '
+          'when action is in started state', () {
+        final action = UserAction(name: 'checkout');
+        final processor = FaroUserActionSpanProcessor(
+          delegate: mockDelegate,
+          activeUserActionResolver: () => action,
+          lifecycleSignalChannel: lifecycleSignalChannel,
+        );
 
+        processor.onStart(mockSpan, mockContext);
+
+        final captured =
+            verify(() => mockSpan.setAttribute(captureAny())).captured;
+
+        expect(captured, hasLength(2));
+        final nameAttr = captured[0] as otel_api.Attribute;
+        final parentIdAttr = captured[1] as otel_api.Attribute;
+
+        expect(nameAttr.key, equals('faro.action.user.name'));
+        expect(nameAttr.value, equals('checkout'));
+        expect(parentIdAttr.key, equals('faro.action.user.parentId'));
+        expect(parentIdAttr.value, equals(action.id));
+
+        action.dispose();
+      });
+
+      test('should NOT set attributes when no active action', () {
+        final processor = FaroUserActionSpanProcessor(
+          delegate: mockDelegate,
+          activeUserActionResolver: () => null,
+          lifecycleSignalChannel: lifecycleSignalChannel,
+        );
+
+        processor.onStart(mockSpan, mockContext);
+
+        verifyNever(() => mockSpan.setAttribute(any()));
+      });
+
+      test('should NOT set attributes when action is in halted state', () {
+        final action = UserAction(name: 'checkout');
+        action.halt();
+
+        final processor = FaroUserActionSpanProcessor(
+          delegate: mockDelegate,
+          activeUserActionResolver: () => action,
+          lifecycleSignalChannel: lifecycleSignalChannel,
+        );
+
+        processor.onStart(mockSpan, mockContext);
+
+        verifyNever(() => mockSpan.setAttribute(any()));
+
+        action.dispose();
+      });
+
+      test('should NOT set attributes when action is in ended state', () {
+        final action = UserAction(name: 'checkout');
+        action.end();
+
+        final processor = FaroUserActionSpanProcessor(
+          delegate: mockDelegate,
+          activeUserActionResolver: () => action,
+          lifecycleSignalChannel: lifecycleSignalChannel,
+        );
+
+        processor.onStart(mockSpan, mockContext);
+
+        verifyNever(() => mockSpan.setAttribute(any()));
+
+        action.dispose();
+      });
+
+      test('should NOT set attributes when action is in cancelled state', () {
+        final action = UserAction(name: 'checkout');
+        action.cancel();
+
+        final processor = FaroUserActionSpanProcessor(
+          delegate: mockDelegate,
+          activeUserActionResolver: () => action,
+          lifecycleSignalChannel: lifecycleSignalChannel,
+        );
+
+        processor.onStart(mockSpan, mockContext);
+
+        verifyNever(() => mockSpan.setAttribute(any()));
+
+        action.dispose();
+      });
+
+      test('should set action attributes on all span kinds', () {
+        final action = UserAction(name: 'checkout');
+        final processor = FaroUserActionSpanProcessor(
+          delegate: mockDelegate,
+          activeUserActionResolver: () => action,
+          lifecycleSignalChannel: lifecycleSignalChannel,
+        );
+
+        for (final kind in otel_api.SpanKind.values) {
+          reset(mockSpan);
+          when(() => mockSpan.kind).thenReturn(kind);
+          when(
+            () => mockSpan.attributes,
+          ).thenReturn(otel_sdk.Attributes.empty());
           processor.onStart(mockSpan, mockContext);
 
-          final captured = verify(
-            () => mockSpan.setAttribute(captureAny()),
-          ).captured;
+          verify(() => mockSpan.setAttribute(any())).called(2);
+        }
 
-          expect(captured, hasLength(2));
-          final nameAttr = captured[0] as otel_api.Attribute;
-          final parentIdAttr = captured[1] as otel_api.Attribute;
+        action.dispose();
+      });
 
-          expect(nameAttr.key, equals('faro.action.user.name'));
-          expect(nameAttr.value, equals('checkout'));
-          expect(parentIdAttr.key, equals('faro.action.user.parentId'));
-          expect(parentIdAttr.value, equals(action.id));
+      test('should always delegate onStart to wrapped processor', () {
+        final processor = FaroUserActionSpanProcessor(
+          delegate: mockDelegate,
+          activeUserActionResolver: () => null,
+          lifecycleSignalChannel: lifecycleSignalChannel,
+        );
 
-          action.dispose();
-        },
-      );
+        processor.onStart(mockSpan, mockContext);
 
-      test(
-        'should NOT set attributes when no active action',
-        () {
-          final processor = FaroUserActionSpanProcessor(
-            delegate: mockDelegate,
-            activeUserActionResolver: () => null,
-            lifecycleSignalChannel: lifecycleSignalChannel,
-          );
-
-          processor.onStart(mockSpan, mockContext);
-
-          verifyNever(() => mockSpan.setAttribute(any()));
-        },
-      );
-
-      test(
-        'should NOT set attributes when action is in halted state',
-        () {
-          final action = UserAction(name: 'checkout');
-          action.halt();
-
-          final processor = FaroUserActionSpanProcessor(
-            delegate: mockDelegate,
-            activeUserActionResolver: () => action,
-            lifecycleSignalChannel: lifecycleSignalChannel,
-          );
-
-          processor.onStart(mockSpan, mockContext);
-
-          verifyNever(() => mockSpan.setAttribute(any()));
-
-          action.dispose();
-        },
-      );
-
-      test(
-        'should NOT set attributes when action is in ended state',
-        () {
-          final action = UserAction(name: 'checkout');
-          action.end();
-
-          final processor = FaroUserActionSpanProcessor(
-            delegate: mockDelegate,
-            activeUserActionResolver: () => action,
-            lifecycleSignalChannel: lifecycleSignalChannel,
-          );
-
-          processor.onStart(mockSpan, mockContext);
-
-          verifyNever(() => mockSpan.setAttribute(any()));
-
-          action.dispose();
-        },
-      );
-
-      test(
-        'should NOT set attributes when action is in cancelled state',
-        () {
-          final action = UserAction(name: 'checkout');
-          action.cancel();
-
-          final processor = FaroUserActionSpanProcessor(
-            delegate: mockDelegate,
-            activeUserActionResolver: () => action,
-            lifecycleSignalChannel: lifecycleSignalChannel,
-          );
-
-          processor.onStart(mockSpan, mockContext);
-
-          verifyNever(() => mockSpan.setAttribute(any()));
-
-          action.dispose();
-        },
-      );
-
-      test(
-        'should set action attributes on all span kinds',
-        () {
-          final action = UserAction(name: 'checkout');
-          final processor = FaroUserActionSpanProcessor(
-            delegate: mockDelegate,
-            activeUserActionResolver: () => action,
-            lifecycleSignalChannel: lifecycleSignalChannel,
-          );
-
-          for (final kind in otel_api.SpanKind.values) {
-            reset(mockSpan);
-            when(() => mockSpan.kind).thenReturn(kind);
-            when(() => mockSpan.attributes)
-                .thenReturn(otel_sdk.Attributes.empty());
-            processor.onStart(mockSpan, mockContext);
-
-            verify(() => mockSpan.setAttribute(any())).called(2);
-          }
-
-          action.dispose();
-        },
-      );
-
-      test(
-        'should always delegate onStart to wrapped processor',
-        () {
-          final processor = FaroUserActionSpanProcessor(
-            delegate: mockDelegate,
-            activeUserActionResolver: () => null,
-            lifecycleSignalChannel: lifecycleSignalChannel,
-          );
-
-          processor.onStart(mockSpan, mockContext);
-
-          verify(() => mockDelegate.onStart(mockSpan, mockContext)).called(1);
-        },
-      );
+        verify(() => mockDelegate.onStart(mockSpan, mockContext)).called(1);
+      });
     });
 
     group('delegation:', () {
@@ -230,50 +209,48 @@ void main() {
         verify(() => mockDelegate.forceFlush()).called(1);
       });
 
-      test('should emit pendingStart and pendingEnd when marker is true',
-          () async {
-        final pendingAttributes = otel_sdk.Attributes.empty();
-        pendingAttributes.add(
-          otel_api.Attribute.fromBoolean(
-            'faro.action.user.pending',
-            true,
-          ),
-        );
-        when(() => mockSpan.attributes).thenReturn(pendingAttributes);
+      test(
+        'should emit pendingStart and pendingEnd when marker is true',
+        () async {
+          final pendingAttributes = otel_sdk.Attributes.empty();
+          pendingAttributes.add(
+            otel_api.Attribute.fromBoolean('faro.action.user.pending', true),
+          );
+          when(() => mockSpan.attributes).thenReturn(pendingAttributes);
 
-        final spanContext = otel_api.SpanContext(
-          otel_api.TraceId.fromString('00000000000000000000000000000001'),
-          otel_api.SpanId.fromString('0000000000000001'),
-          otel_api.TraceFlags.sampled,
-          otel_api.TraceState.empty(),
-        );
-        when(() => mockSpan.spanContext).thenReturn(spanContext);
-        when(() => mockReadOnlySpan.spanContext).thenReturn(spanContext);
+          final spanContext = otel_api.SpanContext(
+            otel_api.TraceId.fromString('00000000000000000000000000000001'),
+            otel_api.SpanId.fromString('0000000000000001'),
+            otel_api.TraceFlags.sampled,
+            otel_api.TraceState.empty(),
+          );
+          when(() => mockSpan.spanContext).thenReturn(spanContext);
+          when(() => mockReadOnlySpan.spanContext).thenReturn(spanContext);
 
-        final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
-          activeUserActionResolver: () => null,
-          lifecycleSignalChannel: lifecycleSignalChannel,
-        );
+          final processor = FaroUserActionSpanProcessor(
+            delegate: mockDelegate,
+            activeUserActionResolver: () => null,
+            lifecycleSignalChannel: lifecycleSignalChannel,
+          );
 
-        final emitted = <UserActionSignal>[];
-        final subscription = lifecycleSignalChannel.stream.listen(emitted.add);
+          final emitted = <UserActionSignal>[];
+          final subscription = lifecycleSignalChannel.stream.listen(
+            emitted.add,
+          );
 
-        processor.onStart(mockSpan, mockContext);
-        await Future<void>.delayed(Duration.zero);
-        processor.onEnd(mockReadOnlySpan);
-        await Future<void>.delayed(Duration.zero);
+          processor.onStart(mockSpan, mockContext);
+          await Future<void>.delayed(Duration.zero);
+          processor.onEnd(mockReadOnlySpan);
+          await Future<void>.delayed(Duration.zero);
 
-        expect(emitted.length, 2);
-        expect(emitted[0].type, UserActionSignalType.pendingStart);
-        expect(emitted[1].type, UserActionSignalType.pendingEnd);
-        expect(
-          emitted[0].operationId,
-          equals(emitted[1].operationId),
-        );
+          expect(emitted.length, 2);
+          expect(emitted[0].type, UserActionSignalType.pendingStart);
+          expect(emitted[1].type, UserActionSignalType.pendingEnd);
+          expect(emitted[0].operationId, equals(emitted[1].operationId));
 
-        await subscription.cancel();
-      });
+          await subscription.cancel();
+        },
+      );
 
       test('should not emit pending signals when marker is absent', () async {
         when(() => mockSpan.attributes).thenReturn(otel_sdk.Attributes.empty());

--- a/test/src/tracing/faro_zone_span_manager_test.dart
+++ b/test/src/tracing/faro_zone_span_manager_test.dart
@@ -72,8 +72,9 @@ void main() {
 
         // Assert
         expect(result, equals(mockSpan));
-        verify(() => mockParentSpanLookup.call(const Symbol('faroSpanContext')))
-            .called(1);
+        verify(
+          () => mockParentSpanLookup.call(const Symbol('faroSpanContext')),
+        ).called(1);
       });
 
       test('should return null when no span exists in the zone', () {
@@ -85,8 +86,9 @@ void main() {
 
         // Assert
         expect(result, isNull);
-        verify(() => mockParentSpanLookup.call(const Symbol('faroSpanContext')))
-            .called(1);
+        verify(
+          () => mockParentSpanLookup.call(const Symbol('faroSpanContext')),
+        ).called(1);
       });
 
       test('should return null when zone value is not a Span', () {
@@ -98,8 +100,9 @@ void main() {
 
         // Assert
         expect(result, isNull);
-        verify(() => mockParentSpanLookup.call(const Symbol('faroSpanContext')))
-            .called(1);
+        verify(
+          () => mockParentSpanLookup.call(const Symbol('faroSpanContext')),
+        ).called(1);
       });
 
       test('should return null when zone value is another type of object', () {
@@ -111,122 +114,140 @@ void main() {
 
         // Assert
         expect(result, isNull);
-        verify(() => mockParentSpanLookup.call(const Symbol('faroSpanContext')))
-            .called(1);
+        verify(
+          () => mockParentSpanLookup.call(const Symbol('faroSpanContext')),
+        ).called(1);
       });
     });
 
     group('executeWithSpan:', () {
-      test('should execute callback with span and end span on success',
-          () async {
-        // Arrange
-        var callbackExecuted = false;
-        Span? receivedSpan;
-        const expectedResult = 'test-result';
+      test(
+        'should execute callback with span and end span on success',
+        () async {
+          // Arrange
+          var callbackExecuted = false;
+          Span? receivedSpan;
+          const expectedResult = 'test-result';
 
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
 
-        // Act
-        final result = await faroZoneSpanManager.executeWithSpan<String>(
-          mockSpan,
-          (span) {
-            callbackExecuted = true;
-            receivedSpan = span;
-            return expectedResult;
-          },
-        );
+          // Act
+          final result = await faroZoneSpanManager.executeWithSpan<String>(
+            mockSpan,
+            (span) {
+              callbackExecuted = true;
+              receivedSpan = span;
+              return expectedResult;
+            },
+          );
 
-        // Assert
-        expect(result, equals(expectedResult));
-        expect(callbackExecuted, isTrue);
-        expect(receivedSpan, equals(mockSpan));
-        verify(() => mockSpan.end()).called(1);
-        verify(() => mockZoneRunner.call<String>(
+          // Assert
+          expect(result, equals(expectedResult));
+          expect(callbackExecuted, isTrue);
+          expect(receivedSpan, equals(mockSpan));
+          verify(() => mockSpan.end()).called(1);
+          verify(
+            () => mockZoneRunner.call<String>(
               any(),
-              any(that: predicate<Map<Object?, Object?>>((zoneValues) {
-                final holder = zoneValues[const Symbol('faroSpanContext')];
-                return holder is SpanContextHolder && holder.span == mockSpan;
-              })),
-            )).called(1);
-      });
-
-      test('should execute async callback with span and end span on success',
-          () async {
-        // Arrange
-        var callbackExecuted = false;
-        Span? receivedSpan;
-        const expectedResult = 'async-result';
-
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
-
-        // Act
-        final result = await faroZoneSpanManager.executeWithSpan<String>(
-          mockSpan,
-          (span) async {
-            callbackExecuted = true;
-            receivedSpan = span;
-            await Future<void>.delayed(Duration.zero); // Simulate async work
-            return expectedResult;
-          },
-        );
-
-        // Assert
-        expect(result, equals(expectedResult));
-        expect(callbackExecuted, isTrue);
-        expect(receivedSpan, equals(mockSpan));
-        verify(() => mockSpan.end()).called(1);
-      });
+              any(
+                that: predicate<Map<Object?, Object?>>((zoneValues) {
+                  final holder = zoneValues[const Symbol('faroSpanContext')];
+                  return holder is SpanContextHolder && holder.span == mockSpan;
+                }),
+              ),
+            ),
+          ).called(1);
+        },
+      );
 
       test(
-          'should handle exception, set span error status, record exception, and rethrow',
-          () async {
-        // Arrange
-        final testException = Exception('test-exception');
+        'should execute async callback with span and end span on success',
+        () async {
+          // Arrange
+          var callbackExecuted = false;
+          Span? receivedSpan;
+          const expectedResult = 'async-result';
 
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
 
-        // Act & Assert
-        expect(
-          () async => faroZoneSpanManager.executeWithSpan<String>(
+          // Act
+          final result = await faroZoneSpanManager.executeWithSpan<String>(
             mockSpan,
-            (span) => throw testException,
-          ),
-          throwsA(equals(testException)),
-        );
+            (span) async {
+              callbackExecuted = true;
+              receivedSpan = span;
+              await Future<void>.delayed(Duration.zero); // Simulate async work
+              return expectedResult;
+            },
+          );
 
-        // Verify span error handling
-        verify(() => mockSpan.setStatus(
+          // Assert
+          expect(result, equals(expectedResult));
+          expect(callbackExecuted, isTrue);
+          expect(receivedSpan, equals(mockSpan));
+          verify(() => mockSpan.end()).called(1);
+        },
+      );
+
+      test(
+        'should handle exception, set span error status, record exception, and rethrow',
+        () async {
+          // Arrange
+          final testException = Exception('test-exception');
+
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
+
+          // Act & Assert
+          expect(
+            () async => faroZoneSpanManager.executeWithSpan<String>(
+              mockSpan,
+              (span) => throw testException,
+            ),
+            throwsA(equals(testException)),
+          );
+
+          // Verify span error handling
+          verify(
+            () => mockSpan.setStatus(
               SpanStatusCode.error,
               message: testException.toString(),
-            )).called(1);
-        verify(() => mockSpan.recordException(
+            ),
+          ).called(1);
+          verify(
+            () => mockSpan.recordException(
               testException,
               stackTrace: any(named: 'stackTrace'),
-            )).called(1);
-        verify(() => mockSpan.end()).called(1);
-      });
+            ),
+          ).called(1);
+          verify(() => mockSpan.end()).called(1);
+        },
+      );
 
       test('should ensure span is ended even if exception occurs', () async {
         // Arrange
         final testException = StateError('test-error');
 
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
+        when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+          invocation,
+        ) async {
           final callback =
               invocation.positionalArguments[0] as Future<String> Function();
           return callback();
@@ -246,44 +267,51 @@ void main() {
       });
 
       test(
-          'should handle error in span.end() gracefully (end exception masks original)',
-          () async {
-        // Arrange
-        final originalException = Exception('original-exception');
-        final endException = Exception('end-exception');
+        'should handle error in span.end() gracefully (end exception masks original)',
+        () async {
+          // Arrange
+          final originalException = Exception('original-exception');
+          final endException = Exception('end-exception');
 
-        when(() => mockSpan.end()).thenThrow(endException);
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
+          when(() => mockSpan.end()).thenThrow(endException);
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
 
-        // Act & Assert - The end exception will mask the original exception (standard Dart behavior)
-        expect(
-          () async => faroZoneSpanManager.executeWithSpan<String>(
-            mockSpan,
-            (span) => throw originalException,
-          ),
-          throwsA(equals(endException)),
-        );
+          // Act & Assert - The end exception will mask the original exception (standard Dart behavior)
+          expect(
+            () async => faroZoneSpanManager.executeWithSpan<String>(
+              mockSpan,
+              (span) => throw originalException,
+            ),
+            throwsA(equals(endException)),
+          );
 
-        verify(() => mockSpan.setStatus(
+          verify(
+            () => mockSpan.setStatus(
               SpanStatusCode.error,
               message: originalException.toString(),
-            )).called(1);
-        verify(() => mockSpan.recordException(
+            ),
+          ).called(1);
+          verify(
+            () => mockSpan.recordException(
               originalException,
               stackTrace: any(named: 'stackTrace'),
-            )).called(1);
-        verify(() => mockSpan.end()).called(1);
-      });
+            ),
+          ).called(1);
+          verify(() => mockSpan.end()).called(1);
+        },
+      );
 
       test('should pass zone values to zone runner', () async {
         // Arrange
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
+        when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+          invocation,
+        ) async {
           final callback =
               invocation.positionalArguments[0] as Future<String> Function();
           return callback();
@@ -296,141 +324,160 @@ void main() {
         );
 
         // Assert
-        verify(() => mockZoneRunner.call<String>(
-              any(),
-              any(that: predicate<Map<Object?, Object?>>((zoneValues) {
+        verify(
+          () => mockZoneRunner.call<String>(
+            any(),
+            any(
+              that: predicate<Map<Object?, Object?>>((zoneValues) {
                 final holder = zoneValues[const Symbol('faroSpanContext')];
                 return holder is SpanContextHolder && holder.span == mockSpan;
-              })),
-            )).called(1);
-      });
-
-      test('should set status to OK when statusHasBeenSet is false on success',
-          () async {
-        // Arrange
-        when(() => mockSpan.statusHasBeenSet).thenReturn(false);
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
-
-        // Act
-        await faroZoneSpanManager.executeWithSpan<String>(
-          mockSpan,
-          (span) => 'result',
-        );
-
-        // Assert
-        verify(() => mockSpan.setStatus(SpanStatusCode.ok)).called(1);
+              }),
+            ),
+          ),
+        ).called(1);
       });
 
       test(
-          'should NOT set status to OK when statusHasBeenSet is true on success',
-          () async {
-        // Arrange
-        when(() => mockSpan.statusHasBeenSet).thenReturn(true);
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
+        'should set status to OK when statusHasBeenSet is false on success',
+        () async {
+          // Arrange
+          when(() => mockSpan.statusHasBeenSet).thenReturn(false);
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
 
-        // Act
-        await faroZoneSpanManager.executeWithSpan<String>(
-          mockSpan,
-          (span) => 'result',
-        );
-
-        // Assert
-        verifyNever(() => mockSpan.setStatus(SpanStatusCode.ok));
-      });
-
-      test('should set status to ERROR when statusHasBeenSet is false on error',
-          () async {
-        // Arrange
-        final testException = Exception('test-exception');
-        when(() => mockSpan.statusHasBeenSet).thenReturn(false);
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
-
-        // Act & Assert
-        expect(
-          () async => faroZoneSpanManager.executeWithSpan<String>(
+          // Act
+          await faroZoneSpanManager.executeWithSpan<String>(
             mockSpan,
-            (span) => throw testException,
-          ),
-          throwsA(equals(testException)),
-        );
+            (span) => 'result',
+          );
 
-        // Verify span error handling
-        verify(() => mockSpan.setStatus(
-              SpanStatusCode.error,
-              message: testException.toString(),
-            )).called(1);
-      });
+          // Assert
+          verify(() => mockSpan.setStatus(SpanStatusCode.ok)).called(1);
+        },
+      );
 
       test(
-          'should NOT set status to ERROR when statusHasBeenSet is true on error',
-          () async {
-        // Arrange
-        final testException = Exception('test-exception');
-        when(() => mockSpan.statusHasBeenSet).thenReturn(true);
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
+        'should NOT set status to OK when statusHasBeenSet is true on success',
+        () async {
+          // Arrange
+          when(() => mockSpan.statusHasBeenSet).thenReturn(true);
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
 
-        // Act & Assert
-        expect(
-          () async => faroZoneSpanManager.executeWithSpan<String>(
+          // Act
+          await faroZoneSpanManager.executeWithSpan<String>(
             mockSpan,
-            (span) => throw testException,
-          ),
-          throwsA(equals(testException)),
-        );
+            (span) => 'result',
+          );
 
-        // Verify span error handling is NOT called
-        verifyNever(() => mockSpan.setStatus(
+          // Assert
+          verifyNever(() => mockSpan.setStatus(SpanStatusCode.ok));
+        },
+      );
+
+      test(
+        'should set status to ERROR when statusHasBeenSet is false on error',
+        () async {
+          // Arrange
+          final testException = Exception('test-exception');
+          when(() => mockSpan.statusHasBeenSet).thenReturn(false);
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
+
+          // Act & Assert
+          expect(
+            () async => faroZoneSpanManager.executeWithSpan<String>(
+              mockSpan,
+              (span) => throw testException,
+            ),
+            throwsA(equals(testException)),
+          );
+
+          // Verify span error handling
+          verify(
+            () => mockSpan.setStatus(
               SpanStatusCode.error,
               message: testException.toString(),
-            ));
-        // But exception is still recorded
-        verify(() => mockSpan.recordException(
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'should NOT set status to ERROR when statusHasBeenSet is true on error',
+        () async {
+          // Arrange
+          final testException = Exception('test-exception');
+          when(() => mockSpan.statusHasBeenSet).thenReturn(true);
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
+
+          // Act & Assert
+          expect(
+            () async => faroZoneSpanManager.executeWithSpan<String>(
+              mockSpan,
+              (span) => throw testException,
+            ),
+            throwsA(equals(testException)),
+          );
+
+          // Verify span error handling is NOT called
+          verifyNever(
+            () => mockSpan.setStatus(
+              SpanStatusCode.error,
+              message: testException.toString(),
+            ),
+          );
+          // But exception is still recorded
+          verify(
+            () => mockSpan.recordException(
               testException,
               stackTrace: any(named: 'stackTrace'),
-            )).called(1);
-      });
+            ),
+          ).called(1);
+        },
+      );
 
       test('should respect manually set status during success flow', () async {
         // Arrange
         var statusHasBeenSet = false;
-        when(() => mockSpan.statusHasBeenSet)
-            .thenAnswer((_) => statusHasBeenSet);
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
+        when(
+          () => mockSpan.statusHasBeenSet,
+        ).thenAnswer((_) => statusHasBeenSet);
+        when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+          invocation,
+        ) async {
           final callback =
               invocation.positionalArguments[0] as Future<String> Function();
           return callback();
         });
 
         // Act
-        await faroZoneSpanManager.executeWithSpan<String>(
-          mockSpan,
-          (span) {
-            // Simulate manually setting status during execution
-            statusHasBeenSet = true;
-            return 'result';
-          },
-        );
+        await faroZoneSpanManager.executeWithSpan<String>(mockSpan, (span) {
+          // Simulate manually setting status during execution
+          statusHasBeenSet = true;
+          return 'result';
+        });
 
         // Assert - should NOT have been called since statusHasBeenSet was true when checked
         verifyNever(() => mockSpan.setStatus(SpanStatusCode.ok));
@@ -440,10 +487,12 @@ void main() {
         // Arrange
         final testException = Exception('test-exception');
         var statusHasBeenSet = false;
-        when(() => mockSpan.statusHasBeenSet)
-            .thenAnswer((_) => statusHasBeenSet);
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
+        when(
+          () => mockSpan.statusHasBeenSet,
+        ).thenAnswer((_) => statusHasBeenSet);
+        when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+          invocation,
+        ) async {
           final callback =
               invocation.positionalArguments[0] as Future<String> Function();
           return callback();
@@ -451,27 +500,29 @@ void main() {
 
         // Act & Assert
         expect(
-          () async => faroZoneSpanManager.executeWithSpan<String>(
-            mockSpan,
-            (span) {
-              // Simulate manually setting status during execution
-              statusHasBeenSet = true;
-              throw testException;
-            },
-          ),
+          () async =>
+              faroZoneSpanManager.executeWithSpan<String>(mockSpan, (span) {
+                // Simulate manually setting status during execution
+                statusHasBeenSet = true;
+                throw testException;
+              }),
           throwsA(equals(testException)),
         );
 
         // Assert - should NOT have been called since statusHasBeenSet was true when checked
-        verifyNever(() => mockSpan.setStatus(
-              SpanStatusCode.error,
-              message: testException.toString(),
-            ));
+        verifyNever(
+          () => mockSpan.setStatus(
+            SpanStatusCode.error,
+            message: testException.toString(),
+          ),
+        );
         // But exception should still be recorded
-        verify(() => mockSpan.recordException(
-              testException,
-              stackTrace: any(named: 'stackTrace'),
-            )).called(1);
+        verify(
+          () => mockSpan.recordException(
+            testException,
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
       });
     });
   });
@@ -491,33 +542,34 @@ void main() {
       expect(result, isA<FaroZoneSpanManager>());
     });
 
-    test('should create FaroZoneSpanManager that works with real Zone',
-        () async {
-      // Arrange
-      final spanManager = factory.create();
-      final mockSpan = MockSpan();
-      var callbackExecuted = false;
+    test(
+      'should create FaroZoneSpanManager that works with real Zone',
+      () async {
+        // Arrange
+        final spanManager = factory.create();
+        final mockSpan = MockSpan();
+        var callbackExecuted = false;
 
-      // Setup required stubs for the mock span
-      when(() => mockSpan.statusHasBeenSet).thenReturn(false);
+        // Setup required stubs for the mock span
+        when(() => mockSpan.statusHasBeenSet).thenReturn(false);
 
-      // Act
-      final result = await spanManager.executeWithSpan<String>(
-        mockSpan,
-        (span) {
+        // Act
+        final result = await spanManager.executeWithSpan<String>(mockSpan, (
+          span,
+        ) {
           callbackExecuted = true;
           // Verify we can get the active span within the zone
           final activeSpan = spanManager.getActiveSpan();
           expect(activeSpan, equals(mockSpan));
           return 'zone-test-result';
-        },
-      );
+        });
 
-      // Assert
-      expect(result, equals('zone-test-result'));
-      expect(callbackExecuted, isTrue);
-      verify(mockSpan.end).called(1);
-    });
+        // Assert
+        expect(result, equals('zone-test-result'));
+        expect(callbackExecuted, isTrue);
+        verify(mockSpan.end).called(1);
+      },
+    );
 
     test('should return null for getActiveSpan when no zone context', () {
       // Arrange
@@ -584,21 +636,22 @@ void main() {
       });
 
       test(
-          'should still return span when holder uses ContextScope.zone and is active',
-          () {
-        // Arrange
-        final holder = SpanContextHolder(
-          span: mockSpan,
-          contextScope: ContextScope.zone,
-        );
-        when(() => mockParentSpanLookup.call(any())).thenReturn(holder);
+        'should still return span when holder uses ContextScope.zone and is active',
+        () {
+          // Arrange
+          final holder = SpanContextHolder(
+            span: mockSpan,
+            contextScope: ContextScope.zone,
+          );
+          when(() => mockParentSpanLookup.call(any())).thenReturn(holder);
 
-        // Act
-        final result = faroZoneSpanManager.getActiveSpan();
+          // Act
+          final result = faroZoneSpanManager.getActiveSpan();
 
-        // Assert
-        expect(result, equals(mockSpan));
-      });
+          // Assert
+          expect(result, equals(mockSpan));
+        },
+      );
     });
 
     group('executeWithSpan with ContextScope:', () {
@@ -622,58 +675,64 @@ void main() {
       });
 
       test(
-          'should pass SpanContextHolder to zone values instead of span directly',
-          () async {
-        // Arrange
-        SpanContextHolder? capturedHolder;
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final zoneValues =
-              invocation.positionalArguments[1] as Map<Object?, Object?>;
-          capturedHolder =
-              zoneValues[const Symbol('faroSpanContext')] as SpanContextHolder?;
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
+        'should pass SpanContextHolder to zone values instead of span directly',
+        () async {
+          // Arrange
+          SpanContextHolder? capturedHolder;
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final zoneValues =
+                invocation.positionalArguments[1] as Map<Object?, Object?>;
+            capturedHolder =
+                zoneValues[const Symbol('faroSpanContext')]
+                    as SpanContextHolder?;
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
 
-        // Act
-        await faroZoneSpanManager.executeWithSpan<String>(
-          mockSpan,
-          (span) => 'result',
-        );
+          // Act
+          await faroZoneSpanManager.executeWithSpan<String>(
+            mockSpan,
+            (span) => 'result',
+          );
 
-        // Assert
-        expect(capturedHolder, isNotNull);
-        expect(capturedHolder!.span, equals(mockSpan));
-      });
+          // Assert
+          expect(capturedHolder, isNotNull);
+          expect(capturedHolder!.span, equals(mockSpan));
+        },
+      );
 
       test(
-          'should deactivate holder after callback completes with ContextScope.callback (default)',
-          () async {
-        // Arrange
-        SpanContextHolder? capturedHolder;
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final zoneValues =
-              invocation.positionalArguments[1] as Map<Object?, Object?>;
-          capturedHolder =
-              zoneValues[const Symbol('faroSpanContext')] as SpanContextHolder?;
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
+        'should deactivate holder after callback completes with ContextScope.callback (default)',
+        () async {
+          // Arrange
+          SpanContextHolder? capturedHolder;
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final zoneValues =
+                invocation.positionalArguments[1] as Map<Object?, Object?>;
+            capturedHolder =
+                zoneValues[const Symbol('faroSpanContext')]
+                    as SpanContextHolder?;
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
 
-        // Act
-        await faroZoneSpanManager.executeWithSpan<String>(
-          mockSpan,
-          (span) => 'result',
-        );
+          // Act
+          await faroZoneSpanManager.executeWithSpan<String>(
+            mockSpan,
+            (span) => 'result',
+          );
 
-        // Assert - holder should be deactivated after callback completes
-        expect(capturedHolder, isNotNull);
-        expect(capturedHolder!.isActive, isFalse);
-      });
+          // Assert - holder should be deactivated after callback completes
+          expect(capturedHolder, isNotNull);
+          expect(capturedHolder!.isActive, isFalse);
+        },
+      );
 
       test('should deactivate holder AFTER span.end() is called', () async {
         // Arrange
@@ -683,8 +742,9 @@ void main() {
         when(() => mockSpan.end()).thenAnswer((_) {
           holderWasActiveWhenEndCalled = capturedHolder?.isActive;
         });
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
+        when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+          invocation,
+        ) async {
           final zoneValues =
               invocation.positionalArguments[1] as Map<Object?, Object?>;
           capturedHolder =
@@ -708,8 +768,9 @@ void main() {
       test('should NOT deactivate holder with ContextScope.zone', () async {
         // Arrange
         SpanContextHolder? capturedHolder;
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
+        when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+          invocation,
+        ) async {
           final zoneValues =
               invocation.positionalArguments[1] as Map<Object?, Object?>;
           capturedHolder =
@@ -735,8 +796,9 @@ void main() {
         // Arrange
         final testException = Exception('test-exception');
         SpanContextHolder? capturedHolder;
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
+        when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+          invocation,
+        ) async {
           final zoneValues =
               invocation.positionalArguments[1] as Map<Object?, Object?>;
           capturedHolder =
@@ -760,36 +822,40 @@ void main() {
         expect(capturedHolder!.isActive, isFalse);
       });
 
-      test('should NOT deactivate holder on exception with ContextScope.zone',
-          () async {
-        // Arrange
-        final testException = Exception('test-exception');
-        SpanContextHolder? capturedHolder;
-        when(() => mockZoneRunner.call<String>(any(), any()))
-            .thenAnswer((invocation) async {
-          final zoneValues =
-              invocation.positionalArguments[1] as Map<Object?, Object?>;
-          capturedHolder =
-              zoneValues[const Symbol('faroSpanContext')] as SpanContextHolder?;
-          final callback =
-              invocation.positionalArguments[0] as Future<String> Function();
-          return callback();
-        });
+      test(
+        'should NOT deactivate holder on exception with ContextScope.zone',
+        () async {
+          // Arrange
+          final testException = Exception('test-exception');
+          SpanContextHolder? capturedHolder;
+          when(() => mockZoneRunner.call<String>(any(), any())).thenAnswer((
+            invocation,
+          ) async {
+            final zoneValues =
+                invocation.positionalArguments[1] as Map<Object?, Object?>;
+            capturedHolder =
+                zoneValues[const Symbol('faroSpanContext')]
+                    as SpanContextHolder?;
+            final callback =
+                invocation.positionalArguments[0] as Future<String> Function();
+            return callback();
+          });
 
-        // Act & Assert
-        expect(
-          () async => faroZoneSpanManager.executeWithSpan<String>(
-            mockSpan,
-            (span) => throw testException,
-            contextScope: ContextScope.zone,
-          ),
-          throwsA(equals(testException)),
-        );
+          // Act & Assert
+          expect(
+            () async => faroZoneSpanManager.executeWithSpan<String>(
+              mockSpan,
+              (span) => throw testException,
+              contextScope: ContextScope.zone,
+            ),
+            throwsA(equals(testException)),
+          );
 
-        // Assert - holder should still be active with ContextScope.zone
-        expect(capturedHolder, isNotNull);
-        expect(capturedHolder!.isActive, isTrue);
-      });
+          // Assert - holder should still be active with ContextScope.zone
+          expect(capturedHolder, isNotNull);
+          expect(capturedHolder!.isActive, isTrue);
+        },
+      );
     });
   });
 
@@ -859,50 +925,55 @@ void main() {
     });
 
     test(
-        'ContextScope.callback: getActiveSpan returns null after callback completes',
-        () async {
-      // Arrange
-      Span? activeSpanDuringCallback;
-      Span? activeSpanAfterCallback;
-      final completer = Completer<void>();
+      'ContextScope.callback: getActiveSpan returns null after callback completes',
+      () async {
+        // Arrange
+        Span? activeSpanDuringCallback;
+        Span? activeSpanAfterCallback;
+        final completer = Completer<void>();
 
-      // Act
-      await spanManager.executeWithSpan<void>(
-        mockSpan,
-        (span) async {
-          activeSpanDuringCallback = spanManager.getActiveSpan();
+        // Act
+        await spanManager.executeWithSpan<void>(
+          mockSpan,
+          (span) async {
+            activeSpanDuringCallback = spanManager.getActiveSpan();
 
-          // Schedule a timer that will fire after the callback completes
-          Timer(Duration.zero, () {
-            activeSpanAfterCallback = spanManager.getActiveSpan();
-            completer.complete();
-          });
-        },
-        // Using default ContextScope.callback
-      );
+            // Schedule a timer that will fire after the callback completes
+            Timer(Duration.zero, () {
+              activeSpanAfterCallback = spanManager.getActiveSpan();
+              completer.complete();
+            });
+          },
+          // Using default ContextScope.callback
+        );
 
-      // Wait for the timer to fire
-      await completer.future;
+        // Wait for the timer to fire
+        await completer.future;
 
-      // Assert
-      expect(activeSpanDuringCallback, equals(mockSpan),
-          reason: 'Span should be active during callback');
-      expect(activeSpanAfterCallback, isNull,
-          reason: 'Span should be deactivated after callback completes');
-    });
+        // Assert
+        expect(
+          activeSpanDuringCallback,
+          equals(mockSpan),
+          reason: 'Span should be active during callback',
+        );
+        expect(
+          activeSpanAfterCallback,
+          isNull,
+          reason: 'Span should be deactivated after callback completes',
+        );
+      },
+    );
 
     test(
-        'ContextScope.zone: getActiveSpan returns span even after callback completes',
-        () async {
-      // Arrange
-      Span? activeSpanDuringCallback;
-      Span? activeSpanAfterCallback;
-      final completer = Completer<void>();
+      'ContextScope.zone: getActiveSpan returns span even after callback completes',
+      () async {
+        // Arrange
+        Span? activeSpanDuringCallback;
+        Span? activeSpanAfterCallback;
+        final completer = Completer<void>();
 
-      // Act
-      await spanManager.executeWithSpan<void>(
-        mockSpan,
-        (span) async {
+        // Act
+        await spanManager.executeWithSpan<void>(mockSpan, (span) async {
           activeSpanDuringCallback = spanManager.getActiveSpan();
 
           // Schedule a timer that will fire after the callback completes
@@ -910,19 +981,24 @@ void main() {
             activeSpanAfterCallback = spanManager.getActiveSpan();
             completer.complete();
           });
-        },
-        contextScope: ContextScope.zone,
-      );
+        }, contextScope: ContextScope.zone);
 
-      // Wait for the timer to fire
-      await completer.future;
+        // Wait for the timer to fire
+        await completer.future;
 
-      // Assert
-      expect(activeSpanDuringCallback, equals(mockSpan),
-          reason: 'Span should be active during callback');
-      expect(activeSpanAfterCallback, equals(mockSpan),
-          reason: 'Span should remain active with ContextScope.zone');
-    });
+        // Assert
+        expect(
+          activeSpanDuringCallback,
+          equals(mockSpan),
+          reason: 'Span should be active during callback',
+        );
+        expect(
+          activeSpanAfterCallback,
+          equals(mockSpan),
+          reason: 'Span should remain active with ContextScope.zone',
+        );
+      },
+    );
 
     test('nested spans work correctly with ContextScope.callback', () async {
       // Arrange
@@ -936,27 +1012,24 @@ void main() {
       Span? activeSpanAfterChild;
 
       // Act
-      await spanManager.executeWithSpan<void>(
-        parentSpan,
-        (parent) async {
-          activeSpanInParent = spanManager.getActiveSpan();
+      await spanManager.executeWithSpan<void>(parentSpan, (parent) async {
+        activeSpanInParent = spanManager.getActiveSpan();
 
-          await spanManager.executeWithSpan<void>(
-            childSpan,
-            (child) async {
-              activeSpanInChild = spanManager.getActiveSpan();
-            },
-          );
+        await spanManager.executeWithSpan<void>(childSpan, (child) async {
+          activeSpanInChild = spanManager.getActiveSpan();
+        });
 
-          activeSpanAfterChild = spanManager.getActiveSpan();
-        },
-      );
+        activeSpanAfterChild = spanManager.getActiveSpan();
+      });
 
       // Assert
       expect(activeSpanInParent, equals(parentSpan));
       expect(activeSpanInChild, equals(childSpan));
-      expect(activeSpanAfterChild, equals(parentSpan),
-          reason: 'After child completes, parent should be active again');
+      expect(
+        activeSpanAfterChild,
+        equals(parentSpan),
+        reason: 'After child completes, parent should be active again',
+      );
     });
   });
 }

--- a/test/src/tracing/otel_attribute_types_test.dart
+++ b/test/src/tracing/otel_attribute_types_test.dart
@@ -97,16 +97,12 @@ void main() {
       final attrList = json['attributes'] as List;
 
       // Find test_int attribute
-      final testIntAttr = attrList.firstWhere(
-        (a) => a['key'] == 'test_int',
-      );
+      final testIntAttr = attrList.firstWhere((a) => a['key'] == 'test_int');
       expect(testIntAttr['value']['intValue'], equals(42));
       expect(testIntAttr['value'].containsKey('stringValue'), isFalse);
 
       // Find test_bool attribute
-      final testBoolAttr = attrList.firstWhere(
-        (a) => a['key'] == 'test_bool',
-      );
+      final testBoolAttr = attrList.firstWhere((a) => a['key'] == 'test_bool');
       expect(testBoolAttr['value']['boolValue'], equals(true));
       expect(testBoolAttr['value'].containsKey('stringValue'), isFalse);
 

--- a/test/src/tracing/span_test.dart
+++ b/test/src/tracing/span_test.dart
@@ -28,31 +28,19 @@ void main() {
     });
 
     test('should throw UnsupportedError when traceId is accessed', () {
-      expect(
-        () => Span.noParent.traceId,
-        throwsA(isA<UnsupportedError>()),
-      );
+      expect(() => Span.noParent.traceId, throwsA(isA<UnsupportedError>()));
     });
 
     test('should throw UnsupportedError when spanId is accessed', () {
-      expect(
-        () => Span.noParent.spanId,
-        throwsA(isA<UnsupportedError>()),
-      );
+      expect(() => Span.noParent.spanId, throwsA(isA<UnsupportedError>()));
     });
 
     test('should throw UnsupportedError when wasEnded is accessed', () {
-      expect(
-        () => Span.noParent.wasEnded,
-        throwsA(isA<UnsupportedError>()),
-      );
+      expect(() => Span.noParent.wasEnded, throwsA(isA<UnsupportedError>()));
     });
 
     test('should throw UnsupportedError when status is accessed', () {
-      expect(
-        () => Span.noParent.status,
-        throwsA(isA<UnsupportedError>()),
-      );
+      expect(() => Span.noParent.status, throwsA(isA<UnsupportedError>()));
     });
 
     test('should throw UnsupportedError when statusHasBeenSet is accessed', () {
@@ -98,17 +86,11 @@ void main() {
     });
 
     test('should throw UnsupportedError when traceparent is accessed', () {
-      expect(
-        () => Span.noParent.traceparent,
-        throwsA(isA<UnsupportedError>()),
-      );
+      expect(() => Span.noParent.traceparent, throwsA(isA<UnsupportedError>()));
     });
 
     test('should throw UnsupportedError when end is called', () {
-      expect(
-        () => Span.noParent.end(),
-        throwsA(isA<UnsupportedError>()),
-      );
+      expect(() => Span.noParent.end(), throwsA(isA<UnsupportedError>()));
     });
 
     test('should have descriptive error message', () {
@@ -146,9 +128,7 @@ void main() {
       Span createSpanWithTraceFlags(int traceFlags) {
         when(() => mockOtelSpan.spanContext).thenReturn(
           otel_api.SpanContext(
-            otel_api.TraceId.fromString(
-              '00000000000000000000000000000001',
-            ),
+            otel_api.TraceId.fromString('00000000000000000000000000000001'),
             otel_api.SpanId.fromString('0000000000000001'),
             traceFlags,
             otel_api.TraceState.empty(),
@@ -200,7 +180,8 @@ void main() {
 
         when(() => mockOtelSpan.setAttributes(any())).thenAnswer((invocation) {
           capturedAttributes.addAll(
-              invocation.positionalArguments[0] as List<otel_api.Attribute>);
+            invocation.positionalArguments[0] as List<otel_api.Attribute>,
+          );
         });
 
         span.setAttributes({'name': 'test'});
@@ -216,7 +197,8 @@ void main() {
 
         when(() => mockOtelSpan.setAttributes(any())).thenAnswer((invocation) {
           capturedAttributes.addAll(
-              invocation.positionalArguments[0] as List<otel_api.Attribute>);
+            invocation.positionalArguments[0] as List<otel_api.Attribute>,
+          );
         });
 
         span.setAttributes({'count': 42});
@@ -232,7 +214,8 @@ void main() {
 
         when(() => mockOtelSpan.setAttributes(any())).thenAnswer((invocation) {
           capturedAttributes.addAll(
-              invocation.positionalArguments[0] as List<otel_api.Attribute>);
+            invocation.positionalArguments[0] as List<otel_api.Attribute>,
+          );
         });
 
         span.setAttributes({'score': 99.5});
@@ -248,7 +231,8 @@ void main() {
 
         when(() => mockOtelSpan.setAttributes(any())).thenAnswer((invocation) {
           capturedAttributes.addAll(
-              invocation.positionalArguments[0] as List<otel_api.Attribute>);
+            invocation.positionalArguments[0] as List<otel_api.Attribute>,
+          );
         });
 
         span.setAttributes({'enabled': true});
@@ -264,7 +248,8 @@ void main() {
 
         when(() => mockOtelSpan.setAttributes(any())).thenAnswer((invocation) {
           capturedAttributes.addAll(
-              invocation.positionalArguments[0] as List<otel_api.Attribute>);
+            invocation.positionalArguments[0] as List<otel_api.Attribute>,
+          );
         });
 
         span.setAttributes({
@@ -277,7 +262,7 @@ void main() {
         expect(capturedAttributes.length, 4);
 
         final attrMap = {
-          for (final attr in capturedAttributes) attr.key: attr.value
+          for (final attr in capturedAttributes) attr.key: attr.value,
         };
         expect(attrMap['name'], 'test');
         expect(attrMap['count'], 42);
@@ -291,26 +276,34 @@ void main() {
         final span = createSpan();
         final capturedAttributes = <otel_api.Attribute>[];
 
-        when(() => mockOtelSpan.addEvent(any(),
-            attributes: any(named: 'attributes'))).thenAnswer((invocation) {
-          final attrs = invocation.namedArguments[const Symbol('attributes')]
-              as List<otel_api.Attribute>?;
+        when(
+          () => mockOtelSpan.addEvent(
+            any(),
+            attributes: any(named: 'attributes'),
+          ),
+        ).thenAnswer((invocation) {
+          final attrs =
+              invocation.namedArguments[const Symbol('attributes')]
+                  as List<otel_api.Attribute>?;
           if (attrs != null) {
             capturedAttributes.addAll(attrs);
           }
         });
 
-        span.addEvent('test event', attributes: {
-          'message': 'hello',
-          'count': 5,
-          'duration': 1.5,
-          'success': true,
-        });
+        span.addEvent(
+          'test event',
+          attributes: {
+            'message': 'hello',
+            'count': 5,
+            'duration': 1.5,
+            'success': true,
+          },
+        );
 
         expect(capturedAttributes.length, 4);
 
         final attrMap = {
-          for (final attr in capturedAttributes) attr.key: attr.value
+          for (final attr in capturedAttributes) attr.key: attr.value,
         };
         expect(attrMap['message'], 'hello');
         expect(attrMap['count'], 5);

--- a/test/src/user/user_manager_test.dart
+++ b/test/src/user/user_manager_test.dart
@@ -52,16 +52,18 @@ void main() {
         verifyNever(() => mockPersistence.clearUser());
       });
 
-      test('applies user and clears stale data when persistUser is false',
-          () async {
-        const user = FaroUser(id: 'test-user');
+      test(
+        'applies user and clears stale data when persistUser is false',
+        () async {
+          const user = FaroUser(id: 'test-user');
 
-        await userManager.setUser(user, persistUser: false);
+          await userManager.setUser(user, persistUser: false);
 
-        expect(appliedUserJson?['id'], 'test-user');
-        verify(() => mockPersistence.clearUser()).called(1);
-        verifyNever(() => mockPersistence.saveUser(any()));
-      });
+          expect(appliedUserJson?['id'], 'test-user');
+          verify(() => mockPersistence.clearUser()).called(1);
+          verifyNever(() => mockPersistence.saveUser(any()));
+        },
+      );
 
       test('clears user when FaroUser.cleared() is passed', () async {
         // First set a user
@@ -173,20 +175,22 @@ void main() {
           verifyNever(() => mockPersistence.loadUser());
         });
 
-        test('clears persisted user when initialUser.cleared() is used',
-            () async {
-          const persistedUser = FaroUser(id: 'persisted-user');
-          when(() => mockPersistence.loadUser()).thenReturn(persistedUser);
+        test(
+          'clears persisted user when initialUser.cleared() is used',
+          () async {
+            const persistedUser = FaroUser(id: 'persisted-user');
+            when(() => mockPersistence.loadUser()).thenReturn(persistedUser);
 
-          await userManager.initialize(
-            initialUser: const FaroUser.cleared(),
-            persistUser: true,
-          );
+            await userManager.initialize(
+              initialUser: const FaroUser.cleared(),
+              persistUser: true,
+            );
 
-          // No user applied when cleared
-          expect(appliedUserJson, isNull);
-          verify(() => mockPersistence.clearUser()).called(1);
-        });
+            // No user applied when cleared
+            expect(appliedUserJson, isNull);
+            verify(() => mockPersistence.clearUser()).called(1);
+          },
+        );
 
         test('has no user when no persisted and no initialUser', () async {
           when(() => mockPersistence.loadUser()).thenReturn(null);

--- a/test/src/user/user_persistence_test.dart
+++ b/test/src/user/user_persistence_test.dart
@@ -20,15 +20,17 @@ void main() {
   group('UserPersistence:', () {
     group('loadUser:', () {
       test('should return null when no user is stored', () {
-        when(() => mockSharedPreferences.getString('faro_persisted_user'))
-            .thenReturn(null);
+        when(
+          () => mockSharedPreferences.getString('faro_persisted_user'),
+        ).thenReturn(null);
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
         final result = sut.loadUser();
 
         expect(result, isNull);
-        verify(() => mockSharedPreferences.getString('faro_persisted_user'))
-            .called(1);
+        verify(
+          () => mockSharedPreferences.getString('faro_persisted_user'),
+        ).called(1);
       });
 
       test('should return persisted user when stored', () {
@@ -37,8 +39,9 @@ void main() {
           'username': 'john.doe',
           'email': 'john@example.com',
         };
-        when(() => mockSharedPreferences.getString('faro_persisted_user'))
-            .thenReturn(json.encode(userData));
+        when(
+          () => mockSharedPreferences.getString('faro_persisted_user'),
+        ).thenReturn(json.encode(userData));
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
         final result = sut.loadUser();
@@ -50,8 +53,9 @@ void main() {
       });
 
       test('should return null when JSON is invalid', () {
-        when(() => mockSharedPreferences.getString('faro_persisted_user'))
-            .thenReturn('invalid json');
+        when(
+          () => mockSharedPreferences.getString('faro_persisted_user'),
+        ).thenReturn('invalid json');
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
         final result = sut.loadUser();
@@ -60,8 +64,9 @@ void main() {
       });
 
       test('should handle errors gracefully', () {
-        when(() => mockSharedPreferences.getString('faro_persisted_user'))
-            .thenThrow(Exception('Storage error'));
+        when(
+          () => mockSharedPreferences.getString('faro_persisted_user'),
+        ).thenThrow(Exception('Storage error'));
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
         final result = sut.loadUser();
@@ -72,8 +77,9 @@ void main() {
 
     group('saveUser:', () {
       test('should persist user data', () async {
-        when(() => mockSharedPreferences.setString(any(), any()))
-            .thenAnswer((_) async => true);
+        when(
+          () => mockSharedPreferences.setString(any(), any()),
+        ).thenAnswer((_) async => true);
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
         const user = FaroUser(
@@ -84,10 +90,14 @@ void main() {
 
         await sut.saveUser(user);
 
-        final captured = verify(
-          () => mockSharedPreferences.setString(
-              'faro_persisted_user', captureAny()),
-        ).captured.single as String;
+        final captured =
+            verify(
+                  () => mockSharedPreferences.setString(
+                    'faro_persisted_user',
+                    captureAny(),
+                  ),
+                ).captured.single
+                as String;
 
         final savedData = json.decode(captured) as Map<String, dynamic>;
         expect(savedData['id'], 'user-123');
@@ -96,34 +106,39 @@ void main() {
       });
 
       test('should clear user when null is passed', () async {
-        when(() => mockSharedPreferences.remove(any()))
-            .thenAnswer((_) async => true);
+        when(
+          () => mockSharedPreferences.remove(any()),
+        ).thenAnswer((_) async => true);
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
 
         await sut.saveUser(null);
 
-        verify(() => mockSharedPreferences.remove('faro_persisted_user'))
-            .called(1);
+        verify(
+          () => mockSharedPreferences.remove('faro_persisted_user'),
+        ).called(1);
         verifyNever(() => mockSharedPreferences.setString(any(), any()));
       });
 
       test('should clear user when cleared user is passed', () async {
-        when(() => mockSharedPreferences.remove(any()))
-            .thenAnswer((_) async => true);
+        when(
+          () => mockSharedPreferences.remove(any()),
+        ).thenAnswer((_) async => true);
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
 
         await sut.saveUser(const FaroUser.cleared());
 
-        verify(() => mockSharedPreferences.remove('faro_persisted_user'))
-            .called(1);
+        verify(
+          () => mockSharedPreferences.remove('faro_persisted_user'),
+        ).called(1);
         verifyNever(() => mockSharedPreferences.setString(any(), any()));
       });
 
       test('should handle errors gracefully', () async {
-        when(() => mockSharedPreferences.setString(any(), any()))
-            .thenThrow(Exception('Storage error'));
+        when(
+          () => mockSharedPreferences.setString(any(), any()),
+        ).thenThrow(Exception('Storage error'));
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
 
@@ -134,20 +149,23 @@ void main() {
 
     group('clearUser:', () {
       test('should remove persisted user data', () async {
-        when(() => mockSharedPreferences.remove(any()))
-            .thenAnswer((_) async => true);
+        when(
+          () => mockSharedPreferences.remove(any()),
+        ).thenAnswer((_) async => true);
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
 
         await sut.clearUser();
 
-        verify(() => mockSharedPreferences.remove('faro_persisted_user'))
-            .called(1);
+        verify(
+          () => mockSharedPreferences.remove('faro_persisted_user'),
+        ).called(1);
       });
 
       test('should handle errors gracefully', () async {
-        when(() => mockSharedPreferences.remove(any()))
-            .thenThrow(Exception('Storage error'));
+        when(
+          () => mockSharedPreferences.remove(any()),
+        ).thenThrow(Exception('Storage error'));
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
 
@@ -158,8 +176,9 @@ void main() {
 
     group('hasPersistedUser:', () {
       test('should return true when user data exists', () {
-        when(() => mockSharedPreferences.containsKey('faro_persisted_user'))
-            .thenReturn(true);
+        when(
+          () => mockSharedPreferences.containsKey('faro_persisted_user'),
+        ).thenReturn(true);
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
 
@@ -167,8 +186,9 @@ void main() {
       });
 
       test('should return false when no user data exists', () {
-        when(() => mockSharedPreferences.containsKey('faro_persisted_user'))
-            .thenReturn(false);
+        when(
+          () => mockSharedPreferences.containsKey('faro_persisted_user'),
+        ).thenReturn(false);
 
         sut = UserPersistence(sharedPreferences: mockSharedPreferences);
 

--- a/test/src/user_actions/user_action_controller_test.dart
+++ b/test/src/user_actions/user_action_controller_test.dart
@@ -23,10 +23,7 @@ void main() {
     group('attach and cleanup:', () {
       test('should attach and start monitoring', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -43,10 +40,7 @@ void main() {
       });
 
       test('should clean up when action ends', () async {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final controller = UserActionLifecycleController(
           action,
@@ -66,10 +60,7 @@ void main() {
       });
 
       test('should clean up when action is cancelled', () async {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final controller = UserActionLifecycleController(
           action,
@@ -92,10 +83,7 @@ void main() {
     group('follow-up timeout:', () {
       test('should cancel action after follow-up timeout with no activity', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -117,10 +105,7 @@ void main() {
 
       test('should end action after follow-up timeout with valid activity', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -129,15 +114,13 @@ void main() {
 
           controller.attach();
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req1'),
+          );
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req1'),
+          );
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
 
@@ -150,10 +133,7 @@ void main() {
 
       test('should reset follow-up timeout on new activity', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -163,18 +143,16 @@ void main() {
           controller.attach();
 
           async.elapse(const Duration(milliseconds: 50));
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req1'),
+          );
 
           async.elapse(const Duration(milliseconds: 50));
           expect(action.getState(), equals(UserActionState.started));
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req1'),
+          );
           async.elapse(const Duration(milliseconds: 100));
 
           expect(action.getState(), equals(UserActionState.ended));
@@ -186,41 +164,39 @@ void main() {
     });
 
     group('halt logic:', () {
-      test('should halt action when pending requests exist after follow-up',
-          () {
-        fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+      test(
+        'should halt action when pending requests exist after follow-up',
+        () {
+          fakeAsync((async) {
+            final action = UserAction(name: 'test-action', trigger: 'test');
 
-          final controller = UserActionLifecycleController(
-            action,
-            signalController.stream,
-          );
+            final controller = UserActionLifecycleController(
+              action,
+              signalController.stream,
+            );
 
-          controller.attach();
+            controller.attach();
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
+            signalController.add(
+              UserActionSignal.pendingStart(
+                source: 'http',
+                operationId: 'req1',
+              ),
+            );
 
-          async.elapse(UserActionConstants.defaultFollowUpTimeout);
+            async.elapse(UserActionConstants.defaultFollowUpTimeout);
 
-          expect(action.getState(), equals(UserActionState.halted));
+            expect(action.getState(), equals(UserActionState.halted));
 
-          controller.dispose();
-          action.dispose();
-        });
-      });
+            controller.dispose();
+            action.dispose();
+          });
+        },
+      );
 
       test('should end action when all requests complete in halted state', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -229,18 +205,16 @@ void main() {
 
           controller.attach();
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req1'),
+          );
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
           expect(action.getState(), equals(UserActionState.halted));
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req1'),
+          );
 
           async.flushMicrotasks();
           expect(action.getState(), equals(UserActionState.ended));
@@ -252,10 +226,7 @@ void main() {
 
       test('should handle multiple pending requests', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -264,38 +235,32 @@ void main() {
 
           controller.attach();
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req2',
-          ));
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req3',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req1'),
+          );
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req2'),
+          );
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req3'),
+          );
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
           expect(action.getState(), equals(UserActionState.halted));
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req1'),
+          );
           expect(action.getState(), equals(UserActionState.halted));
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req2',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req2'),
+          );
           expect(action.getState(), equals(UserActionState.halted));
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req3',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req3'),
+          );
           async.flushMicrotasks();
           expect(action.getState(), equals(UserActionState.ended));
 
@@ -306,10 +271,7 @@ void main() {
 
       test('should ignore untracked request ends in halted state', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -318,25 +280,25 @@ void main() {
 
           controller.attach();
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req1'),
+          );
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
           expect(action.getState(), equals(UserActionState.halted));
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req-unknown',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(
+              source: 'http',
+              operationId: 'req-unknown',
+            ),
+          );
 
           expect(action.getState(), equals(UserActionState.halted));
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req1'),
+          );
 
           async.flushMicrotasks();
           expect(action.getState(), equals(UserActionState.ended));
@@ -350,10 +312,7 @@ void main() {
     group('halt timeout:', () {
       test('should end action after halt timeout expires', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -362,10 +321,9 @@ void main() {
 
           controller.attach();
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req1'),
+          );
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
           expect(action.getState(), equals(UserActionState.halted));
@@ -381,10 +339,7 @@ void main() {
 
       test('should not end if requests complete before halt timeout', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -393,19 +348,17 @@ void main() {
 
           controller.attach();
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req1'),
+          );
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
           expect(action.getState(), equals(UserActionState.halted));
 
           async.elapse(const Duration(seconds: 5));
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req1'),
+          );
 
           async.flushMicrotasks();
           expect(action.getState(), equals(UserActionState.ended));
@@ -422,10 +375,7 @@ void main() {
     group('validity tracking:', () {
       test('should mark action as valid on pending start', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -434,15 +384,13 @@ void main() {
 
           controller.attach();
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req1'),
+          );
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req1'),
+          );
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
 
@@ -455,10 +403,7 @@ void main() {
 
       test('should not mark as valid on pending end alone', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -467,10 +412,9 @@ void main() {
 
           controller.attach();
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req1'),
+          );
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
 
@@ -485,10 +429,7 @@ void main() {
     group('edge cases:', () {
       test('should handle rapid request start/end cycles', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -498,14 +439,15 @@ void main() {
           controller.attach();
 
           for (var i = 0; i < 5; i++) {
-            signalController.add(UserActionSignal.pendingStart(
-              source: 'http',
-              operationId: 'req$i',
-            ));
-            signalController.add(UserActionSignal.pendingEnd(
-              source: 'http',
-              operationId: 'req$i',
-            ));
+            signalController.add(
+              UserActionSignal.pendingStart(
+                source: 'http',
+                operationId: 'req$i',
+              ),
+            );
+            signalController.add(
+              UserActionSignal.pendingEnd(source: 'http', operationId: 'req$i'),
+            );
           }
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
@@ -519,10 +461,7 @@ void main() {
 
       test('should handle no activity', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -542,10 +481,7 @@ void main() {
 
       test('should not process signals after action ends', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -554,23 +490,20 @@ void main() {
 
           controller.attach();
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req1'),
+          );
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req1'),
+          );
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
           expect(action.getState(), equals(UserActionState.ended));
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req2',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req2'),
+          );
 
           expect(action.getState(), equals(UserActionState.ended));
 
@@ -581,10 +514,7 @@ void main() {
 
       test('should handle interleaved requests', () {
         fakeAsync((async) {
-          final action = UserAction(
-            name: 'test-action',
-            trigger: 'test',
-          );
+          final action = UserAction(name: 'test-action', trigger: 'test');
 
           final controller = UserActionLifecycleController(
             action,
@@ -593,38 +523,32 @@ void main() {
 
           controller.attach();
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req1'),
+          );
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req2',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req2'),
+          );
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req1',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req1'),
+          );
 
-          signalController.add(UserActionSignal.pendingStart(
-            source: 'http',
-            operationId: 'req3',
-          ));
+          signalController.add(
+            UserActionSignal.pendingStart(source: 'http', operationId: 'req3'),
+          );
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req2',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req2'),
+          );
 
           async.elapse(UserActionConstants.defaultFollowUpTimeout);
           expect(action.getState(), equals(UserActionState.halted));
 
-          signalController.add(UserActionSignal.pendingEnd(
-            source: 'http',
-            operationId: 'req3',
-          ));
+          signalController.add(
+            UserActionSignal.pendingEnd(source: 'http', operationId: 'req3'),
+          );
 
           async.flushMicrotasks();
           expect(action.getState(), equals(UserActionState.ended));

--- a/test/src/user_actions/user_action_integration_test.dart
+++ b/test/src/user_actions/user_action_integration_test.dart
@@ -367,9 +367,8 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 10));
 
         // Find the user action event
-        final captured = verify(
-          () => mockTransport.send(captureAny()),
-        ).captured;
+        final captured =
+            verify(() => mockTransport.send(captureAny())).captured;
         expect(captured, isNotEmpty);
 
         var foundUserActionEvent = false;

--- a/test/src/user_actions/user_action_test.dart
+++ b/test/src/user_actions/user_action_test.dart
@@ -11,19 +11,13 @@ void main() {
   group('UserAction:', () {
     group('initialization:', () {
       test('should initialize with correct default values', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'pointerdown',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'pointerdown');
 
         expect(action.name, equals('test-action'));
         expect(action.trigger, equals('pointerdown'));
         expect(action.id, isNotEmpty);
         expect(action.id.length, equals(10));
-        expect(
-          action.importance,
-          equals(UserActionConstants.importanceNormal),
-        );
+        expect(action.importance, equals(UserActionConstants.importanceNormal));
         expect(action.attributes, isNull);
         expect(action.getState(), equals(UserActionState.started));
         expect(action.startTime, greaterThan(0));
@@ -61,20 +55,11 @@ void main() {
       });
 
       test('should generate unique IDs for different instances', () {
-        final action1 = UserAction(
-          name: 'action1',
-          trigger: 'test',
-        );
+        final action1 = UserAction(name: 'action1', trigger: 'test');
 
-        final action2 = UserAction(
-          name: 'action2',
-          trigger: 'test',
-        );
+        final action2 = UserAction(name: 'action2', trigger: 'test');
 
-        final action3 = UserAction(
-          name: 'action3',
-          trigger: 'test',
-        );
+        final action3 = UserAction(name: 'action3', trigger: 'test');
 
         expect(action1.id, isNot(equals(action2.id)));
         expect(action1.id, isNot(equals(action3.id)));
@@ -88,10 +73,7 @@ void main() {
 
     group('state machine:', () {
       test('should start in started state', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         expect(action.getState(), equals(UserActionState.started));
 
@@ -99,10 +81,7 @@ void main() {
       });
 
       test('should transition from started to halted', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.halt();
 
@@ -112,10 +91,7 @@ void main() {
       });
 
       test('should not transition to halted if not in started state', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.end();
         expect(action.getState(), equals(UserActionState.ended));
@@ -127,43 +103,28 @@ void main() {
       });
 
       test('should transition from started to cancelled', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.cancel();
 
-        expect(
-          action.getState(),
-          equals(UserActionState.cancelled),
-        );
+        expect(action.getState(), equals(UserActionState.cancelled));
 
         action.dispose();
       });
 
       test('should transition from halted to cancelled', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.halt();
         action.cancel();
 
-        expect(
-          action.getState(),
-          equals(UserActionState.cancelled),
-        );
+        expect(action.getState(), equals(UserActionState.cancelled));
 
         action.dispose();
       });
 
       test('should not transition to cancelled if already ended', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.end();
         expect(action.getState(), equals(UserActionState.ended));
@@ -175,10 +136,7 @@ void main() {
       });
 
       test('should transition from started to ended', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.end();
 
@@ -188,10 +146,7 @@ void main() {
       });
 
       test('should transition from halted to ended', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.halt();
         action.end();
@@ -202,22 +157,13 @@ void main() {
       });
 
       test('should not transition to ended if already cancelled', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.cancel();
-        expect(
-          action.getState(),
-          equals(UserActionState.cancelled),
-        );
+        expect(action.getState(), equals(UserActionState.cancelled));
 
         action.end();
-        expect(
-          action.getState(),
-          equals(UserActionState.cancelled),
-        );
+        expect(action.getState(), equals(UserActionState.cancelled));
 
         action.dispose();
       });
@@ -225,10 +171,7 @@ void main() {
 
     group('state change notifications:', () {
       test('should emit state changes on stateChanges stream', () async {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final states = <UserActionState>[];
         final subscription = action.stateChanges.listen(states.add);
@@ -238,20 +181,14 @@ void main() {
 
         await Future<void>.delayed(Duration.zero);
 
-        expect(
-          states,
-          equals([UserActionState.halted, UserActionState.ended]),
-        );
+        expect(states, equals([UserActionState.halted, UserActionState.ended]));
 
         await subscription.cancel();
         action.dispose();
       });
 
       test('should emit cancelled state on cancel', () async {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final states = <UserActionState>[];
         final subscription = action.stateChanges.listen(states.add);
@@ -267,10 +204,7 @@ void main() {
       });
 
       test('should support multiple subscribers', () async {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final states1 = <UserActionState>[];
         final states2 = <UserActionState>[];
@@ -292,10 +226,7 @@ void main() {
 
     group('item buffering:', () {
       test('should buffer event in started state', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final event = Event('test-event');
         final item = TelemetryItem.fromEvent(event);
@@ -308,10 +239,7 @@ void main() {
       });
 
       test('should buffer log in started state', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final log = FaroLog('test log');
         final item = TelemetryItem.fromLog(log);
@@ -324,10 +252,7 @@ void main() {
       });
 
       test('should buffer exception in started state', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final exception = FaroException('TestException', 'test', {});
         final item = TelemetryItem.fromException(exception);
@@ -340,10 +265,7 @@ void main() {
       });
 
       test('should not buffer in halted state', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.halt();
 
@@ -358,10 +280,7 @@ void main() {
       });
 
       test('should not buffer in ended state', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.end();
 
@@ -376,10 +295,7 @@ void main() {
       });
 
       test('should not buffer in cancelled state', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.cancel();
 
@@ -394,10 +310,7 @@ void main() {
       });
 
       test('should buffer multiple items', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final event1 = Event('event1');
         final event2 = Event('event2');
@@ -418,13 +331,9 @@ void main() {
     });
 
     group('cancel behavior:', () {
-      test(
-          'should make buffered items available without enrichment'
+      test('should make buffered items available without enrichment'
           ' on cancel', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final event = Event('test-event');
         final log = FaroLog('test log');
@@ -446,13 +355,9 @@ void main() {
         action.dispose();
       });
 
-      test(
-          'should not produce pending items multiple times if'
+      test('should not produce pending items multiple times if'
           ' cancelled twice', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final event = Event('test-event');
         action.addItem(TelemetryItem.fromEvent(event));
@@ -470,10 +375,7 @@ void main() {
       });
 
       test('should handle empty buffer on cancel', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.cancel();
 
@@ -485,13 +387,9 @@ void main() {
     });
 
     group('end behavior:', () {
-      test(
-          'should make buffered items available with enrichment'
+      test('should make buffered items available with enrichment'
           ' on end', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final event = Event('test-event');
         final log = FaroLog('test log');
@@ -552,22 +450,10 @@ void main() {
           actionEvent.attributes!['userActionImportance'],
           equals(UserActionConstants.importanceCritical),
         );
-        expect(
-          actionEvent.attributes!['product'],
-          equals('premium'),
-        );
-        expect(
-          actionEvent.attributes!['userActionStartTime'],
-          isNotNull,
-        );
-        expect(
-          actionEvent.attributes!['userActionEndTime'],
-          isNotNull,
-        );
-        expect(
-          actionEvent.attributes!['userActionDuration'],
-          isNotNull,
-        );
+        expect(actionEvent.attributes!['product'], equals('premium'));
+        expect(actionEvent.attributes!['userActionStartTime'], isNotNull);
+        expect(actionEvent.attributes!['userActionEndTime'], isNotNull);
+        expect(actionEvent.attributes!['userActionDuration'], isNotNull);
 
         expect(actionEvent.action, isNotNull);
         expect(actionEvent.action!.id, equals(action.id));
@@ -577,10 +463,7 @@ void main() {
       });
 
       test('should calculate duration correctly', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final startTime = action.startTime;
 
@@ -604,10 +487,7 @@ void main() {
       });
 
       test('should handle empty buffer on end', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.end();
 
@@ -624,10 +504,7 @@ void main() {
       });
 
       test('should handle all telemetry types', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final event = Event('test-event');
         final log = FaroLog('test log');
@@ -649,20 +526,14 @@ void main() {
         expect(items[0].type, equals(TelemetryItemType.event));
         expect(items[1].type, equals(TelemetryItemType.log));
         expect(items[2].type, equals(TelemetryItemType.exception));
-        expect(
-          items[3].type,
-          equals(TelemetryItemType.measurement),
-        );
+        expect(items[3].type, equals(TelemetryItemType.measurement));
         expect(items[4].type, equals(TelemetryItemType.event));
 
         action.dispose();
       });
 
       test('should not enrich measurements with action context', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final measurement = Measurement({'value': 42}, 'test');
         action.addItem(TelemetryItem.fromMeasurement(measurement));
@@ -682,10 +553,7 @@ void main() {
 
     group('takePendingItems:', () {
       test('should return empty list when called before end/cancel', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final items = action.takePendingItems();
         expect(items, isEmpty);
@@ -694,10 +562,7 @@ void main() {
       });
 
       test('should return empty list on second call', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.addItem(TelemetryItem.fromEvent(Event('e1')));
         action.end();
@@ -714,10 +579,7 @@ void main() {
 
     group('dispose:', () {
       test('should close state controller on dispose', () async {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final states = <UserActionState>[];
         final subscription = action.stateChanges.listen(states.add);
@@ -728,10 +590,7 @@ void main() {
       });
 
       test('should not crash if disposed multiple times', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         expect(() {
           action.dispose();
@@ -742,10 +601,7 @@ void main() {
 
     group('edge cases:', () {
       test('should handle actions with no buffered items', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.halt();
         action.end();
@@ -762,10 +618,7 @@ void main() {
       });
 
       test('should handle rapid state transitions', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         action.halt();
         action.halt(); // No-op
@@ -778,10 +631,7 @@ void main() {
       });
 
       test('should preserve item order during flush', () {
-        final action = UserAction(
-          name: 'test-action',
-          trigger: 'test',
-        );
+        final action = UserAction(name: 'test-action', trigger: 'test');
 
         final log1 = FaroLog('log 1');
         final log2 = FaroLog('log 2');
@@ -797,18 +647,9 @@ void main() {
         // 3 logs + 1 summary event
         expect(items.length, equals(4));
 
-        expect(
-          (items[0].asLog!).message,
-          equals('log 1'),
-        );
-        expect(
-          (items[1].asLog!).message,
-          equals('log 2'),
-        );
-        expect(
-          (items[2].asLog!).message,
-          equals('log 3'),
-        );
+        expect((items[0].asLog!).message, equals('log 1'));
+        expect((items[1].asLog!).message, equals('log 2'));
+        expect((items[2].asLog!).message, equals('log 3'));
 
         action.dispose();
       });

--- a/test/src/user_actions/user_action_ui_activity_monitor_test.dart
+++ b/test/src/user_actions/user_action_ui_activity_monitor_test.dart
@@ -41,8 +41,7 @@ void main() {
       signalChannel.dispose();
     });
 
-    testWidgets(
-        'does not recurse when another component wraps '
+    testWidgets('does not recurse when another component wraps '
         'onBuildScheduled after attach', (tester) async {
       final binding = TestWidgetsFlutterBinding.instance;
       final buildOwner = binding.buildOwner!;
@@ -85,8 +84,9 @@ void main() {
       await tester.pump(const Duration(milliseconds: 150));
     });
 
-    testWidgets('preserves external wrapper in the callback chain',
-        (tester) async {
+    testWidgets('preserves external wrapper in the callback chain', (
+      tester,
+    ) async {
       final binding = TestWidgetsFlutterBinding.instance;
       final buildOwner = binding.buildOwner!;
 

--- a/test/src/user_actions/user_actions_service_test.dart
+++ b/test/src/user_actions/user_actions_service_test.dart
@@ -24,9 +24,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(Event('fallback'));
     registerFallbackValue(FaroLog('fallback'));
-    registerFallbackValue(
-      FaroException('fallback', 'fallback', null),
-    );
+    registerFallbackValue(FaroException('fallback', 'fallback', null));
   });
 
   setUp(() {
@@ -87,44 +85,46 @@ void main() {
       service.dispose();
     });
 
-    test('dispatches buffered telemetry and clears active action on end',
-        () async {
-      final action = service.startUserAction('checkout')! as UserAction;
-      service.tryBuffer(TelemetryItem.fromEvent(Event('event')));
-      service.tryBuffer(TelemetryItem.fromLog(FaroLog('log')));
-      service.tryBuffer(
-        TelemetryItem.fromException(
-          FaroException('type', 'value', null),
-        ),
-      );
+    test(
+      'dispatches buffered telemetry and clears active action on end',
+      () async {
+        final action = service.startUserAction('checkout')! as UserAction;
+        service.tryBuffer(TelemetryItem.fromEvent(Event('event')));
+        service.tryBuffer(TelemetryItem.fromLog(FaroLog('log')));
+        service.tryBuffer(
+          TelemetryItem.fromException(FaroException('type', 'value', null)),
+        );
 
-      action.end();
-      await Future<void>.delayed(Duration.zero);
+        action.end();
+        await Future<void>.delayed(Duration.zero);
 
-      // event + summary event
-      verify(() => mockTransport.addEvent(any())).called(2);
-      verify(() => mockTransport.addLog(any())).called(1);
-      verify(() => mockTransport.addExceptions(any())).called(1);
-      expect(service.getActiveUserAction(), isNull);
-      verify(() => mockController.dispose()).called(1);
+        // event + summary event
+        verify(() => mockTransport.addEvent(any())).called(2);
+        verify(() => mockTransport.addLog(any())).called(1);
+        verify(() => mockTransport.addExceptions(any())).called(1);
+        expect(service.getActiveUserAction(), isNull);
+        verify(() => mockController.dispose()).called(1);
 
-      action.dispose();
-    });
+        action.dispose();
+      },
+    );
 
-    test('dispatches buffered telemetry without summary event on cancel',
-        () async {
-      final action = service.startUserAction('checkout')! as UserAction;
-      service.tryBuffer(TelemetryItem.fromEvent(Event('event')));
+    test(
+      'dispatches buffered telemetry without summary event on cancel',
+      () async {
+        final action = service.startUserAction('checkout')! as UserAction;
+        service.tryBuffer(TelemetryItem.fromEvent(Event('event')));
 
-      action.cancel();
-      await Future<void>.delayed(Duration.zero);
+        action.cancel();
+        await Future<void>.delayed(Duration.zero);
 
-      verify(() => mockTransport.addEvent(any())).called(1);
-      expect(service.getActiveUserAction(), isNull);
-      verify(() => mockController.dispose()).called(1);
+        verify(() => mockTransport.addEvent(any())).called(1);
+        expect(service.getActiveUserAction(), isNull);
+        verify(() => mockController.dispose()).called(1);
 
-      action.dispose();
-    });
+        action.dispose();
+      },
+    );
 
     test('dispose releases active action resources', () {
       final action = service.startUserAction('checkout')! as UserAction;

--- a/test/src/util/payload_extension_test.dart
+++ b/test/src/util/payload_extension_test.dart
@@ -44,11 +44,9 @@ void main() {
 
     test('isEmpty returns false when exceptions is not empty', () {
       final payload = Payload(Meta());
-      payload.exceptions.add(FaroException(
-        'test_type',
-        'test_value',
-        {'frames': <String>[]},
-      ));
+      payload.exceptions.add(
+        FaroException('test_type', 'test_value', {'frames': <String>[]}),
+      );
       expect(payload.isEmpty(), false);
     });
 

--- a/test/src/util/short_id_test.dart
+++ b/test/src/util/short_id_test.dart
@@ -21,8 +21,11 @@ void main() {
       for (var i = 0; i < 100; i++) {
         final id = generateShortId();
         for (final char in id.split('')) {
-          expect(allowed.contains(char), isTrue,
-              reason: 'Unexpected character "$char" in ID "$id"');
+          expect(
+            allowed.contains(char),
+            isTrue,
+            reason: 'Unexpected character "$char" in ID "$id"',
+          );
         }
       }
     });

--- a/test/src/util/timestamp_extension_test.dart
+++ b/test/src/util/timestamp_extension_test.dart
@@ -6,12 +6,13 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('TimestampExtension:', () {
     test(
-        'converts valid Unix epoch timestamp in milliseconds to ISO 8601 string',
-        () {
-      const timestamp = '1749080960296';
-      final result = timestamp.toHumanReadableTimestamp();
-      expect(result, '2025-06-04T23:49:20.296Z');
-    });
+      'converts valid Unix epoch timestamp in milliseconds to ISO 8601 string',
+      () {
+        const timestamp = '1749080960296';
+        final result = timestamp.toHumanReadableTimestamp();
+        expect(result, '2025-06-04T23:49:20.296Z');
+      },
+    );
 
     test('converts another valid timestamp correctly', () {
       const timestamp = '1744879144096';

--- a/test/src/webview/faro_webview_bridge_test.dart
+++ b/test/src/webview/faro_webview_bridge_test.dart
@@ -73,10 +73,7 @@ void main() {
 
         final result = bridge.instrumentedUrl(url);
 
-        expect(
-          result.queryParameters.containsKey('session.parent_id'),
-          isTrue,
-        );
+        expect(result.queryParameters.containsKey('session.parent_id'), isTrue);
         final parentId = result.queryParameters['session.parent_id']!;
         expect(parentId, isNotEmpty);
         expect(parentId, equals(faro.meta.session?.id));
@@ -160,10 +157,7 @@ void main() {
         final bridge = FaroWebViewBridge();
         final url = Uri.parse(testUrl);
 
-        final result = bridge.instrumentedUrl(
-          url,
-          spanName: 'CustomWebView',
-        );
+        final result = bridge.instrumentedUrl(url, spanName: 'CustomWebView');
 
         expect(result.queryParameters.containsKey('traceparent'), isTrue);
       });
@@ -179,16 +173,18 @@ void main() {
           appName: 'MyWebApp',
         );
 
-        final captured = verify(
-          () => mockTransport.send(captureAny()),
-        ).captured;
+        final captured =
+            verify(() => mockTransport.send(captureAny())).captured;
         expect(captured, isNotEmpty);
 
         final payload = captured.last as Map<String, dynamic>;
         final events = payload['events'] as List<dynamic>;
-        final linkedEvent = events.firstWhere(
-          (e) => (e as Map<String, dynamic>)['name'] == 'session.linked',
-        ) as Map<String, dynamic>;
+        final linkedEvent =
+            events.firstWhere(
+                  (e) =>
+                      (e as Map<String, dynamic>)['name'] == 'session.linked',
+                )
+                as Map<String, dynamic>;
 
         expect(linkedEvent, isNotNull);
         final attributes = linkedEvent['attributes'] as Map<String, dynamic>?;
@@ -202,16 +198,18 @@ void main() {
 
         bridge.linkChildSession(sessionId: 'web-session-456');
 
-        final captured = verify(
-          () => mockTransport.send(captureAny()),
-        ).captured;
+        final captured =
+            verify(() => mockTransport.send(captureAny())).captured;
         expect(captured, isNotEmpty);
 
         final payload = captured.last as Map<String, dynamic>;
         final events = payload['events'] as List<dynamic>;
-        final linkedEvent = events.firstWhere(
-          (e) => (e as Map<String, dynamic>)['name'] == 'session.linked',
-        ) as Map<String, dynamic>;
+        final linkedEvent =
+            events.firstWhere(
+                  (e) =>
+                      (e as Map<String, dynamic>)['name'] == 'session.linked',
+                )
+                as Map<String, dynamic>;
 
         expect(linkedEvent, isNotNull);
         final attributes = linkedEvent['attributes'] as Map<String, dynamic>?;

--- a/tool/create_release.dart
+++ b/tool/create_release.dart
@@ -28,29 +28,24 @@ Future<String> getVersion() async {
 /// Get the previous git tag
 Future<String?> getPreviousTag() async {
   // Get all tags sorted by version
-  final result = await Process.run(
-    'git',
-    ['tag', '--sort=-v:refname'],
-  );
+  final result = await Process.run('git', ['tag', '--sort=-v:refname']);
 
   if (result.exitCode != 0) {
     return null;
   }
 
-  final tags = (result.stdout as String)
-      .split('\n')
-      .where((t) => t.trim().isNotEmpty && t.startsWith('v'))
-      .toList();
+  final tags =
+      (result.stdout as String)
+          .split('\n')
+          .where((t) => t.trim().isNotEmpty && t.startsWith('v'))
+          .toList();
 
   return tags.isNotEmpty ? tags.first : null;
 }
 
 /// Get the GitHub repository URL
 Future<String?> getRepoUrl() async {
-  final result = await Process.run(
-    'git',
-    ['remote', 'get-url', 'origin'],
-  );
+  final result = await Process.run('git', ['remote', 'get-url', 'origin']);
 
   if (result.exitCode != 0) {
     return null;
@@ -139,7 +134,8 @@ Future<bool> createAndPushTag(String tag) async {
   var result = await Process.run('git', ['tag', tag]);
   if (result.exitCode != 0) {
     stderr.writeln(
-        '${Colors.red}Failed to create tag: ${result.stderr}${Colors.reset}');
+      '${Colors.red}Failed to create tag: ${result.stderr}${Colors.reset}',
+    );
     return false;
   }
 
@@ -147,7 +143,8 @@ Future<bool> createAndPushTag(String tag) async {
   result = await Process.run('git', ['push', 'origin', tag]);
   if (result.exitCode != 0) {
     stderr.writeln(
-        '${Colors.red}Failed to push tag: ${result.stderr}${Colors.reset}');
+      '${Colors.red}Failed to push tag: ${result.stderr}${Colors.reset}',
+    );
     // Try to delete the local tag if push failed
     await Process.run('git', ['tag', '-d', tag]);
     return false;
@@ -157,27 +154,22 @@ Future<bool> createAndPushTag(String tag) async {
 }
 
 /// Create GitHub release using gh CLI
-Future<bool> createGitHubRelease(
-  String tag,
-  String title,
-  String body,
-) async {
-  final result = await Process.run(
-    'gh',
-    [
-      'release',
-      'create',
-      tag,
-      '--title',
-      title,
-      '--notes',
-      body,
-    ],
-  );
+Future<bool> createGitHubRelease(String tag, String title, String body) async {
+  final result = await Process.run('gh', [
+    'release',
+    'create',
+    tag,
+    '--title',
+    title,
+    '--notes',
+    body,
+  ]);
 
   if (result.exitCode != 0) {
-    stderr.writeln('${Colors.red}Failed to create GitHub '
-        'release: ${result.stderr}${Colors.reset}');
+    stderr.writeln(
+      '${Colors.red}Failed to create GitHub '
+      'release: ${result.stderr}${Colors.reset}',
+    );
     return false;
   }
 
@@ -188,14 +180,17 @@ Future<bool> createGitHubRelease(
 Future<String?> enrichWithAI(String changelog, String version) async {
   final apiKey = Platform.environment['OPENAI_API_KEY'];
   if (apiKey == null || apiKey.isEmpty) {
-    stderr.writeln('${Colors.red}Error: OPENAI_API_KEY '
-        'environment variable is not set${Colors.reset}');
+    stderr.writeln(
+      '${Colors.red}Error: OPENAI_API_KEY '
+      'environment variable is not set${Colors.reset}',
+    );
     stderr.writeln('Set it with: export OPENAI_API_KEY="your-key-here"');
     return null;
   }
 
   stdout.write(
-      '${Colors.blue}Enriching release notes with AI... ${Colors.reset}');
+    '${Colors.blue}Enriching release notes with AI... ${Colors.reset}',
+  );
 
   try {
     final client = HttpClient();
@@ -235,7 +230,7 @@ Guidelines:
           'role': 'user',
           'content':
               'Create release notes for version $version from this changelog '
-                  'content:\n\n$changelog',
+              'content:\n\n$changelog',
         },
       ],
     });
@@ -247,8 +242,10 @@ Guidelines:
 
     if (response.statusCode != 200) {
       stdout.writeln('${Colors.red}✗${Colors.reset}');
-      stderr.writeln('${Colors.yellow}Warning: OpenAI API returned status '
-          '${response.statusCode}${Colors.reset}');
+      stderr.writeln(
+        '${Colors.yellow}Warning: OpenAI API returned status '
+        '${response.statusCode}${Colors.reset}',
+      );
       return null;
     }
 
@@ -256,8 +253,10 @@ Guidelines:
     final choices = json['choices'] as List<dynamic>;
     if (choices.isEmpty) {
       stdout.writeln('${Colors.red}✗${Colors.reset}');
-      stderr.writeln('${Colors.yellow}Warning: OpenAI API returned no choices'
-          '${Colors.reset}');
+      stderr.writeln(
+        '${Colors.yellow}Warning: OpenAI API returned no choices'
+        '${Colors.reset}',
+      );
       return null;
     }
 
@@ -267,17 +266,14 @@ Guidelines:
   } catch (e) {
     stdout.writeln('${Colors.red}✗${Colors.reset}');
     stderr.writeln(
-        '${Colors.yellow}Warning: AI enrichment failed: $e${Colors.reset}');
+      '${Colors.yellow}Warning: AI enrichment failed: $e${Colors.reset}',
+    );
     return null;
   }
 }
 
 /// Wrap raw changelog in a standard release notes template
-String _wrapInTemplate(
-  String changelog,
-  String version,
-  String changelogUrl,
-) {
+String _wrapInTemplate(String changelog, String version, String changelogUrl) {
   final buffer = StringBuffer();
   buffer.writeln('# Faro Flutter SDK v$version');
   buffer.writeln();
@@ -292,10 +288,13 @@ void printUsage() {
   stdout.writeln('Usage: dart tool/create_release.dart [options]');
   stdout.writeln('');
   stdout.writeln('Options:');
-  stdout
-      .writeln('  --dry-run    Preview the release without creating anything');
-  stdout.writeln('  --enrich     Use AI to enrich release notes '
-      '(requires OPENAI_API_KEY)');
+  stdout.writeln(
+    '  --dry-run    Preview the release without creating anything',
+  );
+  stdout.writeln(
+    '  --enrich     Use AI to enrich release notes '
+    '(requires OPENAI_API_KEY)',
+  );
   stdout.writeln('  --help       Show this help message');
 }
 
@@ -313,23 +312,29 @@ Future<void> main(List<String> args) async {
   stdout.writeln('');
 
   if (isDryRun) {
-    stdout.writeln('${Colors.yellow}🔍 DRY RUN MODE '
-        '- No changes will be made${Colors.reset}');
+    stdout.writeln(
+      '${Colors.yellow}🔍 DRY RUN MODE '
+      '- No changes will be made${Colors.reset}',
+    );
     stdout.writeln('');
   }
 
   // Check prerequisites (skip in dry-run mode)
   if (!isDryRun) {
     if (!await isOnMainBranch()) {
-      stderr.writeln('${Colors.red}Error: Must be on main '
-          'branch to create a release${Colors.reset}');
+      stderr.writeln(
+        '${Colors.red}Error: Must be on main '
+        'branch to create a release${Colors.reset}',
+      );
       stderr.writeln('Run: git checkout main && git pull origin main');
       exit(1);
     }
 
     if (!await isWorkingDirectoryClean()) {
-      stderr.writeln('${Colors.red}Error: Working directory '
-          'has uncommitted changes${Colors.reset}');
+      stderr.writeln(
+        '${Colors.red}Error: Working directory '
+        'has uncommitted changes${Colors.reset}',
+      );
       stderr.writeln('Commit or stash your changes before creating a release.');
       exit(1);
     }
@@ -339,19 +344,24 @@ Future<void> main(List<String> args) async {
   final version = await getVersion();
   final tag = 'v$version';
 
-  stdout.writeln('${Colors.blue}📦 Creating release for '
-      'Faro Flutter SDK $tag${Colors.reset}');
+  stdout.writeln(
+    '${Colors.blue}📦 Creating release for '
+    'Faro Flutter SDK $tag${Colors.reset}',
+  );
   stdout.writeln('');
 
   // Check if tag already exists (warn in dry-run, error otherwise)
   if (await tagExists(tag)) {
     if (isDryRun) {
-      stdout.writeln('${Colors.yellow}⚠ Tag $tag already '
-          'exists (would fail in real run)${Colors.reset}');
+      stdout.writeln(
+        '${Colors.yellow}⚠ Tag $tag already '
+        'exists (would fail in real run)${Colors.reset}',
+      );
       stdout.writeln('');
     } else {
       stderr.writeln(
-          '${Colors.red}Error: Tag $tag already exists${Colors.reset}');
+        '${Colors.red}Error: Tag $tag already exists${Colors.reset}',
+      );
       stderr.writeln('If you need to re-release, delete the tag first:');
       stderr.writeln('  git tag -d $tag && git push origin :$tag');
       exit(1);
@@ -368,8 +378,10 @@ Future<void> main(List<String> args) async {
   }
 
   if (changelog.trim().isEmpty) {
-    stderr.writeln('${Colors.red}Error: No changelog content '
-        'found for version $version${Colors.reset}');
+    stderr.writeln(
+      '${Colors.red}Error: No changelog content '
+      'found for version $version${Colors.reset}',
+    );
     exit(1);
   }
 
@@ -388,7 +400,8 @@ Future<void> main(List<String> args) async {
       releaseNotes = enriched;
     } else {
       stderr.writeln(
-          '${Colors.yellow}Falling back to plain changelog${Colors.reset}');
+        '${Colors.yellow}Falling back to plain changelog${Colors.reset}',
+      );
       stdout.writeln('');
       releaseNotes = _wrapInTemplate(changelog, version, changelogUrl);
     }
@@ -415,17 +428,23 @@ Future<void> main(List<String> args) async {
   } else {
     stdout.writeln('This will:');
   }
-  stdout.writeln('  ${Colors.green}•${Colors.reset} Create '
-      'git tag: ${Colors.yellow}$tag${Colors.reset}');
+  stdout.writeln(
+    '  ${Colors.green}•${Colors.reset} Create '
+    'git tag: ${Colors.yellow}$tag${Colors.reset}',
+  );
   stdout.writeln('  ${Colors.green}•${Colors.reset} Push tag to origin');
-  stdout.writeln('  ${Colors.green}•${Colors.reset} Create '
-      'GitHub release with above notes');
+  stdout.writeln(
+    '  ${Colors.green}•${Colors.reset} Create '
+    'GitHub release with above notes',
+  );
   stdout.writeln('');
 
   // In dry-run mode, exit here
   if (isDryRun) {
-    stdout.writeln('${Colors.green}✅ Dry run complete. '
-        'No changes were made.${Colors.reset}');
+    stdout.writeln(
+      '${Colors.green}✅ Dry run complete. '
+      'No changes were made.${Colors.reset}',
+    );
     exit(0);
   }
 
@@ -453,29 +472,35 @@ Future<void> main(List<String> args) async {
   try {
     if (!await createGitHubRelease(tag, releaseTitle, releaseNotes)) {
       stderr.writeln('');
-      stderr.writeln('${Colors.yellow}Tag was pushed but GitHub '
-          'release creation failed.${Colors.reset}');
+      stderr.writeln(
+        '${Colors.yellow}Tag was pushed but GitHub '
+        'release creation failed.${Colors.reset}',
+      );
       stderr.writeln('You can create the release manually at:');
       if (repoUrl != null) {
         stderr.writeln('  $repoUrl/releases/new?tag=$tag');
       } else {
         stderr.writeln(
-            '  https://github.com/<owner>/<repo>/releases/new?tag=$tag');
+          '  https://github.com/<owner>/<repo>/releases/new?tag=$tag',
+        );
       }
       exit(1);
     }
   } on ProcessException catch (e) {
     stderr.writeln('');
-    stderr.writeln('${Colors.yellow}Tag was pushed but GitHub '
-        'release creation failed.${Colors.reset}');
+    stderr.writeln(
+      '${Colors.yellow}Tag was pushed but GitHub '
+      'release creation failed.${Colors.reset}',
+    );
     stderr.writeln('${Colors.red}Error: ${e.message}${Colors.reset}');
     stderr.writeln('Make sure the gh CLI is installed and in your PATH.');
     stderr.writeln('You can create the release manually at:');
     if (repoUrl != null) {
       stderr.writeln('  $repoUrl/releases/new?tag=$tag');
     } else {
-      stderr
-          .writeln('  https://github.com/<owner>/<repo>/releases/new?tag=$tag');
+      stderr.writeln(
+        '  https://github.com/<owner>/<repo>/releases/new?tag=$tag',
+      );
     }
     exit(1);
   }
@@ -484,7 +509,8 @@ Future<void> main(List<String> args) async {
   // Success!
   stdout.writeln('');
   stdout.writeln(
-      '${Colors.green}🚀 Release $tag created successfully!${Colors.reset}');
+    '${Colors.green}🚀 Release $tag created successfully!${Colors.reset}',
+  );
   stdout.writeln('');
   stdout.writeln('Next steps:');
   stdout.writeln('  1. GitHub Actions will automatically publish to pub.dev');
@@ -492,7 +518,8 @@ Future<void> main(List<String> args) async {
   stdout.writeln('');
   if (repoUrl != null) {
     stdout.writeln(
-        '${Colors.cyan}Release:${Colors.reset} $repoUrl/releases/tag/$tag');
+      '${Colors.cyan}Release:${Colors.reset} $repoUrl/releases/tag/$tag',
+    );
     stdout.writeln('${Colors.cyan}Actions:${Colors.reset} $repoUrl/actions');
   }
 }

--- a/tool/launch-emulator.sh
+++ b/tool/launch-emulator.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Boot an Android/iOS emulator by id and wait for it to register with Flutter.
+#
+# Usage:
+#   ./tool/launch-emulator.sh <emulator-id>
+#
+# Run ./tool/list-devices.sh to see available emulator ids.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <emulator-id>" >&2
+  echo "Run ./tool/list-devices.sh to see available emulator ids." >&2
+  exit 2
+fi
+
+EMULATOR_ID="$1"
+
+if ! flutter emulators 2>/dev/null | awk '{print $1}' | grep -Fxq "$EMULATOR_ID"; then
+  echo "Error: emulator id '$EMULATOR_ID' not found." >&2
+  echo "Available emulators:" >&2
+  flutter emulators >&2
+  exit 1
+fi
+
+echo "Launching emulator: $EMULATOR_ID"
+flutter emulators --launch "$EMULATOR_ID"
+
+echo "Waiting for emulator to register with Flutter..."
+TIMEOUT_SECONDS=120
+INTERVAL_SECONDS=3
+ELAPSED=0
+PREV_DEVICES=$(flutter devices --machine 2>/dev/null || echo "[]")
+
+while [ "$ELAPSED" -lt "$TIMEOUT_SECONDS" ]; do
+  CURRENT_DEVICES=$(flutter devices --machine 2>/dev/null || echo "[]")
+  # New device appeared if the device list changed and now contains an emulator entry.
+  if [ "$CURRENT_DEVICES" != "$PREV_DEVICES" ] && echo "$CURRENT_DEVICES" | grep -q '"emulator": *true'; then
+    echo
+    echo "Emulator is ready. Connected devices:"
+    flutter devices
+    exit 0
+  fi
+  sleep "$INTERVAL_SECONDS"
+  ELAPSED=$((ELAPSED + INTERVAL_SECONDS))
+  printf '.'
+done
+
+echo
+echo "Error: emulator did not register within ${TIMEOUT_SECONDS}s." >&2
+echo "Check 'flutter devices' manually." >&2
+exit 1

--- a/tool/list-devices.sh
+++ b/tool/list-devices.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# List connected Flutter devices and available Android/iOS emulators,
+# with hints for launching one and running the example app.
+
+set -euo pipefail
+
+bold() { printf '\033[1m%s\033[0m\n' "$1"; }
+dim()  { printf '\033[2m%s\033[0m\n' "$1"; }
+
+bold "Connected devices"
+flutter devices
+echo
+
+bold "Available emulators"
+flutter emulators
+echo
+
+bold "Next steps"
+dim "  Boot an emulator:        ./tool/launch-emulator.sh <emulator-id>"
+dim "  Run example on device:   ./tool/run-example.sh -d <device-id>"
+dim "  Run example (auto pick): ./tool/run-example.sh"

--- a/tool/pre_release_check.dart
+++ b/tool/pre_release_check.dart
@@ -83,11 +83,9 @@ class PreReleaseChecker {
 
   /// Run Android native unit tests via Gradle
   Future<bool> _checkAndroidTests() async {
-    final result = await Process.run(
-      './gradlew',
-      [':faro:testDebugUnitTest'],
-      workingDirectory: 'example/android',
-    );
+    final result = await Process.run('./gradlew', [
+      ':faro:testDebugUnitTest',
+    ], workingDirectory: 'example/android');
     return result.exitCode == 0;
   }
 
@@ -99,15 +97,21 @@ class PreReleaseChecker {
 
   /// Check code formatting
   Future<bool> _checkFormatting() async {
-    final result =
-        await Process.run('dart', ['format', '--set-exit-if-changed', '.']);
+    final result = await Process.run('dart', [
+      'format',
+      '--set-exit-if-changed',
+      '.',
+    ]);
     return result.exitCode == 0;
   }
 
   /// Check publish dry run
   Future<bool> _checkPublishDryRun() async {
-    final result =
-        await Process.run('flutter', ['pub', 'publish', '--dry-run']);
+    final result = await Process.run('flutter', [
+      'pub',
+      'publish',
+      '--dry-run',
+    ]);
     return result.exitCode == 0;
   }
 
@@ -120,8 +124,10 @@ class PreReleaseChecker {
   /// Run pre-version-bump checks
   Future<bool> runPreChecks() async {
     // ignore: avoid_print
-    print('${Colors.blue}🔍 Running pre-version-bump checks...'
-        '${Colors.reset}\n');
+    print(
+      '${Colors.blue}🔍 Running pre-version-bump checks...'
+      '${Colors.reset}\n',
+    );
 
     // Git checks (skipped - we expect changes during development)
 
@@ -142,13 +148,17 @@ class PreReleaseChecker {
     print('\n${Colors.blue}📊 Pre-checks Results:${Colors.reset}');
     if (_checksPassed == _checksTotal) {
       // ignore: avoid_print
-      print('${Colors.green}✅ All $_checksTotal pre-checks passed! '
-          'Ready for version bump.${Colors.reset}');
+      print(
+        '${Colors.green}✅ All $_checksTotal pre-checks passed! '
+        'Ready for version bump.${Colors.reset}',
+      );
       return true;
     } else {
       // ignore: avoid_print
-      print('${Colors.red}❌ $_checksPassed/$_checksTotal pre-checks '
-          'passed. Please fix issues before version bump.${Colors.reset}');
+      print(
+        '${Colors.red}❌ $_checksPassed/$_checksTotal pre-checks '
+        'passed. Please fix issues before version bump.${Colors.reset}',
+      );
       return false;
     }
   }
@@ -156,8 +166,10 @@ class PreReleaseChecker {
   /// Run post-version-bump checks
   Future<bool> runPostChecks() async {
     // ignore: avoid_print
-    print('${Colors.blue}🔍 Running post-version-bump checks...'
-        '${Colors.reset}\n');
+    print(
+      '${Colors.blue}🔍 Running post-version-bump checks...'
+      '${Colors.reset}\n',
+    );
 
     // Reset counters
     _checksPassed = 0;
@@ -171,13 +183,17 @@ class PreReleaseChecker {
     print('\n${Colors.blue}📊 Post-checks Results:${Colors.reset}');
     if (_checksPassed == _checksTotal) {
       // ignore: avoid_print
-      print('${Colors.green}✅ All $_checksTotal post-checks passed! '
-          'Ready to push and create PR.${Colors.reset}');
+      print(
+        '${Colors.green}✅ All $_checksTotal post-checks passed! '
+        'Ready to push and create PR.${Colors.reset}',
+      );
       return true;
     } else {
       // ignore: avoid_print
-      print('${Colors.red}❌ $_checksPassed/$_checksTotal post-checks '
-          'passed. Please fix issues and amend the commit.${Colors.reset}');
+      print(
+        '${Colors.red}❌ $_checksPassed/$_checksTotal post-checks '
+        'passed. Please fix issues and amend the commit.${Colors.reset}',
+      );
       return false;
     }
   }
@@ -194,8 +210,10 @@ Future<void> main(List<String> args) async {
       exit(1);
     }
     // ignore: avoid_print
-    print('\n${Colors.green}🚀 Ready to push and create PR!'
-        '${Colors.reset}');
+    print(
+      '\n${Colors.green}🚀 Ready to push and create PR!'
+      '${Colors.reset}',
+    );
   } else {
     // Pre-version-bump checks
     final success = await checker.runPreChecks();
@@ -203,7 +221,9 @@ Future<void> main(List<String> args) async {
       exit(1);
     }
     // ignore: avoid_print
-    print('\n${Colors.green}🚀 Ready to run: ${Colors.yellow}'
-        'dart tool/version_bump.dart <patch|minor|major>${Colors.reset}');
+    print(
+      '\n${Colors.green}🚀 Ready to run: ${Colors.yellow}'
+      'dart tool/version_bump.dart <patch|minor|major>${Colors.reset}',
+    );
   }
 }

--- a/tool/run-example.sh
+++ b/tool/run-example.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run the example app with the same configuration as .vscode/launch.json.
+#
+# Any extra arguments are passed through to `flutter run`.
+#
+# Usage:
+#   ./tool/run-example.sh                       # let flutter pick a device
+#   ./tool/run-example.sh -d <device-id>        # specific device
+#   ./tool/run-example.sh -d android --release  # Android release build
+#
+# Run ./tool/list-devices.sh to see device ids.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$SCRIPT_DIR/../example"
+CONFIG_FILE="$EXAMPLE_DIR/api-config.json"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Error: $CONFIG_FILE not found." >&2
+  echo "Create it from the template:" >&2
+  echo "  cp example/api-config.example.json example/api-config.json" >&2
+  echo "Then edit it with your FARO_COLLECTOR_URL." >&2
+  exit 1
+fi
+
+cd "$EXAMPLE_DIR"
+exec flutter run \
+  -t lib/main.dart \
+  --dart-define-from-file=api-config.json \
+  "$@"

--- a/tool/version_bump.dart
+++ b/tool/version_bump.dart
@@ -1,11 +1,7 @@
 import 'dart:io';
 
 /// Version bump types
-enum BumpType {
-  patch,
-  minor,
-  major,
-}
+enum BumpType { patch, minor, major }
 
 /// Represents a semantic version
 class Version {
@@ -84,17 +80,15 @@ Future<void> updateChangelog(String version) async {
 
   // Get current date
   final now = DateTime.now();
-  final dateStr = '${now.year}-${now.month.toString().padLeft(2, '0')}-'
+  final dateStr =
+      '${now.year}-${now.month.toString().padLeft(2, '0')}-'
       '${now.day.toString().padLeft(2, '0')}';
 
   // Replace "## [Unreleased]" with version and date, then add new Unreleased
-  final updated = content.replaceFirst(
-    '## [Unreleased]',
-    '''
+  final updated = content.replaceFirst('## [Unreleased]', '''
 ## [Unreleased]
 
-## [$version] - $dateStr''',
-  );
+## [$version] - $dateStr''');
 
   // If there was no "[Unreleased]" section, add the version at the top
   // after the header
@@ -160,7 +154,8 @@ Future<void> main(List<String> args) async {
       break;
     default:
       stderr.writeln(
-          'Invalid bump type: $bumpTypeStr. Must be patch, minor, or major');
+        'Invalid bump type: $bumpTypeStr. Must be patch, minor, or major',
+      );
       exit(1);
   }
 
@@ -168,8 +163,9 @@ Future<void> main(List<String> args) async {
     // Read current version from pubspec
     final pubspecFile = File('pubspec.yaml');
     final pubspecContent = await pubspecFile.readAsString();
-    final versionMatch =
-        RegExp(r'version: (\d+\.\d+\.\d+)').firstMatch(pubspecContent);
+    final versionMatch = RegExp(
+      r'version: (\d+\.\d+\.\d+)',
+    ).firstMatch(pubspecContent);
 
     if (versionMatch == null) {
       stderr.writeln('Could not find version in pubspec.yaml');
@@ -191,11 +187,10 @@ Future<void> main(List<String> args) async {
 
     // Resolve dependencies so example/pubspec.lock reflects the new version
     stdout.writeln('Resolving dependencies...');
-    final pubGetResult = await Process.run(
-      'flutter',
-      ['pub', 'get'],
-      workingDirectory: Directory.current.path,
-    );
+    final pubGetResult = await Process.run('flutter', [
+      'pub',
+      'get',
+    ], workingDirectory: Directory.current.path);
     if (pubGetResult.exitCode != 0) {
       stderr.writeln('Warning: flutter pub get failed:');
       stderr.writeln(pubGetResult.stderr);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Widen `device_info_plus` and `package_info_plus` dependency ranges so downstream apps can resolve the latest Renovate major bumps without forcing every app onto those majors.

Also align Faro's declared Dart and Flutter lower bounds with the effective dependency floor from `device_info_plus`.

## Related Issue(s)

Related to dependency update PRs for `package_info_plus` v10 and `device_info_plus` v13.

## Type of Change

- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [x] 🧹 Chore / Housekeeping

## Checklist

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Verified with latest resolution (`device_info_plus 13.1.0`, `package_info_plus 10.1.0`) and lower-bound resolution (`device_info_plus 12.3.0`, `package_info_plus 8.0.2`). Flutter 3.29.0 was released on February 12, 2025, so the new Flutter lower bound is about 15 months old as of May 5, 2026.

The SDK lower-bound update changes the package language version used by `dart format`, so the branch includes a formatting-only follow-up commit to satisfy CI's `dart format --set-exit-if-changed .` step.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0006faaf-0fd4-4441-8968-31905c3744bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0006faaf-0fd4-4441-8968-31905c3744bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

