### PR TITLE
chore: bump version to v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-07
+
 ### Changed
 
-- Raised the declared Dart SDK lower bound to `>=3.7.0` and Flutter lower
-  bound to `>=3.29.0` to match the effective `device_info_plus` dependency
-  floor.
+- **Breaking for consumers on Flutter < 3.29 / Dart < 3.7:** Raised the
+  declared Dart SDK lower bound to `>=3.7.0` and Flutter lower bound to
+  `>=3.29.0` to match the effective `device_info_plus` dependency floor.
 - Widened `device_info_plus` dependency to `>=12.3.0 <14.0.0`
   (adds v13.x support).
 - Widened `package_info_plus` dependency to `>=8.0.1 <11.0.0`

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.14.0'
+version '0.15.0'
 
 buildscript {
     repositories {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -183,7 +183,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.14.0"
+    version: "0.15.0"
   ffi:
     dependency: transitive
     description:

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.14.0'
+  s.version          = '0.15.0'
   s.summary          = 'Grafana Faro SDK for Flutter - mobile observability and real user monitoring.'
   s.description      = <<-DESC
 Grafana Faro SDK for Flutter applications. Monitor your Flutter app with ease

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,7 +1,7 @@
 /// Constants for the Faro Flutter SDK
 class FaroConstants {
   /// The version of the Faro Flutter SDK
-  static const String sdkVersion = '0.14.0';
+  static const String sdkVersion = '0.15.0';
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-mobile-flutter';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.14.0
+version: 0.15.0
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 


### PR DESCRIPTION
## Description

Release version 0.15.0 of the Faro Flutter SDK.

This release widens `device_info_plus` and `package_info_plus` dependency
ranges (allowing v13.x and v10.x respectively) and raises the SDK floor
to Flutter 3.29 / Dart 3.7. See `CHANGELOG.md` for the full notes.

**Breaking for consumers on Flutter < 3.29 / Dart < 3.7.** This is the
main reason for a minor version bump rather than a patch.

## Related Issue(s)

Releases changes from #223.

## Type of Change

- [x] 💥 Breaking change (SDK floor raise affects consumers on older Flutter)
- [x] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation (CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Additional Notes

Pre-release validation passed (`dart tool/pre_release_check.dart` and
`--post`). After merge, the release is created via
`dart tool/create_release.dart`, which tags `v0.15.0` and triggers the
publish workflow.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Version bump itself is low risk, but this release is *breaking* for consumers on Flutter <3.29 / Dart <3.7 and widens key dependency ranges, which can surface compatibility issues for downstream apps.
> 
> **Overview**
> Cuts release `0.15.0` by updating version metadata across Dart (`pubspec.yaml`, `FaroConstants.sdkVersion`), Android (`android/build.gradle`), iOS (`faro.podspec`), and the example lockfile.
> 
> Updates `CHANGELOG.md` with `0.15.0` notes, highlighting the **breaking** minimum Flutter/Dart SDK floor and widened `device_info_plus`/`package_info_plus` dependency ranges to include newer major versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ffd797196652985c77f55eaaf3a75e420308ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->