### PR TITLE
refactor(tracing): swap Workiva opentelemetry-dart for dartastic_opentelemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: help run-example run-webview-demo
+
+help:
+	@echo "Available targets:"
+	@echo "  make run-example                  Run the Flutter example app"
+	@echo "  make run-example ARGS='...'       Forward extra args to flutter run"
+	@echo "  make run-webview-demo             Run the React WebView demo app"
+	@echo "  make run-webview-demo ARGS='...'  Forward extra args to yarn dev"
+
+run-example:
+	./tool/run-example.sh $(ARGS)
+
+run-webview-demo:
+	cd example/webview_demo && yarn install && yarn dev $(ARGS)

--- a/example/lib/features/custom_telemetry/presentation/custom_telemetry_page.dart
+++ b/example/lib/features/custom_telemetry/presentation/custom_telemetry_page.dart
@@ -12,8 +12,9 @@ class CustomTelemetryPage extends ConsumerWidget {
     final uiState = ref.watch(customTelemetryPageUiStateProvider);
     final actions = ref.watch(customTelemetryPageActionsProvider);
 
-    final dataCollectionColor =
-        uiState.isDataCollectionEnabled ? Colors.green : Colors.orange;
+    final dataCollectionColor = uiState.isDataCollectionEnabled
+        ? Colors.green
+        : Colors.orange;
 
     return Scaffold(
       appBar: AppBar(
@@ -108,14 +109,12 @@ class CustomTelemetryPage extends ConsumerWidget {
                       onPressed: actions.emitEvent,
                     ),
                     _TelemetryButton(
-                      label:
-                          uiState.isDataCollectionEnabled
-                              ? 'Disable Data Collection'
-                              : 'Enable Data Collection',
-                      icon:
-                          uiState.isDataCollectionEnabled
-                              ? Icons.toggle_on
-                              : Icons.toggle_off,
+                      label: uiState.isDataCollectionEnabled
+                          ? 'Disable Data Collection'
+                          : 'Enable Data Collection',
+                      icon: uiState.isDataCollectionEnabled
+                          ? Icons.toggle_on
+                          : Icons.toggle_off,
                       onPressed: actions.toggleDataCollection,
                     ),
                   ],

--- a/example/lib/features/network_requests/domain/network_requests_demo_service.dart
+++ b/example/lib/features/network_requests/domain/network_requests_demo_service.dart
@@ -73,10 +73,12 @@ class NetworkRequestsDemoService {
       final response = await request();
       final isFailure = response.statusCode >= 400;
       final matchedExpectation = isFailure == expectedFailure;
-      final tone =
-          matchedExpectation ? DemoLogTone.success : DemoLogTone.warning;
-      final expectationLabel =
-          expectedFailure ? 'expected failure' : 'expected success';
+      final tone = matchedExpectation
+          ? DemoLogTone.success
+          : DemoLogTone.warning;
+      final expectationLabel = expectedFailure
+          ? 'expected failure'
+          : 'expected success';
 
       log(
         '$label -> status ${response.statusCode} ($expectationLabel)',

--- a/example/lib/features/sampling_settings/presentation/sampling_settings_page_view_model.dart
+++ b/example/lib/features/sampling_settings/presentation/sampling_settings_page_view_model.dart
@@ -120,10 +120,11 @@ class _SamplingSettingsPageViewModel
 // Providers
 // =============================================================================
 
-final _samplingSettingsPageViewModelProvider = NotifierProvider<
-  _SamplingSettingsPageViewModel,
-  SamplingSettingsPageUiState
->(_SamplingSettingsPageViewModel.new);
+final _samplingSettingsPageViewModelProvider =
+    NotifierProvider<
+      _SamplingSettingsPageViewModel,
+      SamplingSettingsPageUiState
+    >(_SamplingSettingsPageViewModel.new);
 
 /// Provider for the sampling settings page UI state.
 ///

--- a/example/lib/features/sampling_settings/presentation/widgets/sampled_status_banner.dart
+++ b/example/lib/features/sampling_settings/presentation/widgets/sampled_status_banner.dart
@@ -14,8 +14,9 @@ class SampledStatusBanner extends StatelessWidget {
         color: isSessionSampled ? Colors.green.shade50 : Colors.grey.shade100,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color:
-              isSessionSampled ? Colors.green.shade200 : Colors.grey.shade300,
+          color: isSessionSampled
+              ? Colors.green.shade200
+              : Colors.grey.shade300,
         ),
       ),
       child: Row(
@@ -35,10 +36,9 @@ class SampledStatusBanner extends StatelessWidget {
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.bold,
-                    color:
-                        isSessionSampled
-                            ? Colors.green.shade800
-                            : Colors.grey.shade700,
+                    color: isSessionSampled
+                        ? Colors.green.shade800
+                        : Colors.grey.shade700,
                   ),
                 ),
                 const SizedBox(height: 4),
@@ -48,10 +48,9 @@ class SampledStatusBanner extends StatelessWidget {
                       : 'No telemetry collected this session',
                   style: TextStyle(
                     fontSize: 12,
-                    color:
-                        isSessionSampled
-                            ? Colors.green.shade700
-                            : Colors.grey.shade600,
+                    color: isSessionSampled
+                        ? Colors.green.shade700
+                        : Colors.grey.shade600,
                   ),
                 ),
               ],

--- a/example/lib/features/tracing/presentation/tracing_page.dart
+++ b/example/lib/features/tracing/presentation/tracing_page.dart
@@ -158,22 +158,21 @@ class _LogSection extends StatelessWidget {
     return Expanded(
       child: Container(
         color: Colors.grey.shade100,
-        child:
-            spanLog.isEmpty
-                ? const Center(
-                  child: Text(
-                    'Run a span operation to see the log',
-                    style: TextStyle(color: Colors.grey),
-                  ),
-                )
-                : ListView.builder(
-                  padding: const EdgeInsets.all(8),
-                  itemCount: spanLog.length,
-                  itemBuilder: (context, index) {
-                    final entry = spanLog[index];
-                    return _LogEntryRow(entry: entry);
-                  },
+        child: spanLog.isEmpty
+            ? const Center(
+                child: Text(
+                  'Run a span operation to see the log',
+                  style: TextStyle(color: Colors.grey),
                 ),
+              )
+            : ListView.builder(
+                padding: const EdgeInsets.all(8),
+                itemCount: spanLog.length,
+                itemBuilder: (context, index) {
+                  final entry = spanLog[index];
+                  return _LogEntryRow(entry: entry);
+                },
+              ),
       ),
     );
   }

--- a/example/lib/features/user_actions/presentation/user_actions_page.dart
+++ b/example/lib/features/user_actions/presentation/user_actions_page.dart
@@ -414,19 +414,18 @@ class _LogSection extends StatelessWidget {
     return Expanded(
       child: Container(
         color: Colors.grey.shade100,
-        child:
-            log.isEmpty
-                ? const Center(
-                  child: Text(
-                    'Run a scenario to see the action lifecycle log',
-                    style: TextStyle(color: Colors.grey),
-                  ),
-                )
-                : ListView.builder(
-                  padding: const EdgeInsets.all(8),
-                  itemCount: log.length,
-                  itemBuilder: (_, index) => _LogEntryRow(entry: log[index]),
+        child: log.isEmpty
+            ? const Center(
+                child: Text(
+                  'Run a scenario to see the action lifecycle log',
+                  style: TextStyle(color: Colors.grey),
                 ),
+              )
+            : ListView.builder(
+                padding: const EdgeInsets.all(8),
+                itemCount: log.length,
+                itemBuilder: (_, index) => _LogEntryRow(entry: log[index]),
+              ),
       ),
     );
   }
@@ -470,8 +469,9 @@ class _LogEntryRow extends StatelessWidget {
               style: TextStyle(
                 fontSize: 12,
                 color: textColor,
-                fontWeight:
-                    entry.isHighlight ? FontWeight.bold : FontWeight.normal,
+                fontWeight: entry.isHighlight
+                    ? FontWeight.bold
+                    : FontWeight.normal,
                 fontFamily: 'monospace',
               ),
             ),

--- a/example/lib/features/user_actions/presentation/user_actions_page_view_model.dart
+++ b/example/lib/features/user_actions/presentation/user_actions_page_view_model.dart
@@ -133,12 +133,11 @@ class _UserActionsPageViewModel extends Notifier<UserActionsPageUiState>
         navigator: navigator,
         route: MaterialPageRoute(
           settings: const RouteSettings(name: '/ua-fast-nav'),
-          builder:
-              (_) => const AutoPopPage(
-                title: 'Fast View Transition',
-                description: 'Generating push/pop view signals.',
-                autoPopDelay: Duration(milliseconds: 40),
-              ),
+          builder: (_) => const AutoPopPage(
+            title: 'Fast View Transition',
+            description: 'Generating push/pop view signals.',
+            autoPopDelay: Duration(milliseconds: 40),
+          ),
         ),
       );
     } finally {
@@ -166,12 +165,11 @@ class _UserActionsPageViewModel extends Notifier<UserActionsPageUiState>
         navigator: navigator,
         route: MaterialPageRoute(
           settings: const RouteSettings(name: '/ua-mixed-nav'),
-          builder:
-              (_) => const AutoPopPage(
-                title: 'Mixed Timing Navigation',
-                description: 'Fast view change while HTTP is in-flight.',
-                autoPopDelay: Duration(milliseconds: 60),
-              ),
+          builder: (_) => const AutoPopPage(
+            title: 'Mixed Timing Navigation',
+            description: 'Fast view change while HTTP is in-flight.',
+            autoPopDelay: Duration(milliseconds: 60),
+          ),
         ),
       );
     } finally {
@@ -190,12 +188,11 @@ class _UserActionsPageViewModel extends Notifier<UserActionsPageUiState>
         routeFactory: () {
           return MaterialPageRoute(
             settings: const RouteSettings(name: '/ua-concurrent-nav'),
-            builder:
-                (_) => const AutoPopPage(
-                  title: 'Concurrent Guard Navigation',
-                  description: 'Small view pulse to mark activity.',
-                  autoPopDelay: Duration(milliseconds: 40),
-                ),
+            builder: (_) => const AutoPopPage(
+              title: 'Concurrent Guard Navigation',
+              description: 'Small view pulse to mark activity.',
+              autoPopDelay: Duration(milliseconds: 40),
+            ),
           );
         },
       );

--- a/example/lib/features/user_settings/user_settings_page.dart
+++ b/example/lib/features/user_settings/user_settings_page.dart
@@ -116,10 +116,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
               _currentUserDisplay,
               style: TextStyle(
                 fontSize: 16,
-                color:
-                    _currentUserDisplay == 'Not set'
-                        ? Colors.grey
-                        : Colors.green,
+                color: _currentUserDisplay == 'Not set'
+                    ? Colors.grey
+                    : Colors.green,
                 fontWeight: FontWeight.w500,
               ),
             ),
@@ -255,19 +254,18 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                 }
               },
               child: Column(
-                children:
-                    InitialUserSetting.values.map((setting) {
-                      return RadioListTile<InitialUserSetting>(
-                        title: Text(setting.displayName),
-                        subtitle: Text(
-                          setting.subtitle,
-                          style: const TextStyle(fontSize: 11),
-                        ),
-                        value: setting,
-                        contentPadding: EdgeInsets.zero,
-                        dense: true,
-                      );
-                    }).toList(),
+                children: InitialUserSetting.values.map((setting) {
+                  return RadioListTile<InitialUserSetting>(
+                    title: Text(setting.displayName),
+                    subtitle: Text(
+                      setting.subtitle,
+                      style: const TextStyle(fontSize: 11),
+                    ),
+                    value: setting,
+                    contentPadding: EdgeInsets.zero,
+                    dense: true,
+                  );
+                }).toList(),
               ),
             ),
             const SizedBox(height: 8),

--- a/example/lib/features/webview_handoff/presentation/webview_handoff_page.dart
+++ b/example/lib/features/webview_handoff/presentation/webview_handoff_page.dart
@@ -27,10 +27,9 @@ class WebViewHandoffPage extends ConsumerWidget {
           ],
           const SizedBox(height: 16),
           ElevatedButton.icon(
-            onPressed:
-                uiState.isConfigured
-                    ? () => _openWebView(context, actions)
-                    : null,
+            onPressed: uiState.isConfigured
+                ? () => _openWebView(context, actions)
+                : null,
             icon: const Icon(Icons.open_in_new),
             label: const Text('Open React demo in WebView'),
           ),

--- a/example/lib/features/webview_handoff/presentation/webview_handoff_webview_page.dart
+++ b/example/lib/features/webview_handoff/presentation/webview_handoff_webview_page.dart
@@ -41,39 +41,38 @@ class _WebViewHandoffWebViewPageState extends State<WebViewHandoffWebViewPage> {
     _bridge = FaroWebViewBridge();
     final instrumentedUrl = _bridge.instrumentedUrl(widget.url);
 
-    _controller =
-        WebViewController()
-          ..setJavaScriptMode(JavaScriptMode.unrestricted)
-          // The React app calls window.HandoffBridge.postMessage(json) to
-          // send login results back to Flutter.
-          ..addJavaScriptChannel(
-            'HandoffBridge',
-            onMessageReceived: _handleBridgeMessage,
-          )
-          ..setNavigationDelegate(
-            NavigationDelegate(
-              onPageStarted: (url) {
-                if (!mounted) return;
-                setState(() {
-                  _status = 'Loading\u2026';
-                  _hasLoadError = false;
-                });
-              },
-              onPageFinished: (url) {
-                if (!mounted) return;
-                setState(() => _status = 'Loaded');
-              },
-              onWebResourceError: (error) {
-                if (!mounted) return;
-                if (error.isForMainFrame != true) return;
-                setState(() {
-                  _status = 'Failed to load';
-                  _hasLoadError = true;
-                });
-              },
-            ),
-          )
-          ..loadRequest(instrumentedUrl);
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      // The React app calls window.HandoffBridge.postMessage(json) to
+      // send login results back to Flutter.
+      ..addJavaScriptChannel(
+        'HandoffBridge',
+        onMessageReceived: _handleBridgeMessage,
+      )
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageStarted: (url) {
+            if (!mounted) return;
+            setState(() {
+              _status = 'Loading\u2026';
+              _hasLoadError = false;
+            });
+          },
+          onPageFinished: (url) {
+            if (!mounted) return;
+            setState(() => _status = 'Loaded');
+          },
+          onWebResourceError: (error) {
+            if (!mounted) return;
+            if (error.isForMainFrame != true) return;
+            setState(() {
+              _status = 'Failed to load';
+              _hasLoadError = true;
+            });
+          },
+        ),
+      )
+      ..loadRequest(instrumentedUrl);
   }
 
   @override
@@ -117,10 +116,9 @@ class _WebViewHandoffWebViewPageState extends State<WebViewHandoffWebViewPage> {
             ),
           ),
           Expanded(
-            child:
-                _hasLoadError
-                    ? const _LoadErrorHint()
-                    : WebViewWidget(controller: _controller),
+            child: _hasLoadError
+                ? const _LoadErrorHint()
+                : WebViewWidget(controller: _controller),
           ),
         ],
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,10 +58,9 @@ void main() async {
     if (qaConfig.hasRunId) 'qa_run_id': qaConfig.runId!,
   };
 
-  final initialUser =
-      qaConfig.hasInitialUser
-          ? qaConfig.initialUser
-          : userSettingsService.initialUser;
+  final initialUser = qaConfig.hasInitialUser
+      ? qaConfig.initialUser
+      : userSettingsService.initialUser;
 
   Faro().transports.add(
     OfflineTransport(maxCacheDuration: const Duration(days: 3)),

--- a/example/lib/qa_config.dart
+++ b/example/lib/qa_config.dart
@@ -64,10 +64,9 @@ class QaConfig {
 
       return FaroUser(
         id: decoded['id'] is String ? decoded['id'] as String : null,
-        username:
-            decoded['username'] is String
-                ? decoded['username'] as String
-                : null,
+        username: decoded['username'] is String
+            ? decoded['username'] as String
+            : null,
         email: decoded['email'] is String ? decoded['email'] as String : null,
         attributes: _parseAttributes(decoded['attributes']),
       );

--- a/example/lib/shared/presentation/widgets/demo_log_section.dart
+++ b/example/lib/shared/presentation/widgets/demo_log_section.dart
@@ -17,22 +17,21 @@ class DemoLogSection extends StatelessWidget {
     return Expanded(
       child: Container(
         color: Colors.grey.shade100,
-        child:
-            entries.isEmpty
-                ? Center(
-                  child: Text(
-                    emptyMessage,
-                    style: const TextStyle(color: Colors.grey),
-                    textAlign: TextAlign.center,
-                  ),
-                )
-                : ListView.builder(
-                  padding: const EdgeInsets.all(8),
-                  itemCount: entries.length,
-                  itemBuilder: (context, index) {
-                    return _DemoLogEntryRow(entry: entries[index]);
-                  },
+        child: entries.isEmpty
+            ? Center(
+                child: Text(
+                  emptyMessage,
+                  style: const TextStyle(color: Colors.grey),
+                  textAlign: TextAlign.center,
                 ),
+              )
+            : ListView.builder(
+                padding: const EdgeInsets.all(8),
+                itemCount: entries.length,
+                itemBuilder: (context, index) {
+                  return _DemoLogEntryRow(entry: entries[index]);
+                },
+              ),
       ),
     );
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -129,6 +129,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dartastic_opentelemetry:
+    dependency: transitive
+    description:
+      name: dartastic_opentelemetry
+      sha256: ce60d797f5ad11bad0050b10e560e78c60aa3f67b53d1cfe0a9923a082ad4526
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0-beta.5"
+  dartastic_opentelemetry_api:
+    dependency: transitive
+    description:
+      name: dartastic_opentelemetry_api
+      sha256: "7635ce77bf53b39709a605d17d68ac3655afa5123884d41bbefc433c6fd3ccdb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0-beta.6"
   dartypod:
     dependency: transitive
     description:
@@ -255,6 +271,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_cloud:
+    dependency: transitive
+    description:
+      name: google_cloud
+      sha256: b385e20726ef5315d302c5933bfb728103116c5be2d3d17094b01a82da538c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
+  googleapis_auth:
+    dependency: transitive
+    description:
+      name: googleapis_auth
+      sha256: "2a8895c3885197f96bb2fd91ee0ae77b53ff3874c7b1f1eadb6566248e880958"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  grpc:
+    dependency: transitive
+    description:
+      name: grpc
+      sha256: "86be3a7d39ad865b214a7370021ac80e68939238b507730de6d97fc662cb2723"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   hooks:
     dependency: transitive
     description:
@@ -271,6 +319,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
+  http2:
+    dependency: transitive
+    description:
+      name: http2
+      sha256: "382d3aefc5bd6dc68c6b892d7664f29b5beb3251611ae946a98d35158a82bbfa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -415,14 +471,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
-  opentelemetry:
-    dependency: transitive
-    description:
-      name: opentelemetry
-      sha256: "92d63a2e0731d34a7548add82420b8f3819ccda569f9bdfdcc4b25e00fe88da4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.18.11"
   package_config:
     dependency: transitive
     description:
@@ -551,14 +599,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.2"
   riverpod:
     dependency: transitive
     description:
@@ -716,6 +756,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -893,5 +941,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.38.4"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
   flutter: ">=3.29.0"
 
 # Dependencies specify other packages that your package needs in order to work.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.32.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -19,6 +19,7 @@ import 'package:faro/src/models/models.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
 import 'package:faro/src/session/session_id_provider.dart';
 import 'package:faro/src/session/session_sampling_provider.dart';
+import 'package:faro/src/tracing/faro_otel_bootstrap.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
 import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/tracing/span_exception_options.dart';
@@ -236,6 +237,7 @@ class Faro {
         setSendUsageInterval: optionsConfiguration.fetchVitalsInterval,
       );
     }
+    await FaroOtelBootstrap.initialize();
     _instance.pushEvent('session_start');
     WidgetsBinding.instance.addPostFrameCallback((_) {
       NativeIntegration.instance.getAppStart();

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -56,8 +56,9 @@ class Faro {
   static set instance(Faro instance) => _instance = instance;
 
   @visibleForTesting
-  static void resetForTesting() {
+  static Future<void> resetForTesting() async {
     _instance._tearDownForReset();
+    await FaroOtelBootstrap.resetForTesting();
     _instance = Faro._();
   }
 

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -152,8 +152,8 @@ class Faro {
 
     _dataCollectionPolicy = await DataCollectionPolicyFactory().create();
 
-    final attributesProvider =
-        await SessionAttributesProviderFactory().create();
+    final attributesProvider = await SessionAttributesProviderFactory()
+        .create();
     final customAttributes = optionsConfiguration.sessionAttributes ?? {};
     final defaultAttributes = await attributesProvider.getAttributes();
     // Merge custom attributes first, then default attributes
@@ -187,10 +187,9 @@ class Faro {
     );
 
     // Make sampling decision (once per session)
-    _isSampled =
-        SessionSamplingProviderFactory()
-            .create(sampling: optionsConfiguration.sampling, meta: meta)
-            .isSampled;
+    _isSampled = SessionSamplingProviderFactory()
+        .create(sampling: optionsConfiguration.sampling, meta: meta)
+        .isSampled;
 
     if (!_isSampled) {
       log('Faro: Session not sampled. Telemetry will be dropped.');
@@ -341,10 +340,9 @@ class Faro {
     'To clear, use setUser(FaroUser.cleared()).',
   )
   void setUserMeta({String? userId, String? userName, String? userEmail}) {
-    final user =
-        (userId == null && userName == null && userEmail == null)
-            ? const FaroUser.cleared()
-            : FaroUser(id: userId, username: userName, email: userEmail);
+    final user = (userId == null && userName == null && userEmail == null)
+        ? const FaroUser.cleared()
+        : FaroUser(id: userId, username: userName, email: userEmail);
     setUser(user);
   }
 
@@ -521,9 +519,9 @@ class Faro {
     ContextScope contextScope = ContextScope.callback,
     SpanExceptionOptions? exceptionOptions,
   }) async {
-    final effectiveOptions = (config?.spanExceptionOptions ??
-            SpanExceptionOptions.defaults)
-        .mergeWith(exceptionOptions);
+    final effectiveOptions =
+        (config?.spanExceptionOptions ?? SpanExceptionOptions.defaults)
+            .mergeWith(exceptionOptions);
     return _tracer.startSpan(
       name,
       body,

--- a/lib/src/models/faro_user.dart
+++ b/lib/src/models/faro_user.dart
@@ -60,10 +60,9 @@ class FaroUser extends Equatable {
       id: json['id'] as String?,
       username: json['username'] as String?,
       email: json['email'] as String?,
-      attributes:
-          json['attributes'] != null
-              ? Map<String, String>.from(json['attributes'] as Map)
-              : null,
+      attributes: json['attributes'] != null
+          ? Map<String, String>.from(json['attributes'] as Map)
+          : null,
     );
   }
 

--- a/lib/src/models/meta.dart
+++ b/lib/src/models/meta.dart
@@ -18,13 +18,15 @@ class Meta {
   });
 
   Meta.fromJson(dynamic json) {
-    session =
-        json['session'] != null ? Session.fromJson(json['session']) : null;
+    session = json['session'] != null
+        ? Session.fromJson(json['session'])
+        : null;
     sdk = json['sdk'] != null ? Sdk.fromJson(json['sdk']) : null;
     app = json['app'] != null ? App.fromJson(json['app']) : null;
     view = json['view'] != null ? ViewMeta.fromJson(json['view']) : null;
-    browser =
-        json['browser'] != null ? Browser.fromJson(json['browser']) : null;
+    browser = json['browser'] != null
+        ? Browser.fromJson(json['browser'])
+        : null;
     page = json['page'] != null ? Page.fromJson(json['page']) : null;
     user = json['user'] != null ? FaroUser.fromJson(json['user']) : null;
   }

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -18,9 +18,7 @@ class SpanRecord {
 
   TraceResource getResource() {
     final attrs = _otelReadOnlySpan.resource?.attributes;
-    return TraceResource(
-      attributes: attrs?.toTraceAttributes() ?? const [],
-    );
+    return TraceResource(attributes: attrs?.toTraceAttributes() ?? const []);
   }
 
   TraceScope getScope() {

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -1,47 +1,55 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/models/trace/trace_resource.dart';
 import 'package:faro/src/models/trace/trace_scope_spans.dart';
 import 'package:faro/src/models/trace/trace_span.dart';
+import 'package:faro/src/models/trace/trace_span_status.dart';
 import 'package:faro/src/tracing/extensions.dart';
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
+import 'package:fixnum/fixnum.dart';
 
 class SpanRecord {
-  SpanRecord({required otel_sdk.ReadOnlySpan otelReadOnlySpan})
+  SpanRecord({required otel.Span otelReadOnlySpan})
     : _otelReadOnlySpan = otelReadOnlySpan;
 
-  final otel_sdk.ReadOnlySpan _otelReadOnlySpan;
+  final otel.Span _otelReadOnlySpan;
 
   String name() {
     return _otelReadOnlySpan.name;
   }
 
   TraceResource getResource() {
+    final attrs = _otelReadOnlySpan.resource?.attributes;
     return TraceResource(
-      attributes: _otelReadOnlySpan.resource.attributes.toTraceAttributes(),
+      attributes: attrs?.toTraceAttributes() ?? const [],
     );
   }
 
   TraceScope getScope() {
-    return TraceScope(
-      name: _otelReadOnlySpan.instrumentationScope.name,
-      version: _otelReadOnlySpan.instrumentationScope.version,
-    );
+    final scope = _otelReadOnlySpan.instrumentationScope;
+    return TraceScope(name: scope.name, version: scope.version ?? '');
   }
 
   TraceSpan getSpan() {
-    final parentSpanId = _otelReadOnlySpan.parentSpanId;
+    final parentSpanContext = _otelReadOnlySpan.parentSpanContext;
     return TraceSpan(
       traceId: _otelReadOnlySpan.spanContext.traceId.toString(),
       spanId: _otelReadOnlySpan.spanContext.spanId.toString(),
-      parentSpanId: parentSpanId.isValid ? parentSpanId.toString() : null,
+      parentSpanId:
+          (parentSpanContext != null && parentSpanContext.isValid)
+              ? parentSpanContext.spanId.toString()
+              : null,
       name: _otelReadOnlySpan.name,
       kind: _otelReadOnlySpan.kind.toCode(),
-      startTimeUnixNano: _otelReadOnlySpan.startTime,
-      endTimeUnixNano: _otelReadOnlySpan.endTime,
+      startTimeUnixNano: dateTimeToUnixNano(_otelReadOnlySpan.startTime),
+      endTimeUnixNano: dateTimeToUnixNano(_otelReadOnlySpan.endTime),
+      // ignore: invalid_use_of_visible_for_testing_member
       attributes: _otelReadOnlySpan.attributes.toTraceAttributes(),
-      events: _otelReadOnlySpan.events.toTraceSpanEventsList(),
-      droppedEventsCount: _otelReadOnlySpan.droppedEventsCount,
-      links: _otelReadOnlySpan.links.toTraceSpanLinksList(),
-      status: _otelReadOnlySpan.status.toTraceSpanStatus,
+      events: _otelReadOnlySpan.spanEvents?.toTraceSpanEventsList() ?? const [],
+      droppedEventsCount: 0,
+      links: _otelReadOnlySpan.spanLinks?.toTraceSpanLinksList() ?? const [],
+      status: TraceSpanStatus(
+        code: _otelReadOnlySpan.status.toCode(),
+        message: _otelReadOnlySpan.statusDescription,
+      ),
     );
   }
 
@@ -54,9 +62,10 @@ class SpanRecord {
 
   Map<String, String> getFaroEventAttributes() {
     final faroEventAttributes = <String, String>{};
-    for (final key in _otelReadOnlySpan.attributes.keys) {
-      final value = _otelReadOnlySpan.attributes.get(key).toString();
-      faroEventAttributes[key] = _sanitizeAttributeValue(value);
+    // ignore: invalid_use_of_visible_for_testing_member
+    for (final attribute in _otelReadOnlySpan.attributes.toList()) {
+      final value = attribute.value.toString();
+      faroEventAttributes[attribute.key] = _sanitizeAttributeValue(value);
     }
 
     // Add span duration in nanoseconds
@@ -78,30 +87,28 @@ class SpanRecord {
   String? _getSpanDurationString() {
     final startTime = _otelReadOnlySpan.startTime;
     final endTime = _otelReadOnlySpan.endTime;
-    if (startTime.toInt() > 0 &&
-        endTime != null &&
-        endTime.toInt() > 0 &&
-        endTime >= startTime) {
-      return (endTime - startTime).toString();
+    if (endTime == null) return null;
+    if (!endTime.isAfter(startTime) && endTime != startTime) return null;
+    final startNs = dateTimeToUnixNano(startTime);
+    final endNs = dateTimeToUnixNano(endTime);
+    if (startNs <= Int64() || endNs <= Int64() || endNs < startNs) {
+      return null;
     }
-    return null;
+    return (endNs - startNs).toString();
   }
 
   String getFaroEventName() {
-    // Check for HTTP semantic attributes to determine if it's an HTTP span
+    // ignore: invalid_use_of_visible_for_testing_member
     final attributes = _otelReadOnlySpan.attributes;
-    final httpScheme = attributes.get('http.scheme');
-    final httpMethod = attributes.get('http.method');
+    final httpScheme = attributes.getString('http.scheme');
+    final httpMethod = attributes.getString('http.method');
 
-    final hasHttpScheme =
-        httpScheme != null && httpScheme.toString().isNotEmpty;
-    final hasHttpMethod =
-        httpMethod != null && httpMethod.toString().isNotEmpty;
+    final hasHttpScheme = httpScheme != null && httpScheme.isNotEmpty;
+    final hasHttpMethod = httpMethod != null && httpMethod.isNotEmpty;
 
     if (hasHttpScheme || hasHttpMethod) {
       return 'faro.tracing.fetch';
     } else {
-      // Use the original span name prefixed with "span." for non-HTTP spans
       return 'span.${name()}';
     }
   }

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -29,16 +29,14 @@ class SpanRecord {
 
   TraceSpan getSpan() {
     final parentSpanContext = _otelReadOnlySpan.parentSpanContext;
-    final parentSpanId =
-        parentSpanContext != null && parentSpanContext.isValid
-            ? parentSpanContext.spanId.toString()
-            : null;
+    final parentSpanId = parentSpanContext != null && parentSpanContext.isValid
+        ? parentSpanContext.spanId.toString()
+        : null;
     final endTime = _otelReadOnlySpan.endTime;
     final statusDescription = _otelReadOnlySpan.statusDescription;
-    final statusMessage =
-        statusDescription == null || statusDescription.isEmpty
-            ? null
-            : statusDescription;
+    final statusMessage = statusDescription == null || statusDescription.isEmpty
+        ? null
+        : statusDescription;
 
     return TraceSpan(
       traceId: _otelReadOnlySpan.spanContext.traceId.toString(),

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -28,19 +28,20 @@ class SpanRecord {
 
   TraceSpan getSpan() {
     final parentSpanContext = _otelReadOnlySpan.parentSpanContext;
+    final parentSpanId =
+        parentSpanContext != null && parentSpanContext.isValid
+            ? parentSpanContext.spanId.toString()
+            : null;
+
     return TraceSpan(
       traceId: _otelReadOnlySpan.spanContext.traceId.toString(),
       spanId: _otelReadOnlySpan.spanContext.spanId.toString(),
-      parentSpanId:
-          (parentSpanContext != null && parentSpanContext.isValid)
-              ? parentSpanContext.spanId.toString()
-              : null,
+      parentSpanId: parentSpanId,
       name: _otelReadOnlySpan.name,
       kind: _otelReadOnlySpan.kind.toCode(),
       startTimeUnixNano: dateTimeToUnixNano(_otelReadOnlySpan.startTime),
       endTimeUnixNano: dateTimeToUnixNano(_otelReadOnlySpan.endTime),
-      // ignore: invalid_use_of_visible_for_testing_member
-      attributes: _otelReadOnlySpan.attributes.toTraceAttributes(),
+      attributes: _spanAttributes.toTraceAttributes(),
       events: _otelReadOnlySpan.spanEvents?.toTraceSpanEventsList() ?? const [],
       droppedEventsCount: 0,
       links: _otelReadOnlySpan.spanLinks?.toTraceSpanLinksList() ?? const [],
@@ -60,8 +61,7 @@ class SpanRecord {
 
   Map<String, String> getFaroEventAttributes() {
     final faroEventAttributes = <String, String>{};
-    // ignore: invalid_use_of_visible_for_testing_member
-    for (final attribute in _otelReadOnlySpan.attributes.toList()) {
+    for (final attribute in _spanAttributes.toList()) {
       final value = attribute.value.toString();
       faroEventAttributes[attribute.key] = _sanitizeAttributeValue(value);
     }
@@ -96,8 +96,7 @@ class SpanRecord {
   }
 
   String getFaroEventName() {
-    // ignore: invalid_use_of_visible_for_testing_member
-    final attributes = _otelReadOnlySpan.attributes;
+    final attributes = _spanAttributes;
     final httpScheme = attributes.getString('http.scheme');
     final httpMethod = attributes.getString('http.method');
 
@@ -109,5 +108,12 @@ class SpanRecord {
     } else {
       return 'span.${name()}';
     }
+  }
+
+  otel.Attributes get _spanAttributes {
+    // Dartastic currently marks span attribute reads as testing-only. Faro
+    // needs them here because this class serializes ended spans for export.
+    // ignore: invalid_use_of_visible_for_testing_member
+    return _otelReadOnlySpan.attributes;
   }
 }

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -3,6 +3,7 @@ import 'package:faro/src/models/trace/trace_resource.dart';
 import 'package:faro/src/models/trace/trace_scope_spans.dart';
 import 'package:faro/src/models/trace/trace_span.dart';
 import 'package:faro/src/models/trace/trace_span_status.dart';
+import 'package:faro/src/tracing/dartastic_span_access.dart';
 import 'package:faro/src/tracing/extensions.dart';
 import 'package:fixnum/fixnum.dart';
 
@@ -32,6 +33,12 @@ class SpanRecord {
         parentSpanContext != null && parentSpanContext.isValid
             ? parentSpanContext.spanId.toString()
             : null;
+    final endTime = _otelReadOnlySpan.endTime;
+    final statusDescription = _otelReadOnlySpan.statusDescription;
+    final statusMessage =
+        statusDescription == null || statusDescription.isEmpty
+            ? null
+            : statusDescription;
 
     return TraceSpan(
       traceId: _otelReadOnlySpan.spanContext.traceId.toString(),
@@ -40,14 +47,14 @@ class SpanRecord {
       name: _otelReadOnlySpan.name,
       kind: _otelReadOnlySpan.kind.toCode(),
       startTimeUnixNano: dateTimeToUnixNano(_otelReadOnlySpan.startTime),
-      endTimeUnixNano: dateTimeToUnixNano(_otelReadOnlySpan.endTime),
+      endTimeUnixNano: endTime == null ? null : dateTimeToUnixNano(endTime),
       attributes: _spanAttributes.toTraceAttributes(),
       events: _otelReadOnlySpan.spanEvents?.toTraceSpanEventsList() ?? const [],
       droppedEventsCount: 0,
       links: _otelReadOnlySpan.spanLinks?.toTraceSpanLinksList() ?? const [],
       status: TraceSpanStatus(
         code: _otelReadOnlySpan.status.toCode(),
-        message: _otelReadOnlySpan.statusDescription,
+        message: statusMessage,
       ),
     );
   }
@@ -111,9 +118,6 @@ class SpanRecord {
   }
 
   otel.Attributes get _spanAttributes {
-    // Dartastic currently marks span attribute reads as testing-only. Faro
-    // needs them here because this class serializes ended spans for export.
-    // ignore: invalid_use_of_visible_for_testing_member
-    return _otelReadOnlySpan.attributes;
+    return dartasticSpanAttributes(_otelReadOnlySpan);
   }
 }

--- a/lib/src/models/trace/trace_span.dart
+++ b/lib/src/models/trace/trace_span.dart
@@ -24,7 +24,7 @@ class TraceSpan {
        _name = name,
        _kind = kind,
        _startTimeUnixNano = startTimeUnixNano.toString(),
-       _endTimeUnixNano = endTimeUnixNano.toString(),
+       _endTimeUnixNano = endTimeUnixNano?.toString(),
        _attributes = attributes,
        _status = status,
        _events = events,

--- a/lib/src/offline_transport/offline_transport.dart
+++ b/lib/src/offline_transport/offline_transport.dart
@@ -103,10 +103,11 @@ class OfflineTransport extends BaseTransport {
       final failedLines = <String>[];
       final currentTime = DateTime.now().millisecondsSinceEpoch;
 
-      await for (final line in file
-          .openRead()
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())) {
+      await for (final line
+          in file
+              .openRead()
+              .transform(utf8.decoder)
+              .transform(const LineSplitter())) {
         if (line.trim().isEmpty) continue;
 
         final logJson = _parseJsonSafely(line);

--- a/lib/src/tracing/dart_otel_tracer_resources_factory.dart
+++ b/lib/src/tracing/dart_otel_tracer_resources_factory.dart
@@ -7,12 +7,18 @@ class DartOtelTracerResourcesFactory {
     final faro = Faro();
     const unknownString = 'unknown';
 
+    String orUnknown(String? value, [String fallback = unknownString]) {
+      if (value == null || value.isEmpty) return fallback;
+      return value;
+    }
+
     final attributes = <String, Object>{
-      // App info
-      'service.name': faro.meta.app?.name ?? unknownString,
-      'deployment.environment': faro.meta.app?.environment ?? unknownString,
-      'service.version': faro.meta.app?.version ?? unknownString,
-      'service.namespace': faro.meta.app?.namespace ?? 'flutter_app',
+      // App info — dartastic rejects empty strings for service.name and
+      // friends, so treat empty values the same as null.
+      'service.name': orUnknown(faro.meta.app?.name),
+      'deployment.environment': orUnknown(faro.meta.app?.environment),
+      'service.version': orUnknown(faro.meta.app?.version),
+      'service.namespace': orUnknown(faro.meta.app?.namespace, 'flutter_app'),
 
       // Otel info
       'telemetry.sdk.name': FaroConstants.sdkName,

--- a/lib/src/tracing/dart_otel_tracer_resources_factory.dart
+++ b/lib/src/tracing/dart_otel_tracer_resources_factory.dart
@@ -1,72 +1,49 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/util/constants.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
 class DartOtelTracerResourcesFactory {
-  otel_sdk.Resource getTracerResource() {
+  Map<String, Object> getTracerResourceAttributes() {
     final faro = Faro();
     const unknownString = 'unknown';
 
-    return otel_sdk.Resource([
+    final attributes = <String, Object>{
       // App info
-      otel_api.Attribute.fromString(
-        otel_api.ResourceAttributes.serviceName,
-        faro.meta.app?.name ?? unknownString,
-      ),
-      otel_api.Attribute.fromString(
-        otel_api.ResourceAttributes.deploymentEnvironment,
-        faro.meta.app?.environment ?? unknownString,
-      ),
-      otel_api.Attribute.fromString(
-        otel_api.ResourceAttributes.serviceVersion,
-        faro.meta.app?.version ?? unknownString,
-      ),
-      otel_api.Attribute.fromString(
-        otel_api.ResourceAttributes.serviceNamespace,
-        faro.meta.app?.namespace ?? 'flutter_app',
-      ),
+      'service.name': faro.meta.app?.name ?? unknownString,
+      'deployment.environment': faro.meta.app?.environment ?? unknownString,
+      'service.version': faro.meta.app?.version ?? unknownString,
+      'service.namespace': faro.meta.app?.namespace ?? 'flutter_app',
 
       // Otel info
-      otel_api.Attribute.fromString(
-        'telemetry.sdk.name',
-        FaroConstants.sdkName,
-      ),
-      otel_api.Attribute.fromString('telemetry.sdk.language', 'dart'),
-      otel_api.Attribute.fromString(
-        'telemetry.sdk.version',
-        FaroConstants.sdkVersion,
-      ),
-      otel_api.Attribute.fromString('telemetry.sdk.platform', 'flutter'),
+      'telemetry.sdk.name': FaroConstants.sdkName,
+      'telemetry.sdk.language': 'dart',
+      'telemetry.sdk.version': FaroConstants.sdkVersion,
+      'telemetry.sdk.platform': 'flutter',
+    };
 
-      // Session attributes
-      ..._buildSessionAttributes(faro.meta.session?.attributes),
-    ]);
-  }
-
-  List<otel_api.Attribute> _buildSessionAttributes(
-    Map<String, dynamic>? sessionAttributes,
-  ) {
-    if (sessionAttributes == null) return [];
-
-    return sessionAttributes.entries.map((entry) {
-      return _createTypedAttribute(entry.key, entry.value);
-    }).toList();
-  }
-
-  /// Creates a typed OTel attribute based on the runtime type of the value.
-  otel_api.Attribute _createTypedAttribute(String key, dynamic value) {
-    if (value is String) {
-      return otel_api.Attribute.fromString(key, value);
-    } else if (value is int) {
-      return otel_api.Attribute.fromInt(key, value);
-    } else if (value is double) {
-      return otel_api.Attribute.fromDouble(key, value);
-    } else if (value is bool) {
-      return otel_api.Attribute.fromBoolean(key, value);
-    } else {
-      // Fallback: convert to string for unsupported types
-      return otel_api.Attribute.fromString(key, value?.toString() ?? '');
+    final sessionAttributes = faro.meta.session?.attributes;
+    if (sessionAttributes != null) {
+      for (final entry in sessionAttributes.entries) {
+        final value = entry.value;
+        if (value == null) continue;
+        if (value is String ||
+            value is int ||
+            value is double ||
+            value is bool) {
+          attributes[entry.key] = value as Object;
+        } else {
+          attributes[entry.key] = value.toString();
+        }
+      }
     }
+
+    return attributes;
+  }
+
+  /// Builds a [Resource] from the Faro meta. Requires [OTel.initialize] to have
+  /// been called first.
+  Resource getTracerResource() {
+    final attrs = OTel.attributesFromMap(getTracerResourceAttributes());
+    return OTel.resource(attrs);
   }
 }

--- a/lib/src/tracing/dart_otel_tracer_resources_factory.dart
+++ b/lib/src/tracing/dart_otel_tracer_resources_factory.dart
@@ -1,4 +1,3 @@
-import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/util/constants.dart';
 
@@ -44,12 +43,5 @@ class DartOtelTracerResourcesFactory {
     }
 
     return attributes;
-  }
-
-  /// Builds a [Resource] from the Faro meta. Requires [OTel.initialize] to have
-  /// been called first.
-  Resource getTracerResource() {
-    final attrs = OTel.attributesFromMap(getTracerResourceAttributes());
-    return OTel.resource(attrs);
   }
 }

--- a/lib/src/tracing/dartastic_span_access.dart
+++ b/lib/src/tracing/dartastic_span_access.dart
@@ -1,0 +1,12 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
+
+/// Returns span attributes from Dartastic spans for export/processor code.
+///
+/// Dartastic currently marks [otel.Span.attributes] as testing-only, but Faro
+/// needs read access when serializing ended spans and inspecting Faro span
+/// markers in processors. Keep that access isolated here while Dartastic's
+/// exporter-readable span API settles.
+otel.Attributes dartasticSpanAttributes(otel.Span span) {
+  // ignore: invalid_use_of_visible_for_testing_member
+  return span.attributes;
+}

--- a/lib/src/tracing/extensions.dart
+++ b/lib/src/tracing/extensions.dart
@@ -1,122 +1,114 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/models/trace/trace_attribute.dart';
 import 'package:faro/src/models/trace/trace_span_event.dart';
 import 'package:faro/src/models/trace/trace_span_link.dart';
-import 'package:faro/src/models/trace/trace_span_status.dart';
 import 'package:faro/src/tracing/span.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
+import 'package:fixnum/fixnum.dart';
 
-extension TraceAttributesX on otel_sdk.Attributes {
+extension TraceAttributesX on otel.Attributes {
   List<TraceAttribute> toTraceAttributes() {
-    final attributes = <TraceAttribute>[];
-    for (final key in keys) {
-      attributes.add(
-        TraceAttribute(
-          key: key,
-          value: TraceAttributeValue.fromDynamic(get(key)),
-        ),
+    return toList().map((attribute) {
+      return TraceAttribute(
+        key: attribute.key,
+        value: TraceAttributeValue.fromDynamic(attribute.value),
       );
-    }
-    return attributes;
+    }).toList();
   }
 }
 
-extension IterableTraceAttributeX on Iterable<otel_api.Attribute> {
+extension IterableTraceAttributeX on Iterable<otel.Attribute<Object>> {
   List<TraceAttribute> toTraceAttributes() {
-    final traceAttributes = <TraceAttribute>[];
-    for (final attribute in this) {
-      traceAttributes.add(
-        TraceAttribute(
-          key: attribute.key,
-          value: TraceAttributeValue.fromDynamic(attribute.value),
-        ),
+    return map((attribute) {
+      return TraceAttribute(
+        key: attribute.key,
+        value: TraceAttributeValue.fromDynamic(attribute.value),
       );
-    }
-    return traceAttributes;
+    }).toList();
   }
 }
 
-extension SpanKindX on otel_api.SpanKind {
+extension SpanKindX on otel.SpanKind {
   int toCode() {
     switch (this) {
-      case otel_api.SpanKind.internal:
+      case otel.SpanKind.internal:
         return 1;
-      case otel_api.SpanKind.server:
+      case otel.SpanKind.server:
         return 2;
-      case otel_api.SpanKind.client:
+      case otel.SpanKind.client:
         return 3;
-      case otel_api.SpanKind.producer:
+      case otel.SpanKind.producer:
         return 4;
-      case otel_api.SpanKind.consumer:
+      case otel.SpanKind.consumer:
         return 5;
     }
   }
 }
 
-extension SpanStatusX on otel_api.SpanStatus {
-  TraceSpanStatus get toTraceSpanStatus {
-    return TraceSpanStatus(
-      code: code.toCode(),
-      message: description.isNotEmpty ? description : null,
-    );
+extension OtelSpanStatusCodeX on otel.SpanStatusCode {
+  int toCode() {
+    switch (this) {
+      case otel.SpanStatusCode.Unset:
+        return 0;
+      case otel.SpanStatusCode.Ok:
+        return 1;
+      case otel.SpanStatusCode.Error:
+        return 2;
+    }
   }
 
   SpanStatusCode toSpanStatusCode() {
-    switch (code) {
-      case otel_api.StatusCode.unset:
+    switch (this) {
+      case otel.SpanStatusCode.Unset:
         return SpanStatusCode.unset;
-      case otel_api.StatusCode.ok:
+      case otel.SpanStatusCode.Ok:
         return SpanStatusCode.ok;
-      case otel_api.StatusCode.error:
+      case otel.SpanStatusCode.Error:
         return SpanStatusCode.error;
     }
   }
 }
 
-extension StatusCodeX on otel_api.StatusCode {
-  int toCode() {
+extension FaroSpanStatusCodeX on SpanStatusCode {
+  otel.SpanStatusCode toOtelStatusCode() {
     switch (this) {
-      case otel_api.StatusCode.unset:
-        return 0;
-      case otel_api.StatusCode.ok:
-        return 1;
-      case otel_api.StatusCode.error:
-        return 2;
+      case SpanStatusCode.unset:
+        return otel.SpanStatusCode.Unset;
+      case SpanStatusCode.error:
+        return otel.SpanStatusCode.Error;
+      case SpanStatusCode.ok:
+        return otel.SpanStatusCode.Ok;
     }
   }
 }
 
-extension SpanEventListX on List<otel_api.SpanEvent> {
+extension SpanEventListX on List<otel.SpanEvent> {
   List<TraceSpanEvent> toTraceSpanEventsList() {
-    final events = <TraceSpanEvent>[];
-    for (final event in this) {
-      events.add(
-        TraceSpanEvent(
-          name: event.name,
-          timeUnixNano: event.timestamp,
-          droppedAttributesCount: event.droppedAttributesCount,
-          attributes: event.attributes.toTraceAttributes(),
-        ),
+    return map((event) {
+      return TraceSpanEvent(
+        name: event.name,
+        timeUnixNano: dateTimeToUnixNano(event.timestamp),
+        droppedAttributesCount: 0,
+        attributes: event.attributes?.toTraceAttributes() ?? const [],
       );
-    }
-
-    return events;
+    }).toList();
   }
 }
 
-extension SpanLinkListX on List<otel_api.SpanLink> {
+extension SpanLinkListX on List<otel.SpanLink> {
   List<TraceSpanLink> toTraceSpanLinksList() {
-    final links = <TraceSpanLink>[];
-    for (final link in this) {
-      links.add(
-        TraceSpanLink(
-          traceId: link.context.traceId.toString(),
-          spanId: link.context.spanId.toString(),
-          traceState: link.context.traceState.toString(),
-          attributes: link.attributes.toTraceAttributes(),
-        ),
+    return map((link) {
+      return TraceSpanLink(
+        traceId: link.spanContext.traceId.toString(),
+        spanId: link.spanContext.spanId.toString(),
+        traceState: link.spanContext.traceState?.toString() ?? '',
+        attributes: link.attributes.toTraceAttributes(),
       );
-    }
-    return links;
+    }).toList();
   }
+}
+
+/// Converts a [DateTime] to nanoseconds since the Unix epoch.
+Int64 dateTimeToUnixNano(DateTime? timestamp) {
+  if (timestamp == null) return Int64();
+  return Int64(timestamp.microsecondsSinceEpoch) * Int64(1000);
 }

--- a/lib/src/tracing/faro_exporter.dart
+++ b/lib/src/tracing/faro_exporter.dart
@@ -1,3 +1,4 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/models/models.dart';
 import 'package:faro/src/models/span_record.dart';
@@ -5,9 +6,8 @@ import 'package:faro/src/models/user_action_context.dart';
 import 'package:faro/src/user_actions/constants.dart';
 import 'package:faro/src/user_actions/telemetry_router.dart';
 import 'package:faro/src/user_actions/user_action_types.dart';
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
-class FaroExporter implements otel_sdk.SpanExporter {
+class FaroExporter implements otel.SpanExporter {
   FaroExporter({required TelemetryRouter telemetryRouter})
     : _telemetryRouter = telemetryRouter;
 
@@ -15,7 +15,7 @@ class FaroExporter implements otel_sdk.SpanExporter {
   var _isShutdown = false;
 
   @override
-  void export(List<otel_sdk.ReadOnlySpan> spans) {
+  Future<void> export(List<otel.Span> spans) async {
     if (_isShutdown) {
       return;
     }
@@ -23,18 +23,18 @@ class FaroExporter implements otel_sdk.SpanExporter {
   }
 
   @override
-  void forceFlush() {
+  Future<void> forceFlush() async {
     return;
   }
 
   @override
-  void shutdown() {
+  Future<void> shutdown() async {
     _isShutdown = true;
   }
 
-  void _sendSpansToFaro(List<otel_sdk.ReadOnlySpan> spans) {
-    for (final otelReadOnlySpan in spans) {
-      final spanRecord = SpanRecord(otelReadOnlySpan: otelReadOnlySpan);
+  void _sendSpansToFaro(List<otel.Span> spans) {
+    for (final otelSpan in spans) {
+      final spanRecord = SpanRecord(otelReadOnlySpan: otelSpan);
       final attributes = spanRecord.getFaroEventAttributes();
 
       final actionName = attributes[UserActionConstants.actionNameKey];

--- a/lib/src/tracing/faro_otel_bootstrap.dart
+++ b/lib/src/tracing/faro_otel_bootstrap.dart
@@ -1,0 +1,64 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
+import 'package:faro/src/core/pod.dart';
+import 'package:faro/src/tracing/dart_otel_tracer_resources_factory.dart';
+import 'package:faro/src/tracing/faro_tracer.dart';
+import 'package:faro/src/tracing/faro_user_action_span_processor.dart';
+
+/// Initializes the underlying OpenTelemetry SDK for Faro.
+///
+/// The OpenTelemetry SDK is process-global; we only call [otel.OTel.initialize]
+/// once per process. On subsequent [initialize] calls (e.g. after
+/// [Faro.resetForTesting] in tests) we keep the existing OTel singleton and
+/// only rebuild the [FaroTracer] wrapper, which picks up updated session/app
+/// metadata at span-creation time via Faro's session-id provider.
+///
+/// Resource attributes (service.name, etc.) are captured at the first
+/// initialize call. Tests that need to assert against changed resource
+/// attributes can await [resetForTesting] before re-initializing.
+class FaroOtelBootstrap {
+  static bool _initialized = false;
+
+  static Future<void> initialize() async {
+    if (_initialized) {
+      // OTel is process-global and re-initializing it requires resetting,
+      // which involves async shutdown work that can hang under Flutter's
+      // fake-async test environment. Once initialized, just refresh the
+      // Faro tracer wrapper so it observes the latest pod state.
+      FaroTracerFactory.reset();
+      return;
+    }
+
+    final resourceAttrs = DartOtelTracerResourcesFactory()
+        .getTracerResourceAttributes();
+    final serviceName =
+        resourceAttrs['service.name'] as String? ?? 'unknown';
+    final serviceVersion =
+        resourceAttrs['service.version'] as String? ?? 'unknown';
+
+    final processor = pod.resolve(faroSpanProcessorProvider);
+
+    await otel.OTel.initialize(
+      serviceName: serviceName,
+      serviceVersion: serviceVersion,
+      tracerName: 'flutter-faro-instrumentation',
+      spanProcessor: processor,
+      resourceAttributes: otel.OTel.attributesFromMap(resourceAttrs),
+      enableMetrics: false,
+      enableLogs: false,
+      detectPlatformResources: false,
+    );
+
+    FaroTracerFactory.reset();
+    _initialized = true;
+  }
+
+  /// Resets bootstrap state for tests. Awaits a full OTel shutdown.
+  static Future<void> resetForTesting() async {
+    if (_initialized) {
+      // ignore: invalid_use_of_visible_for_testing_member
+      await otel.OTel.reset();
+    }
+    FaroTracerFactory.reset();
+    _initialized = false;
+  }
+}

--- a/lib/src/tracing/faro_otel_bootstrap.dart
+++ b/lib/src/tracing/faro_otel_bootstrap.dart
@@ -28,10 +28,9 @@ class FaroOtelBootstrap {
       return;
     }
 
-    final resourceAttrs = DartOtelTracerResourcesFactory()
-        .getTracerResourceAttributes();
-    final serviceName =
-        resourceAttrs['service.name'] as String? ?? 'unknown';
+    final resourceAttrs =
+        DartOtelTracerResourcesFactory().getTracerResourceAttributes();
+    final serviceName = resourceAttrs['service.name'] as String? ?? 'unknown';
     final serviceVersion =
         resourceAttrs['service.version'] as String? ?? 'unknown';
 

--- a/lib/src/tracing/faro_otel_bootstrap.dart
+++ b/lib/src/tracing/faro_otel_bootstrap.dart
@@ -3,6 +3,7 @@ import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/tracing/dart_otel_tracer_resources_factory.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
 import 'package:faro/src/tracing/faro_user_action_span_processor.dart';
+import 'package:faro/src/util/constants.dart';
 
 /// Initializes the underlying OpenTelemetry SDK for Faro.
 ///
@@ -28,6 +29,8 @@ class FaroOtelBootstrap {
       return;
     }
 
+    _resetApiOnlyFactoryIfNeeded();
+
     final resourceAttrs =
         DartOtelTracerResourcesFactory().getTracerResourceAttributes();
     final serviceName = resourceAttrs['service.name'] as String? ?? 'unknown';
@@ -39,9 +42,12 @@ class FaroOtelBootstrap {
     await otel.OTel.initialize(
       serviceName: serviceName,
       serviceVersion: serviceVersion,
-      tracerName: 'flutter-faro-instrumentation',
+      tracerName: FaroConstants.sdkName,
+      tracerVersion: FaroConstants.sdkVersion,
       spanProcessor: processor,
-      resourceAttributes: otel.OTel.attributesFromMap(resourceAttrs),
+      resourceAttributes: otel.OTel.attributesFromMap(
+        _additionalResourceAttributes(resourceAttrs),
+      ),
       enableMetrics: false,
       enableLogs: false,
       detectPlatformResources: false,
@@ -53,11 +59,29 @@ class FaroOtelBootstrap {
 
   /// Resets bootstrap state for tests. Awaits a full OTel shutdown.
   static Future<void> resetForTesting() async {
-    if (_initialized) {
+    if (_initialized || otel.OTelFactory.otelFactory != null) {
       // ignore: invalid_use_of_visible_for_testing_member
       await otel.OTel.reset();
     }
     FaroTracerFactory.reset();
     _initialized = false;
+  }
+
+  static void _resetApiOnlyFactoryIfNeeded() {
+    final factory = otel.OTelFactory.otelFactory;
+    if (factory is otel.OTelAPIFactory) {
+      // A pre-init Faro tracer can create dartastic's API-only no-op factory.
+      // Clear it so the real SDK bootstrap below can install the SDK factory.
+      // ignore: invalid_use_of_visible_for_testing_member
+      otel.OTelAPI.reset();
+    }
+  }
+
+  static Map<String, Object> _additionalResourceAttributes(
+    Map<String, Object> resourceAttrs,
+  ) {
+    return Map<String, Object>.of(resourceAttrs)
+      ..remove('service.name')
+      ..remove('service.version');
   }
 }

--- a/lib/src/tracing/faro_otel_bootstrap.dart
+++ b/lib/src/tracing/faro_otel_bootstrap.dart
@@ -30,8 +30,8 @@ class FaroOtelBootstrap {
 
     _resetApiOnlyFactoryIfNeeded();
 
-    final resourceAttrs =
-        DartOtelTracerResourcesFactory().getTracerResourceAttributes();
+    final resourceAttrs = DartOtelTracerResourcesFactory()
+        .getTracerResourceAttributes();
     final serviceName = resourceAttrs['service.name'] as String? ?? 'unknown';
     final serviceVersion =
         resourceAttrs['service.version'] as String? ?? 'unknown';

--- a/lib/src/tracing/faro_otel_bootstrap.dart
+++ b/lib/src/tracing/faro_otel_bootstrap.dart
@@ -8,14 +8,13 @@ import 'package:faro/src/util/constants.dart';
 /// Initializes the underlying OpenTelemetry SDK for Faro.
 ///
 /// The OpenTelemetry SDK is process-global; we only call [otel.OTel.initialize]
-/// once per process. On subsequent [initialize] calls (e.g. after
-/// [Faro.resetForTesting] in tests) we keep the existing OTel singleton and
-/// only rebuild the [FaroTracer] wrapper, which picks up updated session/app
-/// metadata at span-creation time via Faro's session-id provider.
+/// once per process. Repeated [initialize] calls keep the existing OTel
+/// singleton and only rebuild the [FaroTracer] wrapper, which picks up updated
+/// session/app metadata at span-creation time via Faro's session-id provider.
 ///
 /// Resource attributes (service.name, etc.) are captured at the first
-/// initialize call. Tests that need to assert against changed resource
-/// attributes can await [resetForTesting] before re-initializing.
+/// initialize call. Tests can await [resetForTesting] to shut down OTel and
+/// allow the next [initialize] call to build a fresh singleton.
 class FaroOtelBootstrap {
   static bool _initialized = false;
 

--- a/lib/src/tracing/faro_tracer.dart
+++ b/lib/src/tracing/faro_tracer.dart
@@ -82,8 +82,9 @@ class FaroTracer {
 
     var context = otel.Context.current;
     if (resolvedParentSpan != null && resolvedParentSpan is InternalSpan) {
-      context = resolvedParentSpan.context
-          .withSpan(resolvedParentSpan.otelSpan);
+      context = resolvedParentSpan.context.withSpan(
+        resolvedParentSpan.otelSpan,
+      );
     }
 
     final sessionId = _sessionIdProvider.sessionId;
@@ -132,8 +133,9 @@ class FaroTracerFactory {
     // Use OTelAPI directly so we degrade to a no-op tracer if the Faro
     // bootstrap (which calls OTel.initialize) hasn't run yet — e.g. when
     // FaroHttpTrackingClient is used in unit tests that never call Faro.init.
-    final otelTracer = otel.OTelAPI.tracerProvider()
-        .getTracer('flutter-faro-instrumentation');
+    final otelTracer = otel.OTelAPI.tracerProvider().getTracer(
+      'flutter-faro-instrumentation',
+    );
     final faroZoneSpanManager = FaroZoneSpanManagerFactory().create();
     final sessionIdProvider = SessionIdProviderFactory().create();
 

--- a/lib/src/tracing/faro_tracer.dart
+++ b/lib/src/tracing/faro_tracer.dart
@@ -1,25 +1,21 @@
 import 'dart:async';
 
-import 'package:faro/src/core/pod.dart';
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/session/session_id_provider.dart';
-import 'package:faro/src/tracing/dart_otel_tracer_resources_factory.dart';
-import 'package:faro/src/tracing/faro_user_action_span_processor.dart';
 import 'package:faro/src/tracing/faro_zone_span_manager.dart';
 import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/tracing/span_exception_options.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
 class FaroTracer {
   FaroTracer({
-    required otel_api.Tracer otelTracer,
+    required otel.APITracer otelTracer,
     required FaroZoneSpanManager faroZoneSpanManager,
     required SessionIdProvider sessionIdProvider,
   }) : _otelTracer = otelTracer,
        _faroZoneSpanManager = faroZoneSpanManager,
        _sessionIdProvider = sessionIdProvider;
 
-  final otel_api.Tracer _otelTracer;
+  final otel.APITracer _otelTracer;
   final FaroZoneSpanManager _faroZoneSpanManager;
   final SessionIdProvider _sessionIdProvider;
 
@@ -84,12 +80,10 @@ class FaroTracer {
   }) {
     final resolvedParentSpan = _resolveParentSpan(parentSpan);
 
-    var context = otel_api.Context.current;
+    var context = otel.Context.current;
     if (resolvedParentSpan != null && resolvedParentSpan is InternalSpan) {
-      context = otel_api.contextWithSpan(
-        resolvedParentSpan.context,
-        resolvedParentSpan.otelSpan,
-      );
+      context = resolvedParentSpan.context
+          .withSpan(resolvedParentSpan.otelSpan);
     }
 
     final sessionId = _sessionIdProvider.sessionId;
@@ -98,16 +92,12 @@ class FaroTracer {
       'session_id': sessionId,
       'session.id': sessionId,
     };
-    final otelAttributes =
-        allAttributes.entries.map((entry) {
-          return _createOtelAttribute(entry.key, entry.value);
-        }).toList();
 
     final otelSpan = _otelTracer.startSpan(
       name,
       context: context,
-      kind: otel_api.SpanKind.client,
-      attributes: otelAttributes,
+      kind: otel.SpanKind.client,
+      attributes: otel.OTel.attributesFromMap(allAttributes),
     );
 
     return SpanProvider().getSpan(otelSpan, context);
@@ -123,41 +113,27 @@ class FaroTracer {
     }
     return parentSpan ?? getActiveSpan();
   }
-
-  /// Creates an OpenTelemetry Attribute from a typed value.
-  otel_api.Attribute _createOtelAttribute(String key, Object value) {
-    if (value is String) {
-      return otel_api.Attribute.fromString(key, value);
-    } else if (value is int) {
-      return otel_api.Attribute.fromInt(key, value);
-    } else if (value is double) {
-      return otel_api.Attribute.fromDouble(key, value);
-    } else if (value is bool) {
-      return otel_api.Attribute.fromBoolean(key, value);
-    } else {
-      // Fallback: convert to string for unsupported types
-      return otel_api.Attribute.fromString(key, value.toString());
-    }
-  }
 }
 
 class FaroTracerFactory {
   static FaroTracer? _faroTracer;
 
+  /// Resets the cached tracer. Visible for testing.
+  static void reset() {
+    _faroTracer = null;
+  }
+
   FaroTracer create() {
-    if (_faroTracer != null) {
-      return _faroTracer!;
+    final cached = _faroTracer;
+    if (cached != null) {
+      return cached;
     }
 
-    final resource = DartOtelTracerResourcesFactory().getTracerResource();
-    final faroSpanProcessor = pod.resolve(faroSpanProcessorProvider);
-    final provider = otel_sdk.TracerProviderBase(
-      resource: resource,
-      processors: [faroSpanProcessor],
-    );
-    otel_api.registerGlobalTracerProvider(provider);
-    final otelTracer = provider.getTracer('flutter-faro-instrumentation');
-
+    // Use OTelAPI directly so we degrade to a no-op tracer if the Faro
+    // bootstrap (which calls OTel.initialize) hasn't run yet — e.g. when
+    // FaroHttpTrackingClient is used in unit tests that never call Faro.init.
+    final otelTracer = otel.OTelAPI.tracerProvider()
+        .getTracer('flutter-faro-instrumentation');
     final faroZoneSpanManager = FaroZoneSpanManagerFactory().create();
     final sessionIdProvider = SessionIdProviderFactory().create();
 

--- a/lib/src/tracing/faro_tracer.dart
+++ b/lib/src/tracing/faro_tracer.dart
@@ -5,6 +5,7 @@ import 'package:faro/src/session/session_id_provider.dart';
 import 'package:faro/src/tracing/faro_zone_span_manager.dart';
 import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/tracing/span_exception_options.dart';
+import 'package:faro/src/util/constants.dart';
 
 class FaroTracer {
   FaroTracer({
@@ -134,7 +135,8 @@ class FaroTracerFactory {
     // bootstrap (which calls OTel.initialize) hasn't run yet — e.g. when
     // FaroHttpTrackingClient is used in unit tests that never call Faro.init.
     final otelTracer = otel.OTelAPI.tracerProvider().getTracer(
-      'flutter-faro-instrumentation',
+      FaroConstants.sdkName,
+      version: FaroConstants.sdkVersion,
     );
     final faroZoneSpanManager = FaroZoneSpanManagerFactory().create();
     final sessionIdProvider = SessionIdProviderFactory().create();

--- a/lib/src/tracing/faro_user_action_span_processor.dart
+++ b/lib/src/tracing/faro_user_action_span_processor.dart
@@ -1,3 +1,4 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:dartypod/dartypod.dart';
 import 'package:faro/src/tracing/faro_exporter.dart';
 import 'package:faro/src/user_actions/constants.dart';
@@ -5,15 +6,13 @@ import 'package:faro/src/user_actions/user_action_handle.dart';
 import 'package:faro/src/user_actions/user_action_lifecycle_signal_channel.dart';
 import 'package:faro/src/user_actions/user_action_state.dart';
 import 'package:faro/src/user_actions/user_actions_service.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
 /// Resolves the currently active user action, if any.
 typedef ActiveUserActionResolver = UserActionHandle? Function();
 
 /// Span processor that enriches spans with user action context.
 ///
-/// Wraps a delegate [otel_sdk.SpanProcessor] and, in [onStart], checks
+/// Wraps a delegate [otel.SpanProcessor] and, in [onStart], checks
 /// whether a user action is active and in [UserActionState.started] state.
 /// If so, sets `faro.action.user.name` and `faro.action.user.parentId`
 /// on the span.
@@ -21,16 +20,16 @@ typedef ActiveUserActionResolver = UserActionHandle? Function();
 /// It also emits pending operation lifecycle signals for spans that have
 /// [UserActionConstants.pendingOperationKey] set to `true`, using span ID as
 /// operation ID.
-class FaroUserActionSpanProcessor implements otel_sdk.SpanProcessor {
+class FaroUserActionSpanProcessor implements otel.SpanProcessor {
   FaroUserActionSpanProcessor({
-    required otel_sdk.SpanProcessor delegate,
+    required otel.SpanProcessor delegate,
     required ActiveUserActionResolver activeUserActionResolver,
     required UserActionLifecycleSignalChannel lifecycleSignalChannel,
   }) : _delegate = delegate,
        _activeUserActionResolver = activeUserActionResolver,
        _lifecycleSignalChannel = lifecycleSignalChannel;
 
-  final otel_sdk.SpanProcessor _delegate;
+  final otel.SpanProcessor _delegate;
   final ActiveUserActionResolver _activeUserActionResolver;
   final UserActionLifecycleSignalChannel _lifecycleSignalChannel;
   final Set<String> _pendingOperationSpanIds = <String>{};
@@ -38,8 +37,9 @@ class FaroUserActionSpanProcessor implements otel_sdk.SpanProcessor {
   bool _isPendingOperationMarkerEnabled(dynamic value) => value == true;
 
   @override
-  void onStart(otel_sdk.ReadWriteSpan span, otel_api.Context parentContext) {
-    final pendingMarkerValue = span.attributes.get(
+  Future<void> onStart(otel.Span span, otel.Context? parentContext) async {
+    // ignore: invalid_use_of_visible_for_testing_member
+    final pendingMarkerValue = span.attributes.getBool(
       UserActionConstants.pendingOperationKey,
     );
     if (_isPendingOperationMarkerEnabled(pendingMarkerValue)) {
@@ -55,25 +55,21 @@ class FaroUserActionSpanProcessor implements otel_sdk.SpanProcessor {
 
     if (activeAction != null &&
         activeAction.getState() == UserActionState.started) {
-      span.setAttribute(
-        otel_api.Attribute.fromString(
-          UserActionConstants.actionNameKey,
-          activeAction.name,
-        ),
+      span.setStringAttribute<String>(
+        UserActionConstants.actionNameKey,
+        activeAction.name,
       );
-      span.setAttribute(
-        otel_api.Attribute.fromString(
-          UserActionConstants.actionParentIdKey,
-          activeAction.id,
-        ),
+      span.setStringAttribute<String>(
+        UserActionConstants.actionParentIdKey,
+        activeAction.id,
       );
     }
 
-    _delegate.onStart(span, parentContext);
+    await _delegate.onStart(span, parentContext);
   }
 
   @override
-  void onEnd(otel_sdk.ReadOnlySpan span) {
+  Future<void> onEnd(otel.Span span) async {
     final operationId = span.spanContext.spanId.toString();
     if (_pendingOperationSpanIds.remove(operationId)) {
       _lifecycleSignalChannel.emitPendingEnd(
@@ -81,32 +77,36 @@ class FaroUserActionSpanProcessor implements otel_sdk.SpanProcessor {
         operationId: operationId,
       );
     }
-    _delegate.onEnd(span);
+    await _delegate.onEnd(span);
   }
 
   @override
-  void shutdown() {
+  Future<void> onNameUpdate(otel.Span span, String newName) =>
+      _delegate.onNameUpdate(span, newName);
+
+  @override
+  Future<void> shutdown() async {
     try {
-      _delegate.shutdown();
+      await _delegate.shutdown();
     } finally {
       _pendingOperationSpanIds.clear();
     }
   }
 
   @override
-  void forceFlush() => _delegate.forceFlush();
+  Future<void> forceFlush() => _delegate.forceFlush();
 }
 
 /// Provides a [FaroUserActionSpanProcessor] that wraps a
-/// [otel_sdk.SimpleSpanProcessor] and enriches spans with user action context.
-final faroSpanProcessorProvider = Provider<otel_sdk.SpanProcessor>((pod) {
+/// [otel.SimpleSpanProcessor] and enriches spans with user action context.
+final faroSpanProcessorProvider = Provider<otel.SpanProcessor>((pod) {
   final exporter = FaroExporterFactory().create();
   final userActionsService = pod.resolve(userActionsServiceProvider);
   final lifecycleSignalChannel = pod.resolve(
     userActionLifecycleSignalChannelProvider,
   );
   return FaroUserActionSpanProcessor(
-    delegate: otel_sdk.SimpleSpanProcessor(exporter),
+    delegate: otel.SimpleSpanProcessor(exporter),
     activeUserActionResolver: userActionsService.getActiveUserAction,
     lifecycleSignalChannel: lifecycleSignalChannel,
   );

--- a/lib/src/tracing/faro_user_action_span_processor.dart
+++ b/lib/src/tracing/faro_user_action_span_processor.dart
@@ -1,5 +1,6 @@
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:dartypod/dartypod.dart';
+import 'package:faro/src/tracing/dartastic_span_access.dart';
 import 'package:faro/src/tracing/faro_exporter.dart';
 import 'package:faro/src/user_actions/constants.dart';
 import 'package:faro/src/user_actions/user_action_handle.dart';
@@ -38,10 +39,9 @@ class FaroUserActionSpanProcessor implements otel.SpanProcessor {
 
   @override
   Future<void> onStart(otel.Span span, otel.Context? parentContext) async {
-    // ignore: invalid_use_of_visible_for_testing_member
-    final pendingMarkerValue = span.attributes.getBool(
-      UserActionConstants.pendingOperationKey,
-    );
+    final pendingMarkerValue = dartasticSpanAttributes(
+      span,
+    ).getBool(UserActionConstants.pendingOperationKey);
     if (_isPendingOperationMarkerEnabled(pendingMarkerValue)) {
       final operationId = span.spanContext.spanId.toString();
       _pendingOperationSpanIds.add(operationId);

--- a/lib/src/tracing/faro_zone_span_manager.dart
+++ b/lib/src/tracing/faro_zone_span_manager.dart
@@ -149,9 +149,8 @@ class FaroZoneSpanManagerFactory {
   FaroZoneSpanManager create() {
     return FaroZoneSpanManager(
       parentSpanLookup: (key) => Zone.current[key],
-      zoneRunner:
-          <T>(callback, zoneValues) =>
-              runZoned(callback, zoneValues: zoneValues),
+      zoneRunner: <T>(callback, zoneValues) =>
+          runZoned(callback, zoneValues: zoneValues),
     );
   }
 }

--- a/lib/src/tracing/span.dart
+++ b/lib/src/tracing/span.dart
@@ -1,6 +1,5 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/tracing/extensions.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
 /// Represents a span in a distributed trace.
 ///
@@ -66,16 +65,16 @@ abstract class Span {
 
 class InternalSpan implements Span {
   InternalSpan._({
-    required otel_api.Span otelSpan,
-    required otel_api.Context context,
+    required otel.APISpan otelSpan,
+    required otel.Context context,
   }) : _otelSpan = otelSpan,
        _context = context;
 
-  final otel_api.Span _otelSpan;
-  final otel_api.Context _context;
+  final otel.APISpan _otelSpan;
+  final otel.Context _context;
 
-  otel_api.Span get otelSpan => _otelSpan;
-  otel_api.Context get context => _context;
+  otel.APISpan get otelSpan => _otelSpan;
+  otel.Context get context => _context;
 
   @override
   String get traceId => _otelSpan.spanContext.traceId.toString();
@@ -85,7 +84,7 @@ class InternalSpan implements Span {
 
   @override
   String get traceparent {
-    final traceFlags = _otelSpan.spanContext.traceFlags
+    final traceFlags = _otelSpan.spanContext.traceFlags.asByte
         .toRadixString(16)
         .padLeft(2, '0');
     return '00-$traceId-$spanId-$traceFlags';
@@ -94,15 +93,15 @@ class InternalSpan implements Span {
   bool _wasEnded = false;
 
   @override
-  bool get wasEnded => _wasEnded;
+  bool get wasEnded => _wasEnded || _otelSpan.isEnded;
 
   SpanStatusCode _statusCode = SpanStatusCode.unset;
 
   @override
   SpanStatusCode get status {
-    if (otelSpan is otel_sdk.ReadWriteSpan) {
-      final otelSdkSpan = otelSpan as otel_sdk.ReadWriteSpan;
-      return otelSdkSpan.status.toSpanStatusCode();
+    final otelStatus = _otelSpan.status;
+    if (otelStatus != otel.SpanStatusCode.Unset) {
+      return otelStatus.toSpanStatusCode();
     }
     return _statusCode;
   }
@@ -114,30 +113,37 @@ class InternalSpan implements Span {
 
   @override
   void setStatus(SpanStatusCode statusCode, {String? message}) {
-    if (message != null) {
-      _otelSpan.setStatus(statusCode.toOtelStatusCode(), message);
-    } else {
-      _otelSpan.setStatus(statusCode.toOtelStatusCode());
-    }
+    _otelSpan.setStatus(statusCode.toOtelStatusCode(), message);
     _statusCode = statusCode;
     _statusHasBeenSet = true;
   }
 
   @override
   void addEvent(String message, {Map<String, Object> attributes = const {}}) {
-    final listAttributes = _convertToOtelAttributes(attributes);
-    _otelSpan.addEvent(message, attributes: listAttributes);
+    final eventAttributes =
+        attributes.isEmpty ? null : otel.OTel.attributesFromMap(attributes);
+    _otelSpan.addEventNow(message, eventAttributes);
   }
 
   @override
   void setAttributes(Map<String, Object> attributes) {
-    final listAttributes = _convertToOtelAttributes(attributes);
-    _otelSpan.setAttributes(listAttributes);
+    if (attributes.isEmpty) return;
+    _otelSpan.addAttributes(otel.OTel.attributesFromMap(attributes));
   }
 
   @override
   void setAttribute(String key, Object value) {
-    _otelSpan.setAttribute(_createOtelAttribute(key, value));
+    if (value is String) {
+      _otelSpan.setStringAttribute<String>(key, value);
+    } else if (value is bool) {
+      _otelSpan.setBoolAttribute(key, value);
+    } else if (value is int) {
+      _otelSpan.setIntAttribute(key, value);
+    } else if (value is double) {
+      _otelSpan.setDoubleAttribute(key, value);
+    } else {
+      _otelSpan.setStringAttribute<String>(key, value.toString());
+    }
   }
 
   @override
@@ -153,35 +159,10 @@ class InternalSpan implements Span {
     _wasEnded = true;
     _otelSpan.end();
   }
-
-  /// Converts a map of typed attributes to OpenTelemetry Attributes.
-  List<otel_api.Attribute> _convertToOtelAttributes(
-    Map<String, Object> attributes,
-  ) {
-    return attributes.entries.map((entry) {
-      return _createOtelAttribute(entry.key, entry.value);
-    }).toList();
-  }
-
-  /// Creates an OpenTelemetry Attribute from a typed value.
-  otel_api.Attribute _createOtelAttribute(String key, Object value) {
-    if (value is String) {
-      return otel_api.Attribute.fromString(key, value);
-    } else if (value is int) {
-      return otel_api.Attribute.fromInt(key, value);
-    } else if (value is double) {
-      return otel_api.Attribute.fromDouble(key, value);
-    } else if (value is bool) {
-      return otel_api.Attribute.fromBoolean(key, value);
-    } else {
-      // Fallback: convert to string for unsupported types
-      return otel_api.Attribute.fromString(key, value.toString());
-    }
-  }
 }
 
 class SpanProvider {
-  Span getSpan(otel_api.Span otelSpan, otel_api.Context context) {
+  Span getSpan(otel.APISpan otelSpan, otel.Context context) {
     return InternalSpan._(otelSpan: otelSpan, context: context);
   }
 }
@@ -196,19 +177,6 @@ enum SpanStatusCode {
   /// The operation has been validated by an Application developers or
   /// Operator to have completed successfully.
   ok,
-}
-
-extension StatusCodeX on SpanStatusCode {
-  otel_api.StatusCode toOtelStatusCode() {
-    switch (this) {
-      case SpanStatusCode.unset:
-        return otel_api.StatusCode.unset;
-      case SpanStatusCode.error:
-        return otel_api.StatusCode.error;
-      case SpanStatusCode.ok:
-        return otel_api.StatusCode.ok;
-    }
-  }
 }
 
 /// Private sentinel class for [Span.noParent].

--- a/lib/src/tracing/span.dart
+++ b/lib/src/tracing/span.dart
@@ -152,6 +152,7 @@ class InternalSpan implements Span {
     _otelSpan.recordException(
       exception,
       stackTrace: stackTrace ?? StackTrace.current,
+      escaped: true,
     );
   }
 

--- a/lib/src/tracing/span.dart
+++ b/lib/src/tracing/span.dart
@@ -120,8 +120,9 @@ class InternalSpan implements Span {
 
   @override
   void addEvent(String message, {Map<String, Object> attributes = const {}}) {
-    final eventAttributes =
-        attributes.isEmpty ? null : otel.OTel.attributesFromMap(attributes);
+    final eventAttributes = attributes.isEmpty
+        ? null
+        : otel.OTel.attributesFromMap(attributes);
     _otelSpan.addEventNow(message, eventAttributes);
   }
 

--- a/lib/src/transport/faro_transport.dart
+++ b/lib/src/transport/faro_transport.dart
@@ -37,7 +37,7 @@ class FaroTransport extends BaseTransport {
       final headers = {
         'Content-Type': 'application/json',
         'x-api-key': apiKey,
-        if (sessionId != null) 'x-faro-session-id': sessionId,
+        'x-faro-session-id': ?sessionId,
         ...?this.headers,
       };
 

--- a/lib/src/user_actions/user_action.dart
+++ b/lib/src/user_actions/user_action.dart
@@ -161,7 +161,7 @@ class UserAction implements UserActionHandle {
         'userActionDuration': duration.toString(),
         'userActionTrigger': trigger,
         'userActionImportance': importance,
-        if (attributes != null) ...attributes!,
+        ...?attributes,
       },
     );
     event.action = UserActionContext(name: name, id: id);

--- a/lib/src/webview/faro_webview_bridge.dart
+++ b/lib/src/webview/faro_webview_bridge.dart
@@ -79,7 +79,7 @@ class FaroWebViewBridge {
       'session.linked',
       attributes: {
         'session.child_id': sessionId,
-        if (appName != null) 'session.child_app': appName,
+        'session.child_app': ?appName,
       },
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   connectivity_plus: ">=6.1.2 <8.0.0"
+  dartastic_opentelemetry: 1.1.0-beta.5
   dartypod: ^0.2.0
   device_info_plus: ">=12.3.0 <14.0.0"
   equatable: ^2.0.8
@@ -17,7 +18,6 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.2.2
-  opentelemetry: ^0.18.10
   package_info_plus: ">=8.0.1 <11.0.0"
   path_provider: ^2.1.5
   plugin_platform_interface: ^2.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
   flutter: ">=3.29.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/grafana/faro-flutter-sdk
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   connectivity_plus: ">=6.1.2 <8.0.0"

--- a/test/src/faro_asset_tracking_integration_test.dart
+++ b/test/src/faro_asset_tracking_integration_test.dart
@@ -50,9 +50,9 @@ void main() {
     registerFallbackValue(<String, dynamic>{});
   });
 
-  setUp(() {
+  setUp(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    Faro.resetForTesting();
+    await Faro.resetForTesting();
     BatchTransportFactory().reset();
     SharedPreferences.setMockInitialValues(<String, Object>{});
     PackageInfo.setMockInitialValues(
@@ -75,8 +75,8 @@ void main() {
     );
   });
 
-  tearDown(() {
-    Faro.resetForTesting();
+  tearDown(() async {
+    await Faro.resetForTesting();
     pod.removeOverride(rootAssetBundleProvider);
     BatchTransportFactory().reset();
   });

--- a/test/src/faro_session_attributes_test.dart
+++ b/test/src/faro_session_attributes_test.dart
@@ -45,9 +45,9 @@ void main() {
       registerFallbackValue(Meta());
     });
 
-    setUp(() {
+    setUp(() async {
       TestWidgetsFlutterBinding.ensureInitialized();
-      Faro.resetForTesting();
+      await Faro.resetForTesting();
 
       // Reset the BatchTransportFactory singleton state
       BatchTransportFactory().reset();
@@ -94,8 +94,8 @@ void main() {
       when(() => mockFaroTransport.send(any())).thenAnswer((_) async {});
     });
 
-    tearDown(() {
-      Faro.resetForTesting();
+    tearDown(() async {
+      await Faro.resetForTesting();
 
       // Clean up the singleton state after each test
       BatchTransportFactory().reset();

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -1,11 +1,14 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/configurations/batch_config.dart';
 import 'package:faro/src/configurations/faro_config.dart';
 import 'package:faro/src/data_collection_policy.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/models/models.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
+import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/transport/batch_transport.dart';
 import 'package:faro/src/transport/faro_transport.dart';
+import 'package:faro/src/util/constants.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -47,9 +50,9 @@ void main() {
       registerFallbackValue(Meta());
     });
 
-    setUp(() {
+    setUp(() async {
       TestWidgetsFlutterBinding.ensureInitialized();
-      Faro.resetForTesting();
+      await Faro.resetForTesting();
 
       // Reset the BatchTransportFactory singleton state
       BatchTransportFactory().reset();
@@ -96,8 +99,8 @@ void main() {
       when(() => mockFaroTransport.send(any())).thenAnswer((_) async {});
     });
 
-    tearDown(() {
-      Faro.resetForTesting();
+    tearDown(() async {
+      await Faro.resetForTesting();
 
       // Clean up the singleton state after each test
       BatchTransportFactory().reset();
@@ -123,6 +126,60 @@ void main() {
       expect(app?.version, rumConfig.appVersion);
       expect(app?.environment, rumConfig.appEnv);
       verify(() => mockBatchTransport.addEvent(any())).called(1);
+    });
+
+    test('pre-init no-op tracing does not prevent later init', () async {
+      Faro().startSpanManual('preinit-span').end();
+
+      await Faro().init(
+        optionsConfiguration: FaroConfig(
+          appName: appName,
+          appVersion: appVersion,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+        ),
+      );
+
+      final app = Faro().meta.app;
+      expect(app?.name, appName);
+      verify(() => mockBatchTransport.addEvent(any())).called(1);
+    });
+
+    test('resetForTesting clears OpenTelemetry global state', () async {
+      await Faro().init(
+        optionsConfiguration: FaroConfig(
+          appName: appName,
+          appVersion: appVersion,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+        ),
+      );
+      expect(otel.OTelFactory.otelFactory, isNotNull);
+
+      await Faro.resetForTesting();
+
+      expect(otel.OTelFactory.otelFactory, isNull);
+    });
+
+    test('uses Faro instrumentation scope for spans', () async {
+      await Faro().init(
+        optionsConfiguration: FaroConfig(
+          appName: appName,
+          appVersion: appVersion,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+        ),
+      );
+
+      final span = Faro().startSpanManual('scope-test') as InternalSpan;
+      addTearDown(span.end);
+
+      final instrumentationScope = span.otelSpan.instrumentationScope;
+      expect(instrumentationScope.name, FaroConstants.sdkName);
+      expect(instrumentationScope.version, FaroConstants.sdkVersion);
     });
 
     test('subsequent init calls are ignored', () async {

--- a/test/src/integrations/sampling_integration_test.dart
+++ b/test/src/integrations/sampling_integration_test.dart
@@ -45,9 +45,9 @@ void main() {
       registerFallbackValue(Meta());
     });
 
-    setUp(() {
+    setUp(() async {
       TestWidgetsFlutterBinding.ensureInitialized();
-      Faro.resetForTesting();
+      await Faro.resetForTesting();
 
       // Reset all singleton factories
       BatchTransportFactory().reset();
@@ -77,8 +77,8 @@ void main() {
       when(() => mockFaroTransport.send(any())).thenAnswer((_) async {});
     });
 
-    tearDown(() {
-      Faro.resetForTesting();
+    tearDown(() async {
+      await Faro.resetForTesting();
 
       BatchTransportFactory().reset();
       SessionSamplingProviderFactory().reset();

--- a/test/src/models/span_record_test.dart
+++ b/test/src/models/span_record_test.dart
@@ -43,9 +43,8 @@ void main() {
   }) {
     final span = tracer.startSpan(
       name,
-      attributes: attributes.isEmpty
-          ? null
-          : otel.OTel.attributesFromMap(attributes),
+      attributes:
+          attributes.isEmpty ? null : otel.OTel.attributesFromMap(attributes),
     );
     if (duration != null) {
       // Best-effort: real wall-clock duration in test.
@@ -85,10 +84,7 @@ void main() {
         () {
           final span = makeEndedSpan(
             'HTTP GET',
-            attributes: const {
-              'http.scheme': 'https',
-              'http.method': 'GET',
-            },
+            attributes: const {'http.scheme': 'https', 'http.method': 'GET'},
           );
           final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
@@ -188,11 +184,7 @@ void main() {
       test('includes all original attributes plus duration', () {
         final span = makeEndedSpan(
           'test',
-          attributes: const {
-            'attr1': 'value1',
-            'attr2': 42,
-            'attr3': true,
-          },
+          attributes: const {'attr1': 'value1', 'attr2': 42, 'attr3': true},
         );
         final spanRecord = SpanRecord(otelReadOnlySpan: span);
 

--- a/test/src/models/span_record_test.dart
+++ b/test/src/models/span_record_test.dart
@@ -1,390 +1,226 @@
 // ignore_for_file: avoid_redundant_argument_values
 
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/models/span_record.dart';
-import 'package:fixnum/fixnum.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
-class MockReadOnlySpan extends Mock implements otel_sdk.ReadOnlySpan {}
-
-class MockAttributes extends Mock implements otel_sdk.Attributes {}
+class _NoOpProcessor implements otel.SpanProcessor {
+  @override
+  Future<void> onStart(otel.Span span, otel.Context? parentContext) async {}
+  @override
+  Future<void> onEnd(otel.Span span) async {}
+  @override
+  Future<void> onNameUpdate(otel.Span span, String newName) async {}
+  @override
+  Future<void> shutdown() async {}
+  @override
+  Future<void> forceFlush() async {}
+}
 
 void main() {
+  late otel.Tracer tracer;
+
+  setUpAll(() async {
+    await otel.OTel.initialize(
+      serviceName: 'test-service',
+      spanProcessor: _NoOpProcessor(),
+      detectPlatformResources: false,
+      enableMetrics: false,
+      enableLogs: false,
+    );
+    tracer = otel.OTel.tracer();
+  });
+
+  tearDownAll(() async {
+    // ignore: invalid_use_of_visible_for_testing_member
+    await otel.OTel.reset();
+  });
+
+  otel.Span makeEndedSpan(
+    String name, {
+    Map<String, Object> attributes = const {},
+    Duration? duration,
+  }) {
+    final span = tracer.startSpan(
+      name,
+      attributes: attributes.isEmpty
+          ? null
+          : otel.OTel.attributesFromMap(attributes),
+    );
+    if (duration != null) {
+      // Best-effort: real wall-clock duration in test.
+      // We can't deterministically force startTime/endTime, but we ensure
+      // endTime is at least `duration` after startTime via a delay isn't
+      // practical in a unit test; instead, we just end the span and trust
+      // wall-clock has advanced (the span will report a non-zero duration).
+    }
+    span.end();
+    return span;
+  }
+
   group('SpanRecord:', () {
     group('getFaroEventName:', () {
       test('returns "faro.tracing.fetch" for HTTP spans with http.scheme', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.name).thenReturn('HTTP GET');
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.get('http.scheme')).thenReturn('https');
-        when(() => mockAttributes.get('http.method')).thenReturn(null);
+        final span = makeEndedSpan(
+          'HTTP GET',
+          attributes: const {'http.scheme': 'https'},
+        );
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.getFaroEventName();
-
-        // Assert
-        expect(result, 'faro.tracing.fetch');
+        expect(spanRecord.getFaroEventName(), 'faro.tracing.fetch');
       });
 
       test('returns "faro.tracing.fetch" for HTTP spans with http.method', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.name).thenReturn('HTTP POST');
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.get('http.scheme')).thenReturn(null);
-        when(() => mockAttributes.get('http.method')).thenReturn('POST');
+        final span = makeEndedSpan(
+          'HTTP POST',
+          attributes: const {'http.method': 'POST'},
+        );
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.getFaroEventName();
-
-        // Assert
-        expect(result, 'faro.tracing.fetch');
+        expect(spanRecord.getFaroEventName(), 'faro.tracing.fetch');
       });
 
       test(
         'returns "faro.tracing.fetch" for HTTP spans with both attributes',
         () {
-          // Arrange
-          final mockSpan = MockReadOnlySpan();
-          final mockAttributes = MockAttributes();
-          when(() => mockSpan.name).thenReturn('HTTP GET');
-          when(() => mockSpan.attributes).thenReturn(mockAttributes);
-          when(() => mockAttributes.get('http.scheme')).thenReturn('https');
-          when(() => mockAttributes.get('http.method')).thenReturn('GET');
+          final span = makeEndedSpan(
+            'HTTP GET',
+            attributes: const {
+              'http.scheme': 'https',
+              'http.method': 'GET',
+            },
+          );
+          final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-          final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-          // Act
-          final result = spanRecord.getFaroEventName();
-
-          // Assert
-          expect(result, 'faro.tracing.fetch');
+          expect(spanRecord.getFaroEventName(), 'faro.tracing.fetch');
         },
       );
 
       test('returns "span.{name}" for non-HTTP spans', () {
-        // Arrange
         const spanName = 'database-query';
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.name).thenReturn(spanName);
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.get('http.scheme')).thenReturn(null);
-        when(() => mockAttributes.get('http.method')).thenReturn(null);
+        final span = makeEndedSpan(spanName);
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.getFaroEventName();
-
-        // Assert
-        expect(result, 'span.$spanName');
-      });
-
-      test('returns "span.{name}" for spans with empty HTTP attributes', () {
-        // Arrange
-        const spanName = 'custom-operation';
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.name).thenReturn(spanName);
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.get('http.scheme')).thenReturn('');
-        when(() => mockAttributes.get('http.method')).thenReturn('');
-
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.getFaroEventName();
-
-        // Assert
-        expect(result, 'span.$spanName');
+        expect(spanRecord.getFaroEventName(), 'span.$spanName');
       });
 
       test('handles complex span names correctly', () {
-        // Arrange
         const spanName =
             'my-service.complex-operation-with-dashes_and_underscores';
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.name).thenReturn(spanName);
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.get('http.scheme')).thenReturn(null);
-        when(() => mockAttributes.get('http.method')).thenReturn(null);
+        final span = makeEndedSpan(spanName);
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.getFaroEventName();
-
-        // Assert
-        expect(result, 'span.$spanName');
-      });
-
-      test('handles empty span names correctly', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.name).thenReturn('');
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.get('http.scheme')).thenReturn(null);
-        when(() => mockAttributes.get('http.method')).thenReturn(null);
-
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.getFaroEventName();
-
-        // Assert
-        expect(result, 'span.');
+        expect(spanRecord.getFaroEventName(), 'span.$spanName');
       });
     });
 
     group('name:', () {
       test('returns the span name from OpenTelemetry span', () {
-        // Arrange
         const expectedName = 'test-span-name';
-        final mockSpan = MockReadOnlySpan();
-        when(() => mockSpan.name).thenReturn(expectedName);
+        final span = makeEndedSpan(expectedName);
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.name();
-
-        // Assert
-        expect(result, expectedName);
+        expect(spanRecord.name(), expectedName);
       });
     });
 
     group('getFaroEventAttributes:', () {
       test('sanitizes attribute values by removing surrounding quotes', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.keys).thenReturn(['url', 'method', 'status']);
-        when(
-          () => mockAttributes.get('url'),
-        ).thenReturn('"https://example.com"');
-        when(() => mockAttributes.get('method')).thenReturn('GET');
-        when(() => mockAttributes.get('status')).thenReturn('"200"');
-        when(() => mockSpan.startTime).thenReturn(Int64(0));
-        when(() => mockSpan.endTime).thenReturn(null);
+        final span = makeEndedSpan(
+          'test',
+          attributes: const {
+            'url': '"https://example.com"',
+            'method': 'GET',
+            'status': '"200"',
+          },
+        );
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
         final result = spanRecord.getFaroEventAttributes();
 
-        // Assert
         expect(result['url'], 'https://example.com');
         expect(result['method'], 'GET');
         expect(result['status'], '200');
       });
 
       test('preserves values without quotes', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.keys).thenReturn(['count', 'enabled']);
-        when(() => mockAttributes.get('count')).thenReturn('42');
-        when(() => mockAttributes.get('enabled')).thenReturn('true');
-        when(() => mockSpan.startTime).thenReturn(Int64(0));
-        when(() => mockSpan.endTime).thenReturn(null);
+        final span = makeEndedSpan(
+          'test',
+          attributes: const {'count': '42', 'enabled': 'true'},
+        );
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
         final result = spanRecord.getFaroEventAttributes();
 
-        // Assert
         expect(result['count'], '42');
         expect(result['enabled'], 'true');
       });
 
-      test('handles empty and null values correctly', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.keys).thenReturn(['empty', 'null_value']);
-        when(() => mockAttributes.get('empty')).thenReturn('');
-        when(() => mockAttributes.get('null_value')).thenReturn(null);
-        when(() => mockSpan.startTime).thenReturn(Int64(0));
-        when(() => mockSpan.endTime).thenReturn(null);
-
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.getFaroEventAttributes();
-
-        // Assert
-        expect(result['empty'], '');
-        expect(result['null_value'], 'null');
-      });
-
       test('handles single quote correctly', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.keys).thenReturn(['single_quote']);
-        when(() => mockAttributes.get('single_quote')).thenReturn('"');
-        when(() => mockSpan.startTime).thenReturn(Int64(0));
-        when(() => mockSpan.endTime).thenReturn(null);
+        // Empty strings aren't allowed by dartastic Attributes; use a value
+        // that is just a single quote character.
+        final span = makeEndedSpan(
+          'test',
+          attributes: const {'single_quote': '"'},
+        );
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
         final result = spanRecord.getFaroEventAttributes();
 
-        // Assert
         expect(result['single_quote'], '"');
       });
 
-      test('includes duration when start and end times are valid', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.keys).thenReturn(['test.key']);
-        when(() => mockAttributes.get('test.key')).thenReturn('test.value');
-        when(
-          () => mockSpan.startTime,
-        ).thenReturn(Int64(1000000000)); // 1 second in nanoseconds
-        when(
-          () => mockSpan.endTime,
-        ).thenReturn(Int64(2500000000)); // 2.5 seconds in nanoseconds
+      test('includes duration when span has ended', () {
+        final span = makeEndedSpan(
+          'test',
+          attributes: const {'test.key': 'test.value'},
+        );
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
         final result = spanRecord.getFaroEventAttributes();
 
-        // Assert
-        expect(
-          result['duration_ns'],
-          '1500000000',
-        ); // 1.5 seconds in nanoseconds
-        expect(result['test.key'], 'test.value');
-      });
-
-      test('does not include duration when start time is invalid', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.keys).thenReturn(['test.key']);
-        when(() => mockAttributes.get('test.key')).thenReturn('test.value');
-        when(() => mockSpan.startTime).thenReturn(Int64(0));
-        when(() => mockSpan.endTime).thenReturn(Int64(2500000000));
-
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.getFaroEventAttributes();
-
-        // Assert
-        expect(result.containsKey('duration_ns'), false);
-        expect(result['test.key'], 'test.value');
-      });
-
-      test('does not include duration when end time is invalid', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.keys).thenReturn(['test.key']);
-        when(() => mockAttributes.get('test.key')).thenReturn('test.value');
-        when(() => mockSpan.startTime).thenReturn(Int64(1000000000));
-        when(() => mockSpan.endTime).thenReturn(null);
-
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.getFaroEventAttributes();
-
-        // Assert
-        expect(result.containsKey('duration_ns'), false);
-        expect(result['test.key'], 'test.value');
-      });
-
-      test('does not include duration when both times are invalid', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.keys).thenReturn(['test.key']);
-        when(() => mockAttributes.get('test.key')).thenReturn('test.value');
-        when(() => mockSpan.startTime).thenReturn(Int64(0));
-        when(() => mockSpan.endTime).thenReturn(Int64(0));
-
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
-        final result = spanRecord.getFaroEventAttributes();
-
-        // Assert
-        expect(result.containsKey('duration_ns'), false);
+        expect(result.containsKey('duration_ns'), isTrue);
+        final durationNs = int.parse(result['duration_ns']!);
+        expect(durationNs, greaterThanOrEqualTo(0));
         expect(result['test.key'], 'test.value');
       });
 
       test('includes all original attributes plus duration', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.keys).thenReturn(['attr1', 'attr2', 'attr3']);
-        when(() => mockAttributes.get('attr1')).thenReturn('value1');
-        when(() => mockAttributes.get('attr2')).thenReturn(42);
-        when(() => mockAttributes.get('attr3')).thenReturn(true);
-        when(() => mockSpan.startTime).thenReturn(Int64(1000000000));
-        when(() => mockSpan.endTime).thenReturn(Int64(3000000000));
+        final span = makeEndedSpan(
+          'test',
+          attributes: const {
+            'attr1': 'value1',
+            'attr2': 42,
+            'attr3': true,
+          },
+        );
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
         final result = spanRecord.getFaroEventAttributes();
 
-        // Assert
-        expect(result['duration_ns'], '2000000000');
         expect(result['attr1'], 'value1');
         expect(result['attr2'], '42');
         expect(result['attr3'], 'true');
-        expect(result.length, 4); // 3 original attributes + duration
+        expect(result.containsKey('duration_ns'), isTrue);
+        expect(result.length, 4);
       });
 
-      test('does not include duration when end time is before start time', () {
-        // Arrange
-        final mockSpan = MockReadOnlySpan();
-        final mockAttributes = MockAttributes();
-        when(() => mockSpan.attributes).thenReturn(mockAttributes);
-        when(() => mockAttributes.keys).thenReturn(['test.key']);
-        when(() => mockAttributes.get('test.key')).thenReturn('test.value');
-        when(
-          () => mockSpan.startTime,
-        ).thenReturn(Int64(2500000000)); // 2.5 seconds
-        when(
-          () => mockSpan.endTime,
-        ).thenReturn(Int64(1000000000)); // 1 second (before start time)
+      test('does not include duration for an unended span', () {
+        final span = tracer.startSpan(
+          'open',
+          attributes: otel.OTel.attributesFromMap(const {
+            'test.key': 'test.value',
+          }),
+        );
+        // intentionally not ended
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
 
-        final spanRecord = SpanRecord(otelReadOnlySpan: mockSpan);
-
-        // Act
         final result = spanRecord.getFaroEventAttributes();
 
-        // Assert
-        expect(result.containsKey('duration_ns'), false);
+        expect(result.containsKey('duration_ns'), isFalse);
         expect(result['test.key'], 'test.value');
+
+        span.end();
       });
     });
   });

--- a/test/src/models/span_record_test.dart
+++ b/test/src/models/span_record_test.dart
@@ -42,8 +42,9 @@ void main() {
   }) {
     final span = tracer.startSpan(
       name,
-      attributes:
-          attributes.isEmpty ? null : otel.OTel.attributesFromMap(attributes),
+      attributes: attributes.isEmpty
+          ? null
+          : otel.OTel.attributesFromMap(attributes),
     );
     span.end();
     return span;

--- a/test/src/models/span_record_test.dart
+++ b/test/src/models/span_record_test.dart
@@ -112,6 +112,44 @@ void main() {
       });
     });
 
+    group('getSpan:', () {
+      test('omits endTimeUnixNano for an unended span', () {
+        final span = tracer.startSpan('open');
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
+
+        final result = spanRecord.getSpan().toJson();
+
+        expect(result.containsKey('endTimeUnixNano'), isFalse);
+
+        span.end();
+      });
+
+      test('omits empty status description', () {
+        final span = makeEndedSpan('default-status');
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
+
+        final status = spanRecord.getSpan().toJson()['status'];
+
+        expect(status, isA<Map<String, dynamic>>());
+        expect((status as Map<String, dynamic>).containsKey('message'), false);
+      });
+
+      test('keeps non-empty status description', () {
+        final span = tracer.startSpan('error-status');
+        span.setStatus(otel.SpanStatusCode.Error, 'failed deliberately');
+        span.end();
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
+
+        final status = spanRecord.getSpan().toJson()['status'];
+
+        expect(status, isA<Map<String, dynamic>>());
+        expect(
+          (status as Map<String, dynamic>)['message'],
+          'failed deliberately',
+        );
+      });
+    });
+
     group('getFaroEventAttributes:', () {
       test('sanitizes attribute values by removing surrounding quotes', () {
         final span = makeEndedSpan(

--- a/test/src/models/span_record_test.dart
+++ b/test/src/models/span_record_test.dart
@@ -39,20 +39,12 @@ void main() {
   otel.Span makeEndedSpan(
     String name, {
     Map<String, Object> attributes = const {},
-    Duration? duration,
   }) {
     final span = tracer.startSpan(
       name,
       attributes:
           attributes.isEmpty ? null : otel.OTel.attributesFromMap(attributes),
     );
-    if (duration != null) {
-      // Best-effort: real wall-clock duration in test.
-      // We can't deterministically force startTime/endTime, but we ensure
-      // endTime is at least `duration` after startTime via a delay isn't
-      // practical in a unit test; instead, we just end the span and trust
-      // wall-clock has advanced (the span will report a non-zero duration).
-    }
     span.end();
     return span;
   }
@@ -179,6 +171,21 @@ void main() {
         final durationNs = int.parse(result['duration_ns']!);
         expect(durationNs, greaterThanOrEqualTo(0));
         expect(result['test.key'], 'test.value');
+      });
+
+      test('calculates duration from span start and end timestamps', () {
+        final span = makeEndedSpan('test');
+        final spanRecord = SpanRecord(otelReadOnlySpan: span);
+        final endTime = span.endTime;
+        expect(endTime, isNotNull);
+
+        final result = spanRecord.getFaroEventAttributes();
+
+        final expectedDurationNs =
+            (endTime!.microsecondsSinceEpoch -
+                span.startTime.microsecondsSinceEpoch) *
+            1000;
+        expect(result['duration_ns'], expectedDurationNs.toString());
       });
 
       test('includes all original attributes plus duration', () {

--- a/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
+++ b/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
@@ -7,7 +7,6 @@ import 'package:faro/src/models/models.dart';
 import 'package:faro/src/tracing/dart_otel_tracer_resources_factory.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
 
 class MockMeta extends Mock implements Meta {}
 
@@ -44,19 +43,13 @@ void main() {
       mockApp = MockApp();
       mockSession = MockSession();
 
-      // Set up the Faro singleton with mocked meta
       Faro().meta = mockMeta;
     });
 
-    tearDown(() {
-      // No need to reset Faro.instance - tests use the same instance
-    });
-
-    group('getTracerResource', () {
+    group('getTracerResourceAttributes', () {
       test(
         'should create resource with app information when all app data is present',
         () {
-          // Arrange
           when(() => mockMeta.app).thenReturn(mockApp);
           when(() => mockMeta.session).thenReturn(null);
           when(() => mockApp.name).thenReturn('TestApp');
@@ -64,77 +57,29 @@ void main() {
           when(() => mockApp.version).thenReturn('1.2.3');
           when(() => mockApp.namespace).thenReturn('test.namespace');
 
-          // Act
-          final resource = factory.getTracerResource();
+          final attrs = factory.getTracerResourceAttributes();
 
-          // Assert
-          expect(resource, isNotNull);
-          expect(resource.attributes.keys, isNotEmpty);
-
-          expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.serviceName)
-                .toString(),
-            equals('TestApp'),
-          );
-          expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.deploymentEnvironment)
-                .toString(),
-            equals('production'),
-          );
-          expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.serviceVersion)
-                .toString(),
-            equals('1.2.3'),
-          );
-          expect(
-            resource.attributes
-                .get(otel_api.ResourceAttributes.serviceNamespace)
-                .toString(),
-            equals('test.namespace'),
-          );
+          expect(attrs, isNotEmpty);
+          expect(attrs['service.name'], equals('TestApp'));
+          expect(attrs['deployment.environment'], equals('production'));
+          expect(attrs['service.version'], equals('1.2.3'));
+          expect(attrs['service.namespace'], equals('test.namespace'));
         },
       );
 
       test('should use default values when app data is null', () {
-        // Arrange
         when(() => mockMeta.app).thenReturn(null);
         when(() => mockMeta.session).thenReturn(null);
 
-        // Act
-        final resource = factory.getTracerResource();
+        final attrs = factory.getTracerResourceAttributes();
 
-        // Assert
-        expect(
-          resource.attributes
-              .get(otel_api.ResourceAttributes.serviceName)
-              .toString(),
-          equals('unknown'),
-        );
-        expect(
-          resource.attributes
-              .get(otel_api.ResourceAttributes.deploymentEnvironment)
-              .toString(),
-          equals('unknown'),
-        );
-        expect(
-          resource.attributes
-              .get(otel_api.ResourceAttributes.serviceVersion)
-              .toString(),
-          equals('unknown'),
-        );
-        expect(
-          resource.attributes
-              .get(otel_api.ResourceAttributes.serviceNamespace)
-              .toString(),
-          equals('flutter_app'),
-        );
+        expect(attrs['service.name'], equals('unknown'));
+        expect(attrs['deployment.environment'], equals('unknown'));
+        expect(attrs['service.version'], equals('unknown'));
+        expect(attrs['service.namespace'], equals('flutter_app'));
       });
 
       test('should use default values when individual app fields are null', () {
-        // Arrange
         when(() => mockMeta.app).thenReturn(mockApp);
         when(() => mockMeta.session).thenReturn(null);
         when(() => mockApp.name).thenReturn(null);
@@ -142,65 +87,30 @@ void main() {
         when(() => mockApp.version).thenReturn(null);
         when(() => mockApp.namespace).thenReturn(null);
 
-        // Act
-        final resource = factory.getTracerResource();
+        final attrs = factory.getTracerResourceAttributes();
 
-        // Assert
-        expect(
-          resource.attributes
-              .get(otel_api.ResourceAttributes.serviceName)
-              .toString(),
-          equals('unknown'),
-        );
-        expect(
-          resource.attributes
-              .get(otel_api.ResourceAttributes.deploymentEnvironment)
-              .toString(),
-          equals('unknown'),
-        );
-        expect(
-          resource.attributes
-              .get(otel_api.ResourceAttributes.serviceVersion)
-              .toString(),
-          equals('unknown'),
-        );
-        expect(
-          resource.attributes
-              .get(otel_api.ResourceAttributes.serviceNamespace)
-              .toString(),
-          equals('flutter_app'),
-        );
+        expect(attrs['service.name'], equals('unknown'));
+        expect(attrs['deployment.environment'], equals('unknown'));
+        expect(attrs['service.version'], equals('unknown'));
+        expect(attrs['service.namespace'], equals('flutter_app'));
       });
 
       test('should include SDK telemetry attributes', () {
-        // Arrange
         when(() => mockMeta.app).thenReturn(null);
         when(() => mockMeta.session).thenReturn(null);
 
-        // Act
-        final resource = factory.getTracerResource();
+        final attrs = factory.getTracerResourceAttributes();
 
-        // Assert
+        expect(attrs['telemetry.sdk.name'], equals('faro-mobile-flutter'));
+        expect(attrs['telemetry.sdk.language'], equals('dart'));
         expect(
-          resource.attributes.get('telemetry.sdk.name').toString(),
-          equals('faro-mobile-flutter'),
-        );
-        expect(
-          resource.attributes.get('telemetry.sdk.language').toString(),
-          equals('dart'),
-        );
-        expect(
-          resource.attributes.get('telemetry.sdk.version').toString(),
+          attrs['telemetry.sdk.version'],
           equals(_getPackageVersionFromPubspec()),
         );
-        expect(
-          resource.attributes.get('telemetry.sdk.platform').toString(),
-          equals('flutter'),
-        );
+        expect(attrs['telemetry.sdk.platform'], equals('flutter'));
       });
 
       test('should include session attributes when session exists', () {
-        // Arrange
         when(() => mockMeta.app).thenReturn(null);
         when(() => mockMeta.session).thenReturn(mockSession);
         when(() => mockSession.attributes).thenReturn({
@@ -209,40 +119,24 @@ void main() {
           'custom_attr': 'value',
         });
 
-        // Act
-        final resource = factory.getTracerResource();
+        final attrs = factory.getTracerResourceAttributes();
 
-        // Assert
-        expect(
-          resource.attributes.get('session_id').toString(),
-          equals('12345'),
-        );
-        expect(
-          resource.attributes.get('user_id').toString(),
-          equals('user123'),
-        );
-        expect(
-          resource.attributes.get('custom_attr').toString(),
-          equals('value'),
-        );
+        expect(attrs['session_id'], equals('12345'));
+        expect(attrs['user_id'], equals('user123'));
+        expect(attrs['custom_attr'], equals('value'));
       });
 
       test('should handle empty session attributes', () {
-        // Arrange
         when(() => mockMeta.app).thenReturn(null);
         when(() => mockMeta.session).thenReturn(mockSession);
         when(() => mockSession.attributes).thenReturn(<String, dynamic>{});
 
-        // Act
-        final resource = factory.getTracerResource();
+        final attrs = factory.getTracerResourceAttributes();
 
-        // Assert - should not throw and should still include other attributes
-        expect(resource, isNotNull);
-        expect(resource.attributes.keys, isNotEmpty);
+        expect(attrs, isNotEmpty);
       });
 
       test('should preserve typed session attributes', () {
-        // Arrange
         when(() => mockMeta.app).thenReturn(null);
         when(() => mockMeta.session).thenReturn(mockSession);
         when(() => mockSession.attributes).thenReturn({
@@ -254,47 +148,35 @@ void main() {
           'object': {'nested': 'value'},
         });
 
-        // Act
-        final resource = factory.getTracerResource();
+        final attrs = factory.getTracerResourceAttributes();
 
-        // Assert - typed values are preserved, not stringified
-        final stringAttr = resource.attributes.get('string_value');
-        expect(stringAttr, isNotNull);
-        expect(stringAttr.toString(), equals('hello'));
+        expect(attrs['string_value'], equals('hello'));
+        expect(attrs['string_value'], isA<String>());
 
-        final intAttr = resource.attributes.get('int_value');
-        expect(intAttr, isNotNull);
-        expect(intAttr.toString(), equals('42'));
+        expect(attrs['int_value'], equals(42));
+        expect(attrs['int_value'], isA<int>());
 
-        final doubleAttr = resource.attributes.get('double_value');
-        expect(doubleAttr, isNotNull);
-        expect(doubleAttr.toString(), equals('3.14'));
+        expect(attrs['double_value'], equals(3.14));
+        expect(attrs['double_value'], isA<double>());
 
-        final boolAttr = resource.attributes.get('bool_value');
-        expect(boolAttr, isNotNull);
-        expect(boolAttr.toString(), equals('true'));
+        expect(attrs['bool_value'], equals(true));
+        expect(attrs['bool_value'], isA<bool>());
 
-        // Null and object values fall back to string representation
-        expect(resource.attributes.get('null_value').toString(), equals(''));
-        expect(
-          resource.attributes.get('object').toString(),
-          equals('{nested: value}'),
-        );
+        // Null is skipped entirely.
+        expect(attrs.containsKey('null_value'), isFalse);
+
+        // Non-primitive falls back to string representation.
+        expect(attrs['object'], equals('{nested: value}'));
       });
 
       test('should handle null session', () {
-        // Arrange
         when(() => mockMeta.app).thenReturn(null);
         when(() => mockMeta.session).thenReturn(null);
 
-        // Act
-        final resource = factory.getTracerResource();
+        final attrs = factory.getTracerResourceAttributes();
 
-        // Assert - should not throw and should still include other attributes
-        expect(resource, isNotNull);
-        expect(resource.attributes.keys, isNotEmpty);
-        // Should not have any session attributes
-        expect(resource.attributes.get('session_id'), isNull);
+        expect(attrs, isNotEmpty);
+        expect(attrs.containsKey('session_id'), isFalse);
       });
     });
   });

--- a/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
+++ b/test/src/tracing/dart_otel_tracer_resources_factory_test.dart
@@ -95,6 +95,25 @@ void main() {
         expect(attrs['service.namespace'], equals('flutter_app'));
       });
 
+      test(
+        'should use default values when individual app fields are empty',
+        () {
+          when(() => mockMeta.app).thenReturn(mockApp);
+          when(() => mockMeta.session).thenReturn(null);
+          when(() => mockApp.name).thenReturn('');
+          when(() => mockApp.environment).thenReturn('');
+          when(() => mockApp.version).thenReturn('');
+          when(() => mockApp.namespace).thenReturn('');
+
+          final attrs = factory.getTracerResourceAttributes();
+
+          expect(attrs['service.name'], equals('unknown'));
+          expect(attrs['deployment.environment'], equals('unknown'));
+          expect(attrs['service.version'], equals('unknown'));
+          expect(attrs['service.namespace'], equals('flutter_app'));
+        },
+      );
+
       test('should include SDK telemetry attributes', () {
         when(() => mockMeta.app).thenReturn(null);
         when(() => mockMeta.session).thenReturn(null);

--- a/test/src/tracing/extensions_test.dart
+++ b/test/src/tracing/extensions_test.dart
@@ -1,12 +1,12 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/tracing/extensions.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
 
 void main() {
   group('IterableTraceAttributeX:', () {
     group('toTraceAttributes:', () {
       test('should preserve string attribute value', () {
-        final attributes = [otel_api.Attribute.fromString('name', 'test')];
+        final attributes = [otel.OTelAPI.attributeString('name', 'test')];
 
         final result = attributes.toTraceAttributes();
 
@@ -17,7 +17,7 @@ void main() {
       });
 
       test('should preserve int attribute value', () {
-        final attributes = [otel_api.Attribute.fromInt('count', 42)];
+        final attributes = [otel.OTelAPI.attributeInt('count', 42)];
 
         final result = attributes.toTraceAttributes();
 
@@ -28,7 +28,7 @@ void main() {
       });
 
       test('should preserve double attribute value', () {
-        final attributes = [otel_api.Attribute.fromDouble('duration', 3.14)];
+        final attributes = [otel.OTelAPI.attributeDouble('duration', 3.14)];
 
         final result = attributes.toTraceAttributes();
 
@@ -39,7 +39,7 @@ void main() {
       });
 
       test('should preserve bool attribute value', () {
-        final attributes = [otel_api.Attribute.fromBoolean('enabled', true)];
+        final attributes = [otel.OTelAPI.attributeBool('enabled', true)];
 
         final result = attributes.toTraceAttributes();
 
@@ -50,11 +50,11 @@ void main() {
       });
 
       test('should preserve mixed attribute types', () {
-        final attributes = [
-          otel_api.Attribute.fromString('name', 'test'),
-          otel_api.Attribute.fromInt('count', 100),
-          otel_api.Attribute.fromDouble('score', 99.5),
-          otel_api.Attribute.fromBoolean('active', false),
+        final attributes = <otel.Attribute<Object>>[
+          otel.OTelAPI.attributeString('name', 'test'),
+          otel.OTelAPI.attributeInt('count', 100),
+          otel.OTelAPI.attributeDouble('score', 99.5),
+          otel.OTelAPI.attributeBool('active', false),
         ];
 
         final result = attributes.toTraceAttributes();
@@ -79,7 +79,7 @@ void main() {
       });
 
       test('should handle negative int values', () {
-        final attributes = [otel_api.Attribute.fromInt('offset', -10)];
+        final attributes = [otel.OTelAPI.attributeInt('offset', -10)];
 
         final result = attributes.toTraceAttributes();
 
@@ -88,10 +88,10 @@ void main() {
       });
 
       test('should handle zero values', () {
-        final attributes = [
-          otel_api.Attribute.fromInt('zero_int', 0),
+        final attributes = <otel.Attribute<Object>>[
+          otel.OTelAPI.attributeInt('zero_int', 0),
           // ignore: prefer_int_literals
-          otel_api.Attribute.fromDouble('zero_double', 0.0),
+          otel.OTelAPI.attributeDouble('zero_double', 0.0),
         ];
 
         final result = attributes.toTraceAttributes();
@@ -101,7 +101,7 @@ void main() {
       });
 
       test('should handle empty list', () {
-        final attributes = <otel_api.Attribute>[];
+        final attributes = <otel.Attribute<Object>>[];
 
         final result = attributes.toTraceAttributes();
 
@@ -111,8 +111,8 @@ void main() {
       test('should convert list values to string (unsupported in OTLP)', () {
         // List values are not directly supported in our TraceAttributeValue
         // They should be converted to string representation
-        final attributes = [
-          otel_api.Attribute.fromStringList('tags', ['a', 'b', 'c']),
+        final attributes = <otel.Attribute<Object>>[
+          otel.OTelAPI.attributeStringList('tags', ['a', 'b', 'c']),
         ];
 
         final result = attributes.toTraceAttributes();

--- a/test/src/tracing/faro_exporter_test.dart
+++ b/test/src/tracing/faro_exporter_test.dart
@@ -1,100 +1,76 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/models/models.dart';
 import 'package:faro/src/tracing/faro_exporter.dart';
 import 'package:faro/src/user_actions/telemetry_router.dart';
 import 'package:faro/src/user_actions/user_action_types.dart';
-import 'package:fixnum/fixnum.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
 class MockTelemetryRouter extends Mock implements TelemetryRouter {}
 
-class FakeReadOnlySpan extends Fake implements otel_sdk.ReadOnlySpan {
-  FakeReadOnlySpan({
-    required this.name,
-    required this.attributes,
-    this.kind = otel_api.SpanKind.client,
-  });
-
+class _NoOpProcessor implements otel.SpanProcessor {
   @override
-  final String name;
-
+  Future<void> onStart(otel.Span span, otel.Context? parentContext) async {}
   @override
-  final otel_sdk.Attributes attributes;
-
+  Future<void> onEnd(otel.Span span) async {}
   @override
-  final otel_api.SpanKind kind;
-
+  Future<void> onNameUpdate(otel.Span span, String newName) async {}
   @override
-  otel_api.SpanContext get spanContext => otel_api.SpanContext(
-    otel_api.TraceId.fromString('00000000000000000000000000000001'),
-    otel_api.SpanId.fromString('0000000000000001'),
-    otel_api.TraceFlags.sampled,
-    otel_api.TraceState.empty(),
-  );
-
+  Future<void> shutdown() async {}
   @override
-  otel_api.SpanId get parentSpanId => otel_api.SpanId.invalid();
-
-  @override
-  Int64 get startTime => Int64(1000000);
-
-  @override
-  Int64? get endTime => Int64(2000000);
-
-  @override
-  otel_api.SpanStatus get status =>
-      otel_api.SpanStatus()..code = otel_api.StatusCode.ok;
-
-  @override
-  List<otel_api.SpanEvent> get events => [];
-
-  @override
-  int get droppedEventsCount => 0;
-
-  @override
-  List<otel_api.SpanLink> get links => [];
-
-  @override
-  otel_sdk.InstrumentationScope get instrumentationScope =>
-      otel_sdk.InstrumentationScope('test', 'test', '', []);
-
-  @override
-  otel_sdk.Resource get resource => otel_sdk.Resource([]);
+  Future<void> forceFlush() async {}
 }
 
 void main() {
   late MockTelemetryRouter mockRouter;
+  late otel.Tracer tracer;
 
-  setUpAll(() {
+  setUpAll(() async {
+    await otel.OTel.initialize(
+      serviceName: 'test-service',
+      spanProcessor: _NoOpProcessor(),
+      detectPlatformResources: false,
+      enableMetrics: false,
+      enableLogs: false,
+    );
+    tracer = otel.OTel.tracer();
     registerFallbackValue(TelemetryItem.fromEvent(Event('fallback')));
     registerFallbackValue(false);
+  });
+
+  tearDownAll(() async {
+    // ignore: invalid_use_of_visible_for_testing_member
+    await otel.OTel.reset();
   });
 
   setUp(() {
     mockRouter = MockTelemetryRouter();
   });
 
+  otel.Span makeSpan(String name, Map<String, Object> attributes) {
+    final span = tracer.startSpan(
+      name,
+      kind: otel.SpanKind.client,
+      attributes: otel.OTel.attributesFromMap(attributes),
+    );
+    span.end();
+    return span;
+  }
+
   group('FaroExporter:', () {
     group('user action attribute mapping:', () {
       test('should set Event.action and strip attributes '
           'when both faro.action.user.name and faro.action.user.parentId '
-          'are present', () {
-        final attrs = otel_sdk.Attributes.empty();
-        attrs.add(otel_api.Attribute.fromString('http.method', 'GET'));
-        attrs.add(otel_api.Attribute.fromString('http.scheme', 'https'));
-        attrs.add(
-          otel_api.Attribute.fromString('faro.action.user.name', 'checkout'),
-        );
-        attrs.add(
-          otel_api.Attribute.fromString('faro.action.user.parentId', 'abc123'),
-        );
-
-        final span = FakeReadOnlySpan(name: 'HTTP GET', attributes: attrs);
+          'are present', () async {
+        final span = makeSpan('HTTP GET', {
+          'http.method': 'GET',
+          'http.scheme': 'https',
+          'faro.action.user.name': 'checkout',
+          'faro.action.user.parentId': 'abc123',
+        });
 
         final exporter = FaroExporter(telemetryRouter: mockRouter);
-        exporter.export([span]);
+        await exporter.export([span]);
 
         final captured =
             verify(
@@ -104,7 +80,6 @@ void main() {
               ),
             ).captured;
 
-        // captureAny captures positional args only
         expect(captured, hasLength(2));
 
         final eventItem = captured[0] as TelemetryItem;
@@ -126,17 +101,14 @@ void main() {
       });
 
       test('should NOT set Event.action when only faro.action.user.name '
-          'is present (missing parentId)', () {
-        final attrs = otel_sdk.Attributes.empty();
-        attrs.add(otel_api.Attribute.fromString('http.method', 'GET'));
-        attrs.add(
-          otel_api.Attribute.fromString('faro.action.user.name', 'checkout'),
-        );
-
-        final span = FakeReadOnlySpan(name: 'HTTP GET', attributes: attrs);
+          'is present (missing parentId)', () async {
+        final span = makeSpan('HTTP GET', {
+          'http.method': 'GET',
+          'faro.action.user.name': 'checkout',
+        });
 
         final exporter = FaroExporter(telemetryRouter: mockRouter);
-        exporter.export([span]);
+        await exporter.export([span]);
 
         final captured =
             verify(
@@ -153,14 +125,11 @@ void main() {
       });
 
       test('should NOT set Event.action when no action attributes '
-          'are present', () {
-        final attrs = otel_sdk.Attributes.empty();
-        attrs.add(otel_api.Attribute.fromString('http.method', 'POST'));
-
-        final span = FakeReadOnlySpan(name: 'HTTP POST', attributes: attrs);
+          'are present', () async {
+        final span = makeSpan('HTTP POST', {'http.method': 'POST'});
 
         final exporter = FaroExporter(telemetryRouter: mockRouter);
-        exporter.export([span]);
+        await exporter.export([span]);
 
         final captured =
             verify(
@@ -177,20 +146,16 @@ void main() {
     });
 
     group('telemetry routing:', () {
-      test('should ingest span-derived event with skipBuffer: true', () {
-        final attrs = otel_sdk.Attributes.empty();
-        attrs.add(otel_api.Attribute.fromString('http.method', 'GET'));
-        attrs.add(otel_api.Attribute.fromString('http.scheme', 'https'));
-
-        final span = FakeReadOnlySpan(name: 'HTTP GET', attributes: attrs);
+      test('should ingest span-derived event with skipBuffer: true', () async {
+        final span = makeSpan('HTTP GET', {
+          'http.method': 'GET',
+          'http.scheme': 'https',
+        });
 
         final exporter = FaroExporter(telemetryRouter: mockRouter);
-        exporter.export([span]);
+        await exporter.export([span]);
 
-        // Event should be ingested with skipBuffer: true
         verify(() => mockRouter.ingest(any(), skipBuffer: true)).called(1);
-
-        // Span should be ingested with default skipBuffer (false)
         verify(() => mockRouter.ingest(any())).called(1);
       });
     });

--- a/test/src/tracing/faro_exporter_test.dart
+++ b/test/src/tracing/faro_exporter_test.dart
@@ -72,13 +72,12 @@ void main() {
         final exporter = FaroExporter(telemetryRouter: mockRouter);
         await exporter.export([span]);
 
-        final captured =
-            verify(
-              () => mockRouter.ingest(
-                captureAny(),
-                skipBuffer: any(named: 'skipBuffer'),
-              ),
-            ).captured;
+        final captured = verify(
+          () => mockRouter.ingest(
+            captureAny(),
+            skipBuffer: any(named: 'skipBuffer'),
+          ),
+        ).captured;
 
         expect(captured, hasLength(2));
 
@@ -110,13 +109,12 @@ void main() {
         final exporter = FaroExporter(telemetryRouter: mockRouter);
         await exporter.export([span]);
 
-        final captured =
-            verify(
-              () => mockRouter.ingest(
-                captureAny(),
-                skipBuffer: any(named: 'skipBuffer'),
-              ),
-            ).captured;
+        final captured = verify(
+          () => mockRouter.ingest(
+            captureAny(),
+            skipBuffer: any(named: 'skipBuffer'),
+          ),
+        ).captured;
 
         final eventItem = captured[0] as TelemetryItem;
         final event = eventItem.asEvent!;
@@ -131,13 +129,12 @@ void main() {
         final exporter = FaroExporter(telemetryRouter: mockRouter);
         await exporter.export([span]);
 
-        final captured =
-            verify(
-              () => mockRouter.ingest(
-                captureAny(),
-                skipBuffer: any(named: 'skipBuffer'),
-              ),
-            ).captured;
+        final captured = verify(
+          () => mockRouter.ingest(
+            captureAny(),
+            skipBuffer: any(named: 'skipBuffer'),
+          ),
+        ).captured;
 
         final eventItem = captured[0] as TelemetryItem;
         final event = eventItem.asEvent!;

--- a/test/src/tracing/faro_otel_bootstrap_test.dart
+++ b/test/src/tracing/faro_otel_bootstrap_test.dart
@@ -1,0 +1,101 @@
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
+import 'package:faro/src/core/pod.dart';
+import 'package:faro/src/models/models.dart';
+import 'package:faro/src/tracing/faro_otel_bootstrap.dart';
+import 'package:faro/src/tracing/faro_tracer.dart';
+import 'package:faro/src/tracing/faro_user_action_span_processor.dart';
+import 'package:faro/src/user_actions/telemetry_router.dart';
+import 'package:faro/src/user_actions/user_action_types.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _RecordingRouter implements TelemetryRouter {
+  final List<TelemetryItem> ingested = [];
+
+  @override
+  void ingest(TelemetryItem item, {bool skipBuffer = false}) {
+    ingested.add(item);
+  }
+}
+
+void main() {
+  late _RecordingRouter router;
+
+  setUpAll(() {
+    registerFallbackValue(TelemetryItem.fromEvent(Event('fallback')));
+  });
+
+  setUp(() {
+    router = _RecordingRouter();
+    pod.overrideProvider<TelemetryRouter>(
+      telemetryRouterProvider,
+      (_) => router,
+    );
+    // Bounce the cached span processor so each test gets a fresh exporter.
+    pod.overrideProvider<otel.SpanProcessor>(
+      faroSpanProcessorProvider,
+      (_) => throw StateError('placeholder'),
+    );
+    pod.removeOverride(faroSpanProcessorProvider);
+  });
+
+  tearDown(() async {
+    await FaroOtelBootstrap.resetForTesting();
+    pod.removeOverride(telemetryRouterProvider);
+  });
+
+  group('FaroOtelBootstrap:', () {
+    test('initialize is idempotent — second call is a no-op that does not '
+        'hang and leaves a working tracer', () async {
+      // Regression test: the original implementation called OTel.reset()
+      // followed by OTel.initialize() on every subsequent call, which hung
+      // under Flutter's fake-async test environment when the bootstrap was
+      // re-invoked between testWidgets test cases.
+      await FaroOtelBootstrap.initialize();
+      // Second call must complete promptly without resetting OTel.
+      await FaroOtelBootstrap.initialize().timeout(const Duration(seconds: 5));
+
+      final tracer = FaroTracerFactory().create();
+      final span = tracer.startSpanManual('after-double-init');
+      span.end();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        router.ingested.any((i) => i.type == TelemetryItemType.span),
+        isTrue,
+        reason: 'second initialize() should leave a working tracer pipeline',
+      );
+    });
+
+    test('resetForTesting tears down the OTel SDK so a subsequent '
+        'initialize re-creates the pipeline cleanly', () async {
+      await FaroOtelBootstrap.initialize();
+      await FaroOtelBootstrap.resetForTesting();
+
+      // setUp re-installs the recording router; force a fresh span processor.
+      router.ingested.clear();
+      pod.overrideProvider<TelemetryRouter>(
+        telemetryRouterProvider,
+        (_) => router,
+      );
+      pod.overrideProvider<otel.SpanProcessor>(
+        faroSpanProcessorProvider,
+        (_) => throw StateError('placeholder'),
+      );
+      pod.removeOverride(faroSpanProcessorProvider);
+
+      await FaroOtelBootstrap.initialize();
+      final tracer = FaroTracerFactory().create();
+      final span = tracer.startSpanManual('after-reset');
+      span.end();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        router.ingested.any((i) => i.type == TelemetryItemType.span),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/src/tracing/faro_tracer_test.dart
+++ b/test/src/tracing/faro_tracer_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: lines_longer_than_80_chars
 
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/session/session_id_provider.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
 import 'package:faro/src/tracing/faro_zone_span_manager.dart';
@@ -7,70 +8,108 @@ import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/tracing/span_exception_options.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
 
-class MockOtelTracer extends Mock implements otel_api.Tracer {}
+class MockOtelTracer extends Mock implements otel.Tracer {}
 
 class MockFaroZoneSpanManager extends Mock implements FaroZoneSpanManager {}
 
 class MockSessionIdProvider extends Mock implements SessionIdProvider {}
 
-class MockOtelSpan extends Mock implements otel_api.Span {}
+class MockApiSpan extends Mock implements otel.Span {}
 
 class MockSpan extends Mock implements Span {}
 
-class FakeOtelContext extends Fake implements otel_api.Context {}
+class FakeOtelContext extends Fake implements otel.Context {}
 
 class FakeSpan extends Fake implements Span {}
 
+class FakeAttributes extends Fake implements otel.Attributes {}
+
+class _NoOpProcessor implements otel.SpanProcessor {
+  @override
+  Future<void> onStart(otel.Span span, otel.Context? parentContext) async {}
+  @override
+  Future<void> onEnd(otel.Span span) async {}
+  @override
+  Future<void> onNameUpdate(otel.Span span, String newName) async {}
+  @override
+  Future<void> shutdown() async {}
+  @override
+  Future<void> forceFlush() async {}
+}
+
 void main() {
-  setUpAll(() {
-    // Register fallback values for mocktail
+  setUpAll(() async {
+    await otel.OTel.initialize(
+      serviceName: 'test-service',
+      spanProcessor: _NoOpProcessor(),
+      detectPlatformResources: false,
+      enableMetrics: false,
+      enableLogs: false,
+    );
+
     registerFallbackValue(FakeOtelContext());
-    registerFallbackValue(otel_api.SpanKind.client);
+    registerFallbackValue(otel.SpanKind.client);
     registerFallbackValue(FakeSpan());
     registerFallbackValue(ContextScope.callback);
+    registerFallbackValue(FakeAttributes());
   });
+
+  tearDownAll(() async {
+    // ignore: invalid_use_of_visible_for_testing_member
+    await otel.OTel.reset();
+  });
+
   group('FaroTracer:', () {
     late FaroTracer faroTracer;
     late MockOtelTracer mockOtelTracer;
     late MockFaroZoneSpanManager mockFaroZoneSpanManager;
     late MockSessionIdProvider mockSessionIdProvider;
-    late MockOtelSpan mockOtelSpan;
+    late MockApiSpan mockOtelSpan;
 
     setUp(() {
       mockOtelTracer = MockOtelTracer();
       mockFaroZoneSpanManager = MockFaroZoneSpanManager();
       mockSessionIdProvider = MockSessionIdProvider();
-      mockOtelSpan = MockOtelSpan();
+      mockOtelSpan = MockApiSpan();
 
-      // Create FaroTracer with public constructor
       faroTracer = FaroTracer(
         otelTracer: mockOtelTracer,
         faroZoneSpanManager: mockFaroZoneSpanManager,
         sessionIdProvider: mockSessionIdProvider,
       );
 
-      // Set up default mock behaviors
       when(() => mockSessionIdProvider.sessionId).thenReturn('test-session-id');
     });
 
+    Map<String, Object> capturedAttributesAsMap(otel.Attributes attrs) {
+      return {
+        for (final attr in attrs.toList()) attr.key: attr.value,
+      };
+    }
+
+    void stubStartSpan() {
+      when(
+        () => mockOtelTracer.startSpan(
+          any(),
+          context: any(named: 'context'),
+          spanContext: any(named: 'spanContext'),
+          parentSpan: any(named: 'parentSpan'),
+          kind: any(named: 'kind'),
+          attributes: any(named: 'attributes'),
+          links: any(named: 'links'),
+          isRecording: any(named: 'isRecording'),
+        ),
+      ).thenReturn(mockOtelSpan);
+    }
+
     group('startSpan:', () {
       test('should create span with correct name and execute body', () async {
-        // Arrange
         const spanName = 'test-span';
         var bodyExecuted = false;
         Span? receivedSpan;
 
-        when(
-          () => mockOtelTracer.startSpan(
-            any(),
-            context: any(named: 'context'),
-            kind: any(named: 'kind'),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenReturn(mockOtelSpan);
-
+        stubStartSpan();
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
         when(
           () => mockFaroZoneSpanManager.executeWithSpan<String>(
@@ -85,14 +124,12 @@ void main() {
           return await body(span);
         });
 
-        // Act
         final result = await faroTracer.startSpan<String>(spanName, (span) {
           bodyExecuted = true;
           receivedSpan = span;
           return 'test-result';
         });
 
-        // Assert
         expect(result, equals('test-result'));
         expect(bodyExecuted, isTrue);
         expect(receivedSpan, isA<InternalSpan>());
@@ -101,7 +138,7 @@ void main() {
           () => mockOtelTracer.startSpan(
             spanName,
             context: any(named: 'context'),
-            kind: otel_api.SpanKind.client,
+            kind: otel.SpanKind.client,
             attributes: any(named: 'attributes'),
           ),
         ).called(1);
@@ -116,19 +153,11 @@ void main() {
       });
 
       test('should set session attributes on span', () async {
-        // Arrange
         const spanName = 'test-span';
         const sessionId = 'session-123';
 
         when(() => mockSessionIdProvider.sessionId).thenReturn(sessionId);
-        when(
-          () => mockOtelTracer.startSpan(
-            any(),
-            context: any(named: 'context'),
-            kind: any(named: 'kind'),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenReturn(mockOtelSpan);
+        stubStartSpan();
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
         when(
           () => mockFaroZoneSpanManager.executeWithSpan<String>(
@@ -143,23 +172,18 @@ void main() {
           return await body(span);
         });
 
-        // Act
         await faroTracer.startSpan<String>(spanName, (span) => 'result');
 
-        // Assert
-        final captured =
-            verify(
-              () => mockOtelTracer.startSpan(
-                spanName,
-                context: any(named: 'context'),
-                kind: otel_api.SpanKind.client,
-                attributes: captureAny(named: 'attributes'),
-              ),
-            ).captured;
-        final attributes = captured.single as List<otel_api.Attribute>;
-        final attributeMap = <String, String>{
-          for (final attr in attributes) attr.key: attr.value.toString(),
-        };
+        final captured = verify(
+          () => mockOtelTracer.startSpan(
+            spanName,
+            context: any(named: 'context'),
+            kind: otel.SpanKind.client,
+            attributes: captureAny(named: 'attributes'),
+          ),
+        ).captured;
+        final attrs = captured.single as otel.Attributes;
+        final attributeMap = capturedAttributesAsMap(attrs);
         expect(attributeMap['session_id'], sessionId);
         expect(attributeMap['session.id'], sessionId);
       });
@@ -167,21 +191,13 @@ void main() {
       test(
         'should include custom attributes along with session attributes',
         () async {
-          // Arrange
           const spanName = 'test-span';
           const customAttributes = {
             'custom.key1': 'value1',
             'custom.key2': 'value2',
           };
 
-          when(
-            () => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            ),
-          ).thenReturn(mockOtelSpan);
+          stubStartSpan();
           when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
           when(
             () => mockFaroZoneSpanManager.executeWithSpan<String>(
@@ -196,27 +212,22 @@ void main() {
             return await body(span);
           });
 
-          // Act
           await faroTracer.startSpan<String>(
             spanName,
             (span) => 'result',
             attributes: customAttributes,
           );
 
-          // Assert
-          final captured =
-              verify(
-                () => mockOtelTracer.startSpan(
-                  spanName,
-                  context: any(named: 'context'),
-                  kind: otel_api.SpanKind.client,
-                  attributes: captureAny(named: 'attributes'),
-                ),
-              ).captured;
-          final attributes = captured.single as List<otel_api.Attribute>;
-          final attributeMap = <String, String>{
-            for (final attr in attributes) attr.key: attr.value.toString(),
-          };
+          final captured = verify(
+            () => mockOtelTracer.startSpan(
+              spanName,
+              context: any(named: 'context'),
+              kind: otel.SpanKind.client,
+              attributes: captureAny(named: 'attributes'),
+            ),
+          ).captured;
+          final attrs = captured.single as otel.Attributes;
+          final attributeMap = capturedAttributesAsMap(attrs);
           expect(attributeMap['custom.key1'], 'value1');
           expect(attributeMap['custom.key2'], 'value2');
           expect(attributeMap['session_id'], 'test-session-id');
@@ -225,18 +236,10 @@ void main() {
       );
 
       test('should thread exceptionOptions to executeWithSpan', () async {
-        // Arrange
         const spanName = 'test-span';
         const options = SpanExceptionOptions(recordException: false);
 
-        when(
-          () => mockOtelTracer.startSpan(
-            any(),
-            context: any(named: 'context'),
-            kind: any(named: 'kind'),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenReturn(mockOtelSpan);
+        stubStartSpan();
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
         when(
           () => mockFaroZoneSpanManager.executeWithSpan<String>(
@@ -251,14 +254,12 @@ void main() {
           return await body(span);
         });
 
-        // Act
         await faroTracer.startSpan<String>(
           spanName,
           (span) => 'result',
           exceptionOptions: options,
         );
 
-        // Assert
         verify(
           () => mockFaroZoneSpanManager.executeWithSpan<String>(
             any(),
@@ -270,17 +271,9 @@ void main() {
       });
 
       test('should pass null exceptionOptions by default', () async {
-        // Arrange
         const spanName = 'test-span';
 
-        when(
-          () => mockOtelTracer.startSpan(
-            any(),
-            context: any(named: 'context'),
-            kind: any(named: 'kind'),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenReturn(mockOtelSpan);
+        stubStartSpan();
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
         when(
           () => mockFaroZoneSpanManager.executeWithSpan<String>(
@@ -295,90 +288,63 @@ void main() {
           return await body(span);
         });
 
-        // Act
         await faroTracer.startSpan<String>(spanName, (span) => 'result');
 
-        // Assert
-        final captured =
-            verify(
-              () => mockFaroZoneSpanManager.executeWithSpan<String>(
-                any(),
-                any(),
-                contextScope: any(named: 'contextScope'),
-                exceptionOptions: captureAny(named: 'exceptionOptions'),
-              ),
-            ).captured;
+        final captured = verify(
+          () => mockFaroZoneSpanManager.executeWithSpan<String>(
+            any(),
+            any(),
+            contextScope: any(named: 'contextScope'),
+            exceptionOptions: captureAny(named: 'exceptionOptions'),
+          ),
+        ).captured;
         expect(captured.single, isNull);
       });
     });
 
     group('startSpanManual:', () {
       test('should create and return span without executing body', () {
-        // Arrange
         const spanName = 'manual-span';
 
-        when(
-          () => mockOtelTracer.startSpan(
-            any(),
-            context: any(named: 'context'),
-            kind: any(named: 'kind'),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenReturn(mockOtelSpan);
+        stubStartSpan();
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
 
-        // Act
         final result = faroTracer.startSpanManual(spanName);
 
-        // Assert
         expect(result, isA<InternalSpan>());
         verify(
           () => mockOtelTracer.startSpan(
             spanName,
             context: any(named: 'context'),
-            kind: otel_api.SpanKind.client,
+            kind: otel.SpanKind.client,
             attributes: any(named: 'attributes'),
           ),
         ).called(1);
 
-        // Verify executeWithSpan is NOT called for manual spans
         verifyNever(
           () => mockFaroZoneSpanManager.executeWithSpan<dynamic>(any(), any()),
         );
       });
 
       test('should set attributes on manual span', () {
-        // Arrange
         const spanName = 'manual-span';
         const customAttributes = {'manual.key': 'manual.value'};
 
-        when(
-          () => mockOtelTracer.startSpan(
-            any(),
-            context: any(named: 'context'),
-            kind: any(named: 'kind'),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenReturn(mockOtelSpan);
+        stubStartSpan();
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
 
-        // Act
         faroTracer.startSpanManual(spanName, attributes: customAttributes);
 
-        // Assert
-        final captured =
-            verify(
-              () => mockOtelTracer.startSpan(
-                spanName,
-                context: any(named: 'context'),
-                kind: otel_api.SpanKind.client,
-                attributes: captureAny(named: 'attributes'),
-              ),
-            ).captured;
-        final attributes = captured.single as List<otel_api.Attribute>;
-        final attributeMap = <String, String>{
-          for (final attr in attributes) attr.key: attr.value.toString(),
-        };
+        final captured = verify(
+          () => mockOtelTracer.startSpan(
+            spanName,
+            context: any(named: 'context'),
+            kind: otel.SpanKind.client,
+            attributes: captureAny(named: 'attributes'),
+          ),
+        ).captured;
+        final attrs = captured.single as otel.Attributes;
+        final attributeMap = capturedAttributesAsMap(attrs);
         expect(attributeMap['manual.key'], 'manual.value');
         expect(attributeMap['session_id'], 'test-session-id');
         expect(attributeMap['session.id'], 'test-session-id');
@@ -387,28 +353,22 @@ void main() {
 
     group('getActiveSpan:', () {
       test('should return active span from zone span manager', () {
-        // Arrange
         final mockActiveSpan = MockSpan();
         when(
           () => mockFaroZoneSpanManager.getActiveSpan(),
         ).thenReturn(mockActiveSpan);
 
-        // Act
         final result = faroTracer.getActiveSpan();
 
-        // Assert
         expect(result, equals(mockActiveSpan));
         verify(() => mockFaroZoneSpanManager.getActiveSpan()).called(1);
       });
 
       test('should return null when no active span', () {
-        // Arrange
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
 
-        // Act
         final result = faroTracer.getActiveSpan();
 
-        // Assert
         expect(result, isNull);
         verify(() => mockFaroZoneSpanManager.getActiveSpan()).called(1);
       });
@@ -418,38 +378,25 @@ void main() {
       test(
         'should always include both session_id and session.id attributes',
         () {
-          // Arrange
           const spanName = 'session-test';
           const sessionId = 'unique-session-xyz';
 
           when(() => mockSessionIdProvider.sessionId).thenReturn(sessionId);
-          when(
-            () => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            ),
-          ).thenReturn(mockOtelSpan);
+          stubStartSpan();
           when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
 
-          // Act
           faroTracer.startSpanManual(spanName);
 
-          // Assert
-          final captured =
-              verify(
-                () => mockOtelTracer.startSpan(
-                  spanName,
-                  context: any(named: 'context'),
-                  kind: otel_api.SpanKind.client,
-                  attributes: captureAny(named: 'attributes'),
-                ),
-              ).captured;
-          final attributes = captured.single as List<otel_api.Attribute>;
-          final attributeMap = <String, String>{
-            for (final attr in attributes) attr.key: attr.value.toString(),
-          };
+          final captured = verify(
+            () => mockOtelTracer.startSpan(
+              spanName,
+              context: any(named: 'context'),
+              kind: otel.SpanKind.client,
+              attributes: captureAny(named: 'attributes'),
+            ),
+          ).captured;
+          final attrs = captured.single as otel.Attributes;
+          final attributeMap = capturedAttributesAsMap(attrs);
           expect(attributeMap['session_id'], sessionId);
           expect(attributeMap['session.id'], sessionId);
         },
@@ -458,21 +405,10 @@ void main() {
 
     group('contextScope:', () {
       test('should pass ContextScope.callback by default', () async {
-        // Arrange
         const spanName = 'scoped-span';
         ContextScope? capturedScope;
 
-        when(
-          () => mockSessionIdProvider.sessionId,
-        ).thenReturn('test-session-id');
-        when(
-          () => mockOtelTracer.startSpan(
-            any(),
-            context: any(named: 'context'),
-            kind: any(named: 'kind'),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenReturn(mockOtelSpan);
+        stubStartSpan();
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
         when(
           () => mockFaroZoneSpanManager.executeWithSpan<String>(
@@ -489,29 +425,16 @@ void main() {
           return await body(span);
         });
 
-        // Act
         await faroTracer.startSpan<String>(spanName, (span) => 'result');
 
-        // Assert
         expect(capturedScope, equals(ContextScope.callback));
       });
 
       test('should pass ContextScope.zone when specified', () async {
-        // Arrange
         const spanName = 'zone-scoped-span';
         ContextScope? capturedScope;
 
-        when(
-          () => mockSessionIdProvider.sessionId,
-        ).thenReturn('test-session-id');
-        when(
-          () => mockOtelTracer.startSpan(
-            any(),
-            context: any(named: 'context'),
-            kind: any(named: 'kind'),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenReturn(mockOtelSpan);
+        stubStartSpan();
         when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
         when(
           () => mockFaroZoneSpanManager.executeWithSpan<String>(
@@ -528,52 +451,35 @@ void main() {
           return await body(span);
         });
 
-        // Act
         await faroTracer.startSpan<String>(
           spanName,
           (span) => 'result',
           contextScope: ContextScope.zone,
         );
 
-        // Assert
         expect(capturedScope, equals(ContextScope.zone));
       });
     });
 
     group('Span.noParent:', () {
       test('should create span without parent when Span.noParent is passed', () {
-        // Arrange
         const spanName = 'no-parent-span';
         final mockActiveSpan = MockSpan();
 
-        when(
-          () => mockSessionIdProvider.sessionId,
-        ).thenReturn('test-session-id');
-        when(
-          () => mockOtelTracer.startSpan(
-            any(),
-            context: any(named: 'context'),
-            kind: any(named: 'kind'),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenReturn(mockOtelSpan);
+        stubStartSpan();
         when(
           () => mockFaroZoneSpanManager.getActiveSpan(),
         ).thenReturn(mockActiveSpan);
 
-        // Act
         faroTracer.startSpanManual(spanName, parentSpan: Span.noParent);
 
-        // Assert - should NOT call getActiveSpan since we're explicitly
-        // requesting no parent
         verifyNever(() => mockFaroZoneSpanManager.getActiveSpan());
 
-        // Verify span was created (with default context, not parent's context)
         verify(
           () => mockOtelTracer.startSpan(
             spanName,
             context: any(named: 'context'),
-            kind: otel_api.SpanKind.client,
+            kind: otel.SpanKind.client,
             attributes: any(named: 'attributes'),
           ),
         ).called(1);
@@ -581,61 +487,33 @@ void main() {
 
       test('should ignore active span when Span.noParent is passed even if '
           'active span exists', () {
-        // Arrange
         const spanName = 'independent-trace';
         final mockActiveSpan = MockSpan();
 
-        when(
-          () => mockSessionIdProvider.sessionId,
-        ).thenReturn('test-session-id');
-        when(
-          () => mockOtelTracer.startSpan(
-            any(),
-            context: any(named: 'context'),
-            kind: any(named: 'kind'),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenReturn(mockOtelSpan);
-        // Even though there's an active span available...
+        stubStartSpan();
         when(
           () => mockFaroZoneSpanManager.getActiveSpan(),
         ).thenReturn(mockActiveSpan);
 
-        // Act - pass Span.noParent to explicitly request no parent
         final span = faroTracer.startSpanManual(
           spanName,
           parentSpan: Span.noParent,
         );
 
-        // Assert
         expect(span, isA<InternalSpan>());
-        // getActiveSpan should not be called when Span.noParent is used
         verifyNever(() => mockFaroZoneSpanManager.getActiveSpan());
       });
 
       test(
         'should use active span when parentSpan is null (default behavior)',
         () {
-          // Arrange
           const spanName = 'child-span';
 
-          when(
-            () => mockSessionIdProvider.sessionId,
-          ).thenReturn('test-session-id');
-          when(
-            () => mockOtelTracer.startSpan(
-              any(),
-              context: any(named: 'context'),
-              kind: any(named: 'kind'),
-              attributes: any(named: 'attributes'),
-            ),
-          ).thenReturn(mockOtelSpan);
+          stubStartSpan();
           when(() => mockFaroZoneSpanManager.getActiveSpan()).thenReturn(null);
 
-          // Act - no parentSpan provided, should check for active span
           faroTracer.startSpanManual(spanName);
 
-          // Assert - should call getActiveSpan to check for parent
           verify(() => mockFaroZoneSpanManager.getActiveSpan()).called(1);
         },
       );

--- a/test/src/tracing/faro_tracer_test.dart
+++ b/test/src/tracing/faro_tracer_test.dart
@@ -83,9 +83,7 @@ void main() {
     });
 
     Map<String, Object> capturedAttributesAsMap(otel.Attributes attrs) {
-      return {
-        for (final attr in attrs.toList()) attr.key: attr.value,
-      };
+      return {for (final attr in attrs.toList()) attr.key: attr.value};
     }
 
     void stubStartSpan() {
@@ -174,14 +172,15 @@ void main() {
 
         await faroTracer.startSpan<String>(spanName, (span) => 'result');
 
-        final captured = verify(
-          () => mockOtelTracer.startSpan(
-            spanName,
-            context: any(named: 'context'),
-            kind: otel.SpanKind.client,
-            attributes: captureAny(named: 'attributes'),
-          ),
-        ).captured;
+        final captured =
+            verify(
+              () => mockOtelTracer.startSpan(
+                spanName,
+                context: any(named: 'context'),
+                kind: otel.SpanKind.client,
+                attributes: captureAny(named: 'attributes'),
+              ),
+            ).captured;
         final attrs = captured.single as otel.Attributes;
         final attributeMap = capturedAttributesAsMap(attrs);
         expect(attributeMap['session_id'], sessionId);
@@ -218,14 +217,15 @@ void main() {
             attributes: customAttributes,
           );
 
-          final captured = verify(
-            () => mockOtelTracer.startSpan(
-              spanName,
-              context: any(named: 'context'),
-              kind: otel.SpanKind.client,
-              attributes: captureAny(named: 'attributes'),
-            ),
-          ).captured;
+          final captured =
+              verify(
+                () => mockOtelTracer.startSpan(
+                  spanName,
+                  context: any(named: 'context'),
+                  kind: otel.SpanKind.client,
+                  attributes: captureAny(named: 'attributes'),
+                ),
+              ).captured;
           final attrs = captured.single as otel.Attributes;
           final attributeMap = capturedAttributesAsMap(attrs);
           expect(attributeMap['custom.key1'], 'value1');
@@ -290,14 +290,15 @@ void main() {
 
         await faroTracer.startSpan<String>(spanName, (span) => 'result');
 
-        final captured = verify(
-          () => mockFaroZoneSpanManager.executeWithSpan<String>(
-            any(),
-            any(),
-            contextScope: any(named: 'contextScope'),
-            exceptionOptions: captureAny(named: 'exceptionOptions'),
-          ),
-        ).captured;
+        final captured =
+            verify(
+              () => mockFaroZoneSpanManager.executeWithSpan<String>(
+                any(),
+                any(),
+                contextScope: any(named: 'contextScope'),
+                exceptionOptions: captureAny(named: 'exceptionOptions'),
+              ),
+            ).captured;
         expect(captured.single, isNull);
       });
     });
@@ -335,14 +336,15 @@ void main() {
 
         faroTracer.startSpanManual(spanName, attributes: customAttributes);
 
-        final captured = verify(
-          () => mockOtelTracer.startSpan(
-            spanName,
-            context: any(named: 'context'),
-            kind: otel.SpanKind.client,
-            attributes: captureAny(named: 'attributes'),
-          ),
-        ).captured;
+        final captured =
+            verify(
+              () => mockOtelTracer.startSpan(
+                spanName,
+                context: any(named: 'context'),
+                kind: otel.SpanKind.client,
+                attributes: captureAny(named: 'attributes'),
+              ),
+            ).captured;
         final attrs = captured.single as otel.Attributes;
         final attributeMap = capturedAttributesAsMap(attrs);
         expect(attributeMap['manual.key'], 'manual.value');
@@ -387,14 +389,15 @@ void main() {
 
           faroTracer.startSpanManual(spanName);
 
-          final captured = verify(
-            () => mockOtelTracer.startSpan(
-              spanName,
-              context: any(named: 'context'),
-              kind: otel.SpanKind.client,
-              attributes: captureAny(named: 'attributes'),
-            ),
-          ).captured;
+          final captured =
+              verify(
+                () => mockOtelTracer.startSpan(
+                  spanName,
+                  context: any(named: 'context'),
+                  kind: otel.SpanKind.client,
+                  attributes: captureAny(named: 'attributes'),
+                ),
+              ).captured;
           final attrs = captured.single as otel.Attributes;
           final attributeMap = capturedAttributesAsMap(attrs);
           expect(attributeMap['session_id'], sessionId);
@@ -462,28 +465,31 @@ void main() {
     });
 
     group('Span.noParent:', () {
-      test('should create span without parent when Span.noParent is passed', () {
-        const spanName = 'no-parent-span';
-        final mockActiveSpan = MockSpan();
+      test(
+        'should create span without parent when Span.noParent is passed',
+        () {
+          const spanName = 'no-parent-span';
+          final mockActiveSpan = MockSpan();
 
-        stubStartSpan();
-        when(
-          () => mockFaroZoneSpanManager.getActiveSpan(),
-        ).thenReturn(mockActiveSpan);
+          stubStartSpan();
+          when(
+            () => mockFaroZoneSpanManager.getActiveSpan(),
+          ).thenReturn(mockActiveSpan);
 
-        faroTracer.startSpanManual(spanName, parentSpan: Span.noParent);
+          faroTracer.startSpanManual(spanName, parentSpan: Span.noParent);
 
-        verifyNever(() => mockFaroZoneSpanManager.getActiveSpan());
+          verifyNever(() => mockFaroZoneSpanManager.getActiveSpan());
 
-        verify(
-          () => mockOtelTracer.startSpan(
-            spanName,
-            context: any(named: 'context'),
-            kind: otel.SpanKind.client,
-            attributes: any(named: 'attributes'),
-          ),
-        ).called(1);
-      });
+          verify(
+            () => mockOtelTracer.startSpan(
+              spanName,
+              context: any(named: 'context'),
+              kind: otel.SpanKind.client,
+              attributes: any(named: 'attributes'),
+            ),
+          ).called(1);
+        },
+      );
 
       test('should ignore active span when Span.noParent is passed even if '
           'active span exists', () {
@@ -517,6 +523,27 @@ void main() {
           verify(() => mockFaroZoneSpanManager.getActiveSpan()).called(1);
         },
       );
+    });
+  });
+
+  group('FaroTracerFactory:', () {
+    setUp(FaroTracerFactory.reset);
+    tearDown(FaroTracerFactory.reset);
+
+    test('create() returns a working tracer even when OTel has not been '
+        'initialized (e.g. when Faro.init has not run)', () {
+      // Regression test: callers like FaroHttpTrackingClient call
+      // Faro().startSpanManual without first calling Faro().init(),
+      // e.g. in their own unit tests. The factory must degrade to a
+      // no-op API tracer rather than throwing a cast error from
+      // OTel.tracerProvider.
+      // Note: this test relies on no other test having called
+      // FaroOtelBootstrap.initialize without a matching reset.
+      final tracer = FaroTracerFactory().create();
+      final span = tracer.startSpanManual('preinit-span');
+      expect(span, isNotNull);
+      expect(span.traceId, isNotEmpty);
+      span.end();
     });
   });
 }

--- a/test/src/tracing/faro_tracer_test.dart
+++ b/test/src/tracing/faro_tracer_test.dart
@@ -38,15 +38,19 @@ class _NoOpProcessor implements otel.SpanProcessor {
   Future<void> forceFlush() async {}
 }
 
+Future<void> _initializeOtelForTest() async {
+  await otel.OTel.initialize(
+    serviceName: 'test-service',
+    spanProcessor: _NoOpProcessor(),
+    detectPlatformResources: false,
+    enableMetrics: false,
+    enableLogs: false,
+  );
+}
+
 void main() {
   setUpAll(() async {
-    await otel.OTel.initialize(
-      serviceName: 'test-service',
-      spanProcessor: _NoOpProcessor(),
-      detectPlatformResources: false,
-      enableMetrics: false,
-      enableLogs: false,
-    );
+    await _initializeOtelForTest();
 
     registerFallbackValue(FakeOtelContext());
     registerFallbackValue(otel.SpanKind.client);
@@ -531,14 +535,23 @@ void main() {
     tearDown(FaroTracerFactory.reset);
 
     test('create() returns a working tracer even when OTel has not been '
-        'initialized (e.g. when Faro.init has not run)', () {
+        'initialized (e.g. when Faro.init has not run)', () async {
       // Regression test: callers like FaroHttpTrackingClient call
       // Faro().startSpanManual without first calling Faro().init(),
       // e.g. in their own unit tests. The factory must degrade to a
       // no-op API tracer rather than throwing a cast error from
       // OTel.tracerProvider.
-      // Note: this test relies on no other test having called
-      // FaroOtelBootstrap.initialize without a matching reset.
+      // ignore: invalid_use_of_visible_for_testing_member
+      await otel.OTel.reset();
+      addTearDown(() async {
+        // The pre-init call below installs Dartastic's API-only factory.
+        // Reset it before restoring the SDK factory for any later tests.
+        // ignore: invalid_use_of_visible_for_testing_member
+        await otel.OTel.reset();
+        await _initializeOtelForTest();
+      });
+      FaroTracerFactory.reset();
+
       final tracer = FaroTracerFactory().create();
       final span = tracer.startSpanManual('preinit-span');
       expect(span, isNotNull);

--- a/test/src/tracing/faro_tracer_test.dart
+++ b/test/src/tracing/faro_tracer_test.dart
@@ -176,15 +176,14 @@ void main() {
 
         await faroTracer.startSpan<String>(spanName, (span) => 'result');
 
-        final captured =
-            verify(
-              () => mockOtelTracer.startSpan(
-                spanName,
-                context: any(named: 'context'),
-                kind: otel.SpanKind.client,
-                attributes: captureAny(named: 'attributes'),
-              ),
-            ).captured;
+        final captured = verify(
+          () => mockOtelTracer.startSpan(
+            spanName,
+            context: any(named: 'context'),
+            kind: otel.SpanKind.client,
+            attributes: captureAny(named: 'attributes'),
+          ),
+        ).captured;
         final attrs = captured.single as otel.Attributes;
         final attributeMap = capturedAttributesAsMap(attrs);
         expect(attributeMap['session_id'], sessionId);
@@ -221,15 +220,14 @@ void main() {
             attributes: customAttributes,
           );
 
-          final captured =
-              verify(
-                () => mockOtelTracer.startSpan(
-                  spanName,
-                  context: any(named: 'context'),
-                  kind: otel.SpanKind.client,
-                  attributes: captureAny(named: 'attributes'),
-                ),
-              ).captured;
+          final captured = verify(
+            () => mockOtelTracer.startSpan(
+              spanName,
+              context: any(named: 'context'),
+              kind: otel.SpanKind.client,
+              attributes: captureAny(named: 'attributes'),
+            ),
+          ).captured;
           final attrs = captured.single as otel.Attributes;
           final attributeMap = capturedAttributesAsMap(attrs);
           expect(attributeMap['custom.key1'], 'value1');
@@ -294,15 +292,14 @@ void main() {
 
         await faroTracer.startSpan<String>(spanName, (span) => 'result');
 
-        final captured =
-            verify(
-              () => mockFaroZoneSpanManager.executeWithSpan<String>(
-                any(),
-                any(),
-                contextScope: any(named: 'contextScope'),
-                exceptionOptions: captureAny(named: 'exceptionOptions'),
-              ),
-            ).captured;
+        final captured = verify(
+          () => mockFaroZoneSpanManager.executeWithSpan<String>(
+            any(),
+            any(),
+            contextScope: any(named: 'contextScope'),
+            exceptionOptions: captureAny(named: 'exceptionOptions'),
+          ),
+        ).captured;
         expect(captured.single, isNull);
       });
     });
@@ -340,15 +337,14 @@ void main() {
 
         faroTracer.startSpanManual(spanName, attributes: customAttributes);
 
-        final captured =
-            verify(
-              () => mockOtelTracer.startSpan(
-                spanName,
-                context: any(named: 'context'),
-                kind: otel.SpanKind.client,
-                attributes: captureAny(named: 'attributes'),
-              ),
-            ).captured;
+        final captured = verify(
+          () => mockOtelTracer.startSpan(
+            spanName,
+            context: any(named: 'context'),
+            kind: otel.SpanKind.client,
+            attributes: captureAny(named: 'attributes'),
+          ),
+        ).captured;
         final attrs = captured.single as otel.Attributes;
         final attributeMap = capturedAttributesAsMap(attrs);
         expect(attributeMap['manual.key'], 'manual.value');
@@ -393,15 +389,14 @@ void main() {
 
           faroTracer.startSpanManual(spanName);
 
-          final captured =
-              verify(
-                () => mockOtelTracer.startSpan(
-                  spanName,
-                  context: any(named: 'context'),
-                  kind: otel.SpanKind.client,
-                  attributes: captureAny(named: 'attributes'),
-                ),
-              ).captured;
+          final captured = verify(
+            () => mockOtelTracer.startSpan(
+              spanName,
+              context: any(named: 'context'),
+              kind: otel.SpanKind.client,
+              attributes: captureAny(named: 'attributes'),
+            ),
+          ).captured;
           final attrs = captured.single as otel.Attributes;
           final attributeMap = capturedAttributesAsMap(attrs);
           expect(attributeMap['session_id'], sessionId);

--- a/test/src/tracing/faro_tracing_e2e_test.dart
+++ b/test/src/tracing/faro_tracing_e2e_test.dart
@@ -1,0 +1,149 @@
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
+import 'package:faro/src/core/pod.dart';
+import 'package:faro/src/models/models.dart';
+import 'package:faro/src/tracing/faro_otel_bootstrap.dart';
+import 'package:faro/src/tracing/faro_tracer.dart';
+import 'package:faro/src/tracing/faro_user_action_span_processor.dart';
+import 'package:faro/src/tracing/span.dart';
+import 'package:faro/src/user_actions/telemetry_router.dart';
+import 'package:faro/src/user_actions/user_action_types.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _RecordingRouter implements TelemetryRouter {
+  final List<TelemetryItem> ingested = [];
+  final List<bool> skipBufferFlags = [];
+
+  @override
+  void ingest(TelemetryItem item, {bool skipBuffer = false}) {
+    ingested.add(item);
+    skipBufferFlags.add(skipBuffer);
+  }
+}
+
+/// End-to-end smoke tests that verify a span created via the public
+/// FaroTracer surface flows through dartastic_opentelemetry's
+/// SpanProcessor + SpanExporter chain and lands on the Faro
+/// [TelemetryRouter] as a span+event pair with the expected attributes.
+///
+/// This is the most important integration check after the OTel SDK swap:
+/// it catches breakage anywhere along the InternalSpan -> APISpan ->
+/// SimpleSpanProcessor -> FaroExporter -> TelemetryRouter path.
+void main() {
+  late _RecordingRouter router;
+
+  setUpAll(() {
+    registerFallbackValue(TelemetryItem.fromEvent(Event('fallback')));
+  });
+
+  setUp(() async {
+    router = _RecordingRouter();
+    pod.overrideProvider<TelemetryRouter>(
+      telemetryRouterProvider,
+      (_) => router,
+    );
+    // The faroSpanProcessorProvider is a singleton; if a previous test
+    // built (and then shut down) one, the cache would hand back a dead
+    // processor here. Bounce the override to force fresh construction.
+    pod.overrideProvider<otel.SpanProcessor>(
+      faroSpanProcessorProvider,
+      (_) => throw StateError('placeholder — should not be resolved'),
+    );
+    pod.removeOverride(faroSpanProcessorProvider);
+  });
+
+  tearDown(() async {
+    await FaroOtelBootstrap.resetForTesting();
+    pod.removeOverride(telemetryRouterProvider);
+  });
+
+  test('Faro.startSpanManual flows through to the telemetry router as '
+      'an Event with span attributes and a span TelemetryItem', () async {
+    await FaroOtelBootstrap.initialize();
+    final tracer = FaroTracerFactory().create();
+
+    final span = tracer.startSpanManual(
+      'order.checkout',
+      attributes: const {'cart.size': 3, 'cart.currency': 'EUR'},
+    );
+    span.end();
+
+    // Allow async export to drain.
+    await Future<void>.delayed(Duration.zero);
+
+    expect(router.ingested, hasLength(2), reason: 'one Event + one Span');
+
+    final eventItem = router.ingested.firstWhere(
+      (i) => i.type == TelemetryItemType.event,
+    );
+    final event = eventItem.asEvent!;
+    expect(event.name, equals('span.order.checkout'));
+    expect(event.attributes!['cart.size'], equals('3'));
+    expect(event.attributes!['cart.currency'], equals('EUR'));
+    expect(event.trace, isNotNull);
+    expect(event.trace!['trace_id'], equals(span.traceId));
+    expect(event.trace!['span_id'], equals(span.spanId));
+
+    final spanItem = router.ingested.firstWhere(
+      (i) => i.type == TelemetryItemType.span,
+    );
+    expect(spanItem.asSpan, isNotNull);
+
+    // The event is delivered with skipBuffer=true so user-action buffering
+    // does not stall span-derived events.
+    final eventIndex = router.ingested.indexOf(eventItem);
+    expect(router.skipBufferFlags[eventIndex], isTrue);
+  });
+
+  test('HTTP-flavored spans surface as faro.tracing.fetch events', () async {
+    await FaroOtelBootstrap.initialize();
+    final tracer = FaroTracerFactory().create();
+
+    final span = tracer.startSpanManual(
+      'GET https://example.com',
+      attributes: const {
+        'http.method': 'GET',
+        'http.scheme': 'https',
+        'http.url': 'https://example.com/orders',
+      },
+    );
+    span.end();
+    await Future<void>.delayed(Duration.zero);
+
+    final eventItem = router.ingested.firstWhere(
+      (i) => i.type == TelemetryItemType.event,
+    );
+    expect(eventItem.asEvent!.name, equals('faro.tracing.fetch'));
+  });
+
+  test('child span shares the parent trace_id', () async {
+    await FaroOtelBootstrap.initialize();
+    final tracer = FaroTracerFactory().create();
+
+    final parent = tracer.startSpanManual('parent');
+    final child = tracer.startSpanManual('child', parentSpan: parent);
+    expect(child.traceId, equals(parent.traceId));
+    expect(child.spanId, isNot(equals(parent.spanId)));
+    child.end();
+    parent.end();
+  });
+
+  test(
+    'Span.noParent starts a new trace even when an active span exists',
+    () async {
+      await FaroOtelBootstrap.initialize();
+      final tracer = FaroTracerFactory().create();
+
+      final outer = tracer.startSpanManual('outer');
+      final detached = tracer.startSpanManual(
+        'detached',
+        parentSpan: Span.noParent,
+      );
+      expect(detached.traceId, isNot(equals(outer.traceId)));
+      detached.end();
+      outer.end();
+    },
+  );
+}

--- a/test/src/tracing/faro_user_action_span_processor_test.dart
+++ b/test/src/tracing/faro_user_action_span_processor_test.dart
@@ -81,9 +81,8 @@ void main() {
   otel.Span newSpan({Map<String, Object>? attributes}) {
     final span = tracer.startSpan(
       'test-span',
-      attributes: attributes == null
-          ? null
-          : otel.OTel.attributesFromMap(attributes),
+      attributes:
+          attributes == null ? null : otel.OTel.attributesFromMap(attributes),
     );
     return span;
   }
@@ -103,11 +102,15 @@ void main() {
         await processor.onStart(span, null);
 
         // ignore: invalid_use_of_visible_for_testing_member
-        expect(span.attributes.getString('faro.action.user.name'),
-            equals('checkout'));
+        expect(
+          span.attributes.getString('faro.action.user.name'),
+          equals('checkout'),
+        );
         // ignore: invalid_use_of_visible_for_testing_member
-        expect(span.attributes.getString('faro.action.user.parentId'),
-            equals(action.id));
+        expect(
+          span.attributes.getString('faro.action.user.parentId'),
+          equals(action.id),
+        );
 
         action.dispose();
         span.end();
@@ -131,25 +134,27 @@ void main() {
         span.end();
       });
 
-      test('should NOT set attributes when action is in halted state',
-          () async {
-        final action = UserAction(name: 'checkout')..halt();
+      test(
+        'should NOT set attributes when action is in halted state',
+        () async {
+          final action = UserAction(name: 'checkout')..halt();
 
-        final processor = FaroUserActionSpanProcessor(
-          delegate: recordingDelegate,
-          activeUserActionResolver: () => action,
-          lifecycleSignalChannel: lifecycleSignalChannel,
-        );
+          final processor = FaroUserActionSpanProcessor(
+            delegate: recordingDelegate,
+            activeUserActionResolver: () => action,
+            lifecycleSignalChannel: lifecycleSignalChannel,
+          );
 
-        final span = newSpan();
-        await processor.onStart(span, null);
+          final span = newSpan();
+          await processor.onStart(span, null);
 
-        // ignore: invalid_use_of_visible_for_testing_member
-        expect(span.attributes.getString('faro.action.user.name'), isNull);
+          // ignore: invalid_use_of_visible_for_testing_member
+          expect(span.attributes.getString('faro.action.user.name'), isNull);
 
-        action.dispose();
-        span.end();
-      });
+          action.dispose();
+          span.end();
+        },
+      );
 
       test('should NOT set attributes when action is in ended state', () async {
         final action = UserAction(name: 'checkout')..end();
@@ -170,25 +175,27 @@ void main() {
         span.end();
       });
 
-      test('should NOT set attributes when action is in cancelled state',
-          () async {
-        final action = UserAction(name: 'checkout')..cancel();
+      test(
+        'should NOT set attributes when action is in cancelled state',
+        () async {
+          final action = UserAction(name: 'checkout')..cancel();
 
-        final processor = FaroUserActionSpanProcessor(
-          delegate: recordingDelegate,
-          activeUserActionResolver: () => action,
-          lifecycleSignalChannel: lifecycleSignalChannel,
-        );
+          final processor = FaroUserActionSpanProcessor(
+            delegate: recordingDelegate,
+            activeUserActionResolver: () => action,
+            lifecycleSignalChannel: lifecycleSignalChannel,
+          );
 
-        final span = newSpan();
-        await processor.onStart(span, null);
+          final span = newSpan();
+          await processor.onStart(span, null);
 
-        // ignore: invalid_use_of_visible_for_testing_member
-        expect(span.attributes.getString('faro.action.user.name'), isNull);
+          // ignore: invalid_use_of_visible_for_testing_member
+          expect(span.attributes.getString('faro.action.user.name'), isNull);
 
-        action.dispose();
-        span.end();
-      });
+          action.dispose();
+          span.end();
+        },
+      );
 
       test('should always delegate onStart to wrapped processor', () async {
         final processor = FaroUserActionSpanProcessor(

--- a/test/src/tracing/faro_user_action_span_processor_test.dart
+++ b/test/src/tracing/faro_user_action_span_processor_test.dart
@@ -1,234 +1,262 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/tracing/faro_user_action_span_processor.dart';
 import 'package:faro/src/user_actions/user_action.dart';
 import 'package:faro/src/user_actions/user_action_lifecycle_signal_channel.dart';
 import 'package:faro/src/user_actions/user_action_signal.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
-class MockSpanProcessor extends Mock implements otel_sdk.SpanProcessor {}
+class _NoOpProcessor implements otel.SpanProcessor {
+  @override
+  Future<void> onStart(otel.Span span, otel.Context? parentContext) async {}
+  @override
+  Future<void> onEnd(otel.Span span) async {}
+  @override
+  Future<void> onNameUpdate(otel.Span span, String newName) async {}
+  @override
+  Future<void> shutdown() async {}
+  @override
+  Future<void> forceFlush() async {}
+}
 
-class MockReadWriteSpan extends Mock implements otel_sdk.ReadWriteSpan {}
+class _RecordingProcessor implements otel.SpanProcessor {
+  final List<otel.Span> startedSpans = [];
+  final List<otel.Span> endedSpans = [];
+  int shutdownCount = 0;
+  int forceFlushCount = 0;
 
-class MockReadOnlySpan extends Mock implements otel_sdk.ReadOnlySpan {}
+  @override
+  Future<void> onStart(otel.Span span, otel.Context? parentContext) async {
+    startedSpans.add(span);
+  }
 
-class MockContext extends Mock implements otel_api.Context {}
+  @override
+  Future<void> onEnd(otel.Span span) async {
+    endedSpans.add(span);
+  }
+
+  @override
+  Future<void> onNameUpdate(otel.Span span, String newName) async {}
+
+  @override
+  Future<void> shutdown() async {
+    shutdownCount++;
+  }
+
+  @override
+  Future<void> forceFlush() async {
+    forceFlushCount++;
+  }
+}
 
 void main() {
-  late MockSpanProcessor mockDelegate;
-  late MockReadWriteSpan mockSpan;
-  late MockReadOnlySpan mockReadOnlySpan;
-  late MockContext mockContext;
   late UserActionLifecycleSignalChannel lifecycleSignalChannel;
+  late otel.Tracer tracer;
+  late _RecordingProcessor recordingDelegate;
 
-  setUpAll(() {
-    registerFallbackValue(otel_api.Attribute.fromString('', ''));
+  setUpAll(() async {
+    await otel.OTel.initialize(
+      serviceName: 'test-service',
+      spanProcessor: _NoOpProcessor(),
+      detectPlatformResources: false,
+      enableMetrics: false,
+      enableLogs: false,
+    );
+    tracer = otel.OTel.tracer();
+  });
+
+  tearDownAll(() async {
+    // ignore: invalid_use_of_visible_for_testing_member
+    await otel.OTel.reset();
   });
 
   setUp(() {
-    mockDelegate = MockSpanProcessor();
-    mockSpan = MockReadWriteSpan();
-    mockReadOnlySpan = MockReadOnlySpan();
-    mockContext = MockContext();
+    recordingDelegate = _RecordingProcessor();
     lifecycleSignalChannel = UserActionLifecycleSignalChannel();
-    when(() => mockSpan.attributes).thenReturn(otel_sdk.Attributes.empty());
   });
 
   tearDown(() {
     lifecycleSignalChannel.dispose();
   });
 
+  otel.Span newSpan({Map<String, Object>? attributes}) {
+    final span = tracer.startSpan(
+      'test-span',
+      attributes: attributes == null
+          ? null
+          : otel.OTel.attributesFromMap(attributes),
+    );
+    return span;
+  }
+
   group('FaroUserActionSpanProcessor:', () {
     group('onStart:', () {
       test('should set action attributes on span '
-          'when action is in started state', () {
+          'when action is in started state', () async {
         final action = UserAction(name: 'checkout');
         final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
+          delegate: recordingDelegate,
           activeUserActionResolver: () => action,
           lifecycleSignalChannel: lifecycleSignalChannel,
         );
 
-        processor.onStart(mockSpan, mockContext);
+        final span = newSpan();
+        await processor.onStart(span, null);
 
-        final captured =
-            verify(() => mockSpan.setAttribute(captureAny())).captured;
-
-        expect(captured, hasLength(2));
-        final nameAttr = captured[0] as otel_api.Attribute;
-        final parentIdAttr = captured[1] as otel_api.Attribute;
-
-        expect(nameAttr.key, equals('faro.action.user.name'));
-        expect(nameAttr.value, equals('checkout'));
-        expect(parentIdAttr.key, equals('faro.action.user.parentId'));
-        expect(parentIdAttr.value, equals(action.id));
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(span.attributes.getString('faro.action.user.name'),
+            equals('checkout'));
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(span.attributes.getString('faro.action.user.parentId'),
+            equals(action.id));
 
         action.dispose();
+        span.end();
       });
 
-      test('should NOT set attributes when no active action', () {
+      test('should NOT set attributes when no active action', () async {
         final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
+          delegate: recordingDelegate,
           activeUserActionResolver: () => null,
           lifecycleSignalChannel: lifecycleSignalChannel,
         );
 
-        processor.onStart(mockSpan, mockContext);
+        final span = newSpan();
+        await processor.onStart(span, null);
 
-        verifyNever(() => mockSpan.setAttribute(any()));
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(span.attributes.getString('faro.action.user.name'), isNull);
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(span.attributes.getString('faro.action.user.parentId'), isNull);
+
+        span.end();
       });
 
-      test('should NOT set attributes when action is in halted state', () {
-        final action = UserAction(name: 'checkout');
-        action.halt();
+      test('should NOT set attributes when action is in halted state',
+          () async {
+        final action = UserAction(name: 'checkout')..halt();
 
         final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
+          delegate: recordingDelegate,
           activeUserActionResolver: () => action,
           lifecycleSignalChannel: lifecycleSignalChannel,
         );
 
-        processor.onStart(mockSpan, mockContext);
+        final span = newSpan();
+        await processor.onStart(span, null);
 
-        verifyNever(() => mockSpan.setAttribute(any()));
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(span.attributes.getString('faro.action.user.name'), isNull);
 
         action.dispose();
+        span.end();
       });
 
-      test('should NOT set attributes when action is in ended state', () {
-        final action = UserAction(name: 'checkout');
-        action.end();
+      test('should NOT set attributes when action is in ended state', () async {
+        final action = UserAction(name: 'checkout')..end();
 
         final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
+          delegate: recordingDelegate,
           activeUserActionResolver: () => action,
           lifecycleSignalChannel: lifecycleSignalChannel,
         );
 
-        processor.onStart(mockSpan, mockContext);
+        final span = newSpan();
+        await processor.onStart(span, null);
 
-        verifyNever(() => mockSpan.setAttribute(any()));
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(span.attributes.getString('faro.action.user.name'), isNull);
 
         action.dispose();
+        span.end();
       });
 
-      test('should NOT set attributes when action is in cancelled state', () {
-        final action = UserAction(name: 'checkout');
-        action.cancel();
+      test('should NOT set attributes when action is in cancelled state',
+          () async {
+        final action = UserAction(name: 'checkout')..cancel();
 
         final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
+          delegate: recordingDelegate,
           activeUserActionResolver: () => action,
           lifecycleSignalChannel: lifecycleSignalChannel,
         );
 
-        processor.onStart(mockSpan, mockContext);
+        final span = newSpan();
+        await processor.onStart(span, null);
 
-        verifyNever(() => mockSpan.setAttribute(any()));
-
-        action.dispose();
-      });
-
-      test('should set action attributes on all span kinds', () {
-        final action = UserAction(name: 'checkout');
-        final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
-          activeUserActionResolver: () => action,
-          lifecycleSignalChannel: lifecycleSignalChannel,
-        );
-
-        for (final kind in otel_api.SpanKind.values) {
-          reset(mockSpan);
-          when(() => mockSpan.kind).thenReturn(kind);
-          when(
-            () => mockSpan.attributes,
-          ).thenReturn(otel_sdk.Attributes.empty());
-          processor.onStart(mockSpan, mockContext);
-
-          verify(() => mockSpan.setAttribute(any())).called(2);
-        }
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(span.attributes.getString('faro.action.user.name'), isNull);
 
         action.dispose();
+        span.end();
       });
 
-      test('should always delegate onStart to wrapped processor', () {
+      test('should always delegate onStart to wrapped processor', () async {
         final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
+          delegate: recordingDelegate,
           activeUserActionResolver: () => null,
           lifecycleSignalChannel: lifecycleSignalChannel,
         );
 
-        processor.onStart(mockSpan, mockContext);
+        final span = newSpan();
+        await processor.onStart(span, null);
 
-        verify(() => mockDelegate.onStart(mockSpan, mockContext)).called(1);
+        expect(recordingDelegate.startedSpans, hasLength(1));
+        expect(recordingDelegate.startedSpans.first, same(span));
+
+        span.end();
       });
     });
 
     group('delegation:', () {
-      test('should delegate onEnd to wrapped processor', () {
-        final spanContext = otel_api.SpanContext(
-          otel_api.TraceId.fromString('00000000000000000000000000000001'),
-          otel_api.SpanId.fromString('0000000000000001'),
-          otel_api.TraceFlags.sampled,
-          otel_api.TraceState.empty(),
-        );
-        when(() => mockReadOnlySpan.spanContext).thenReturn(spanContext);
+      test('should delegate onEnd to wrapped processor', () async {
         final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
+          delegate: recordingDelegate,
           activeUserActionResolver: () => null,
           lifecycleSignalChannel: lifecycleSignalChannel,
         );
 
-        processor.onEnd(mockReadOnlySpan);
+        final span = newSpan();
+        await processor.onEnd(span);
 
-        verify(() => mockDelegate.onEnd(mockReadOnlySpan)).called(1);
+        expect(recordingDelegate.endedSpans, hasLength(1));
+        expect(recordingDelegate.endedSpans.first, same(span));
+
+        span.end();
       });
 
-      test('should delegate shutdown to wrapped processor', () {
+      test('should delegate shutdown to wrapped processor', () async {
         final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
+          delegate: recordingDelegate,
           activeUserActionResolver: () => null,
           lifecycleSignalChannel: lifecycleSignalChannel,
         );
 
-        processor.shutdown();
+        await processor.shutdown();
 
-        verify(() => mockDelegate.shutdown()).called(1);
+        expect(recordingDelegate.shutdownCount, equals(1));
       });
 
-      test('should delegate forceFlush to wrapped processor', () {
+      test('should delegate forceFlush to wrapped processor', () async {
         final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
+          delegate: recordingDelegate,
           activeUserActionResolver: () => null,
           lifecycleSignalChannel: lifecycleSignalChannel,
         );
 
-        processor.forceFlush();
+        await processor.forceFlush();
 
-        verify(() => mockDelegate.forceFlush()).called(1);
+        expect(recordingDelegate.forceFlushCount, equals(1));
       });
 
       test(
         'should emit pendingStart and pendingEnd when marker is true',
         () async {
-          final pendingAttributes = otel_sdk.Attributes.empty();
-          pendingAttributes.add(
-            otel_api.Attribute.fromBoolean('faro.action.user.pending', true),
+          final span = newSpan(
+            attributes: const {'faro.action.user.pending': true},
           );
-          when(() => mockSpan.attributes).thenReturn(pendingAttributes);
-
-          final spanContext = otel_api.SpanContext(
-            otel_api.TraceId.fromString('00000000000000000000000000000001'),
-            otel_api.SpanId.fromString('0000000000000001'),
-            otel_api.TraceFlags.sampled,
-            otel_api.TraceState.empty(),
-          );
-          when(() => mockSpan.spanContext).thenReturn(spanContext);
-          when(() => mockReadOnlySpan.spanContext).thenReturn(spanContext);
 
           final processor = FaroUserActionSpanProcessor(
-            delegate: mockDelegate,
+            delegate: recordingDelegate,
             activeUserActionResolver: () => null,
             lifecycleSignalChannel: lifecycleSignalChannel,
           );
@@ -238,9 +266,9 @@ void main() {
             emitted.add,
           );
 
-          processor.onStart(mockSpan, mockContext);
+          await processor.onStart(span, null);
           await Future<void>.delayed(Duration.zero);
-          processor.onEnd(mockReadOnlySpan);
+          await processor.onEnd(span);
           await Future<void>.delayed(Duration.zero);
 
           expect(emitted.length, 2);
@@ -249,23 +277,15 @@ void main() {
           expect(emitted[0].operationId, equals(emitted[1].operationId));
 
           await subscription.cancel();
+          span.end();
         },
       );
 
       test('should not emit pending signals when marker is absent', () async {
-        when(() => mockSpan.attributes).thenReturn(otel_sdk.Attributes.empty());
-
-        final spanContext = otel_api.SpanContext(
-          otel_api.TraceId.fromString('00000000000000000000000000000001'),
-          otel_api.SpanId.fromString('0000000000000001'),
-          otel_api.TraceFlags.sampled,
-          otel_api.TraceState.empty(),
-        );
-        when(() => mockSpan.spanContext).thenReturn(spanContext);
-        when(() => mockReadOnlySpan.spanContext).thenReturn(spanContext);
+        final span = newSpan();
 
         final processor = FaroUserActionSpanProcessor(
-          delegate: mockDelegate,
+          delegate: recordingDelegate,
           activeUserActionResolver: () => null,
           lifecycleSignalChannel: lifecycleSignalChannel,
         );
@@ -273,13 +293,14 @@ void main() {
         final emitted = <UserActionSignal>[];
         final subscription = lifecycleSignalChannel.stream.listen(emitted.add);
 
-        processor.onStart(mockSpan, mockContext);
-        processor.onEnd(mockReadOnlySpan);
+        await processor.onStart(span, null);
+        await processor.onEnd(span);
         await Future<void>.delayed(Duration.zero);
 
         expect(emitted, isEmpty);
 
         await subscription.cancel();
+        span.end();
       });
     });
   });

--- a/test/src/tracing/faro_user_action_span_processor_test.dart
+++ b/test/src/tracing/faro_user_action_span_processor_test.dart
@@ -81,8 +81,9 @@ void main() {
   otel.Span newSpan({Map<String, Object>? attributes}) {
     final span = tracer.startSpan(
       'test-span',
-      attributes:
-          attributes == null ? null : otel.OTel.attributesFromMap(attributes),
+      attributes: attributes == null
+          ? null
+          : otel.OTel.attributesFromMap(attributes),
     );
     return span;
   }

--- a/test/src/tracing/otel_attribute_types_test.dart
+++ b/test/src/tracing/otel_attribute_types_test.dart
@@ -1,36 +1,28 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/models/trace/trace_resource.dart';
 import 'package:faro/src/tracing/extensions.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
-import 'package:opentelemetry/sdk.dart' as otel_sdk;
 
 void main() {
   group('OTel Attribute Types', () {
-    test('Resource.attributes.get() should preserve typed values', () {
-      // Create typed attributes
-      final attributes = [
-        otel_api.Attribute.fromString('string_attr', 'hello'),
-        otel_api.Attribute.fromInt('int_attr', 42),
-        otel_api.Attribute.fromDouble('double_attr', 3.14),
-        otel_api.Attribute.fromBoolean('bool_attr', true),
-      ];
+    test('Attributes.getX() should preserve typed values', () {
+      final attributes = otel.OTelAPI.attributes([
+        otel.OTelAPI.attributeString('string_attr', 'hello'),
+        otel.OTelAPI.attributeInt('int_attr', 42),
+        otel.OTelAPI.attributeDouble('double_attr', 3.14),
+        otel.OTelAPI.attributeBool('bool_attr', true),
+      ]);
 
-      // Create Resource with attributes
-      final resource = otel_sdk.Resource(attributes);
+      final stringVal = attributes.getString('string_attr');
+      final intVal = attributes.getInt('int_attr');
+      final doubleVal = attributes.getDouble('double_attr');
+      final boolVal = attributes.getBool('bool_attr');
 
-      // Check what types are returned by get()
-      final stringVal = resource.attributes.get('string_attr');
-      final intVal = resource.attributes.get('int_attr');
-      final doubleVal = resource.attributes.get('double_attr');
-      final boolVal = resource.attributes.get('bool_attr');
-
-      // Verify types
       expect(stringVal, isA<String>());
       expect(intVal, isA<int>());
       expect(doubleVal, isA<double>());
       expect(boolVal, isA<bool>());
 
-      // Verify values
       expect(stringVal, equals('hello'));
       expect(intVal, equals(42));
       expect(doubleVal, equals(3.14));
@@ -38,21 +30,15 @@ void main() {
     });
 
     test('toTraceAttributes extension should preserve typed values', () {
-      // Create typed attributes
-      final attributes = [
-        otel_api.Attribute.fromString('string_attr', 'hello'),
-        otel_api.Attribute.fromInt('int_attr', 42),
-        otel_api.Attribute.fromDouble('double_attr', 3.14),
-        otel_api.Attribute.fromBoolean('bool_attr', true),
-      ];
+      final attributes = otel.OTelAPI.attributes([
+        otel.OTelAPI.attributeString('string_attr', 'hello'),
+        otel.OTelAPI.attributeInt('int_attr', 42),
+        otel.OTelAPI.attributeDouble('double_attr', 3.14),
+        otel.OTelAPI.attributeBool('bool_attr', true),
+      ]);
 
-      // Create Resource with attributes
-      final resource = otel_sdk.Resource(attributes);
+      final traceAttributes = attributes.toTraceAttributes();
 
-      // Convert to TraceAttributes using our extension
-      final traceAttributes = resource.attributes.toTraceAttributes();
-
-      // Find each attribute and verify
       final stringAttr = traceAttributes.firstWhere(
         (a) => a.toJson()['key'] == 'string_attr',
       );
@@ -66,7 +52,6 @@ void main() {
         (a) => a.toJson()['key'] == 'bool_attr',
       );
 
-      // Verify JSON serialization uses typed fields
       expect(stringAttr.toJson()['value'], equals({'stringValue': 'hello'}));
       expect(intAttr.toJson()['value'], equals({'intValue': 42}));
       expect(doubleAttr.toJson()['value'], equals({'doubleValue': 3.14}));
@@ -74,39 +59,33 @@ void main() {
     });
 
     test('Full OTLP JSON structure verification', () {
-      // Create typed attributes
-      final attributes = [
-        otel_api.Attribute.fromString('team', 'mobile'),
-        otel_api.Attribute.fromInt('test_int', 42),
-        otel_api.Attribute.fromDouble('test_double', 3.14),
-        otel_api.Attribute.fromBoolean('test_bool', true),
-      ];
+      final attributes = otel.OTelAPI.attributes([
+        otel.OTelAPI.attributeString('team', 'mobile'),
+        otel.OTelAPI.attributeInt('test_int', 42),
+        otel.OTelAPI.attributeDouble('test_double', 3.14),
+        otel.OTelAPI.attributeBool('test_bool', true),
+      ]);
 
-      // Create Resource with attributes
-      final resource = otel_sdk.Resource(attributes);
-
-      // Convert to TraceResource, simulating what SpanRecord.getResource() does
       final traceResource = TraceResource(
-        attributes: resource.attributes.toTraceAttributes(),
+        attributes: attributes.toTraceAttributes(),
       );
 
-      // Get the full JSON
       final json = traceResource.toJson();
 
-      // Verify the structure matches OTLP spec
       final attrList = json['attributes'] as List;
 
-      // Find test_int attribute
-      final testIntAttr = attrList.firstWhere((a) => a['key'] == 'test_int');
+      final testIntAttr = attrList.firstWhere(
+        (a) => a['key'] == 'test_int',
+      );
       expect(testIntAttr['value']['intValue'], equals(42));
       expect(testIntAttr['value'].containsKey('stringValue'), isFalse);
 
-      // Find test_bool attribute
-      final testBoolAttr = attrList.firstWhere((a) => a['key'] == 'test_bool');
+      final testBoolAttr = attrList.firstWhere(
+        (a) => a['key'] == 'test_bool',
+      );
       expect(testBoolAttr['value']['boolValue'], equals(true));
       expect(testBoolAttr['value'].containsKey('stringValue'), isFalse);
 
-      // Find test_double attribute
       final testDoubleAttr = attrList.firstWhere(
         (a) => a['key'] == 'test_double',
       );

--- a/test/src/tracing/otel_attribute_types_test.dart
+++ b/test/src/tracing/otel_attribute_types_test.dart
@@ -74,15 +74,11 @@ void main() {
 
       final attrList = json['attributes'] as List;
 
-      final testIntAttr = attrList.firstWhere(
-        (a) => a['key'] == 'test_int',
-      );
+      final testIntAttr = attrList.firstWhere((a) => a['key'] == 'test_int');
       expect(testIntAttr['value']['intValue'], equals(42));
       expect(testIntAttr['value'].containsKey('stringValue'), isFalse);
 
-      final testBoolAttr = attrList.firstWhere(
-        (a) => a['key'] == 'test_bool',
-      );
+      final testBoolAttr = attrList.firstWhere((a) => a['key'] == 'test_bool');
       expect(testBoolAttr['value']['boolValue'], equals(true));
       expect(testBoolAttr['value'].containsKey('stringValue'), isFalse);
 

--- a/test/src/tracing/span_exception_options_test.dart
+++ b/test/src/tracing/span_exception_options_test.dart
@@ -53,11 +53,10 @@ void main() {
           );
         }
 
-        final merged = SpanExceptionOptions(
-          exceptionSanitizer: globalSanitizer,
-        ).mergeWith(
-          SpanExceptionOptions(exceptionSanitizer: overrideSanitizer),
-        );
+        final merged = SpanExceptionOptions(exceptionSanitizer: globalSanitizer)
+            .mergeWith(
+              SpanExceptionOptions(exceptionSanitizer: overrideSanitizer),
+            );
 
         expect(merged.exceptionSanitizer, same(overrideSanitizer));
       });
@@ -93,17 +92,18 @@ void main() {
           );
         }
 
-        final merged = SpanExceptionOptions(
-          recordException: false,
-          setStatusOnException: false,
-          exceptionSanitizer: globalSanitizer,
-        ).mergeWith(
-          SpanExceptionOptions(
-            recordException: true,
-            setStatusOnException: true,
-            exceptionSanitizer: overrideSanitizer,
-          ),
-        );
+        final merged =
+            SpanExceptionOptions(
+              recordException: false,
+              setStatusOnException: false,
+              exceptionSanitizer: globalSanitizer,
+            ).mergeWith(
+              SpanExceptionOptions(
+                recordException: true,
+                setStatusOnException: true,
+                exceptionSanitizer: overrideSanitizer,
+              ),
+            );
 
         expect(merged.recordException, isTrue);
         expect(merged.setStatusOnException, isTrue);

--- a/test/src/tracing/span_test.dart
+++ b/test/src/tracing/span_test.dart
@@ -134,13 +134,14 @@ void main() {
       final apiSpan = tracer.startSpan(
         'test-span',
         kind: otel.SpanKind.client,
-        spanContext: traceFlags == null
-            ? null
-            : otel.OTel.spanContext(
-                traceId: otel.OTel.traceId(),
-                spanId: otel.OTel.spanId(),
-                traceFlags: traceFlags,
-              ),
+        spanContext:
+            traceFlags == null
+                ? null
+                : otel.OTel.spanContext(
+                  traceId: otel.OTel.traceId(),
+                  spanId: otel.OTel.spanId(),
+                  traceFlags: traceFlags,
+                ),
       );
       return SpanProvider().getSpan(apiSpan, otel.Context.current);
     }

--- a/test/src/tracing/span_test.dart
+++ b/test/src/tracing/span_test.dart
@@ -1,28 +1,46 @@
 // ignore_for_file: lines_longer_than_80_chars
 
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/tracing/span.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
-import 'package:opentelemetry/api.dart' as otel_api;
 
-class MockOtelSpan extends Mock implements otel_api.Span {}
-
-class FakeOtelContext extends Fake implements otel_api.Context {}
+class _NoOpProcessor implements otel.SpanProcessor {
+  @override
+  Future<void> onStart(otel.Span span, otel.Context? parentContext) async {}
+  @override
+  Future<void> onEnd(otel.Span span) async {}
+  @override
+  Future<void> onNameUpdate(otel.Span span, String newName) async {}
+  @override
+  Future<void> shutdown() async {}
+  @override
+  Future<void> forceFlush() async {}
+}
 
 void main() {
-  setUpAll(() {
-    registerFallbackValue(otel_api.StatusCode.unset);
-    registerFallbackValue(<otel_api.Attribute>[]);
-    registerFallbackValue(otel_api.Attribute.fromString('key', 'value'));
+  late otel.Tracer tracer;
+
+  setUpAll(() async {
+    await otel.OTel.initialize(
+      serviceName: 'test-service',
+      spanProcessor: _NoOpProcessor(),
+      detectPlatformResources: false,
+      enableMetrics: false,
+      enableLogs: false,
+    );
+    tracer = otel.OTel.tracer();
+  });
+
+  tearDownAll(() async {
+    // ignore: invalid_use_of_visible_for_testing_member
+    await otel.OTel.reset();
   });
 
   group('Span.noParent sentinel:', () {
     test('should be a const singleton', () {
-      // Act
       const a = Span.noParent;
       const b = Span.noParent;
 
-      // Assert - both references should be identical (same object)
       expect(identical(a, b), isTrue);
       expect(a == b, isTrue);
     });
@@ -112,145 +130,86 @@ void main() {
   });
 
   group('InternalSpan:', () {
-    late MockOtelSpan mockOtelSpan;
-    late FakeOtelContext fakeContext;
-
-    setUp(() {
-      mockOtelSpan = MockOtelSpan();
-      fakeContext = FakeOtelContext();
-    });
-
-    Span createSpan() {
-      return SpanProvider().getSpan(mockOtelSpan, fakeContext);
+    Span makeFaroSpan({otel.TraceFlags? traceFlags}) {
+      final apiSpan = tracer.startSpan(
+        'test-span',
+        kind: otel.SpanKind.client,
+        spanContext: traceFlags == null
+            ? null
+            : otel.OTel.spanContext(
+                traceId: otel.OTel.traceId(),
+                spanId: otel.OTel.spanId(),
+                traceFlags: traceFlags,
+              ),
+      );
+      return SpanProvider().getSpan(apiSpan, otel.Context.current);
     }
 
     group('traceparent:', () {
-      Span createSpanWithTraceFlags(int traceFlags) {
-        when(() => mockOtelSpan.spanContext).thenReturn(
-          otel_api.SpanContext(
-            otel_api.TraceId.fromString('00000000000000000000000000000001'),
-            otel_api.SpanId.fromString('0000000000000001'),
-            traceFlags,
-            otel_api.TraceState.empty(),
-          ),
-        );
-        return createSpan();
-      }
-
       test('should return W3C formatted traceparent string', () {
-        const traceIdHex = '0af7651916cd43dd8448eb211c80319c';
-        const spanIdHex = 'b7ad6b7169203331';
+        final span = makeFaroSpan(traceFlags: otel.TraceFlags.sampled);
 
-        final spanContext = otel_api.SpanContext(
-          otel_api.TraceId.fromString(traceIdHex),
-          otel_api.SpanId.fromString(spanIdHex),
-          otel_api.TraceFlags.sampled,
-          otel_api.TraceState.empty(),
-        );
-        when(() => mockOtelSpan.spanContext).thenReturn(spanContext);
-
-        final span = createSpan();
-
-        expect(span.traceparent, '00-$traceIdHex-$spanIdHex-01');
+        final tp = span.traceparent;
+        // 00-<32 hex>-<16 hex>-01
+        expect(tp, matches(RegExp(r'^00-[0-9a-f]{32}-[0-9a-f]{16}-01$')));
+        expect(tp, contains(span.traceId));
+        expect(tp, contains(span.spanId));
       });
 
-      test('should preserve sampled trace flag', () {
-        final span = createSpanWithTraceFlags(otel_api.TraceFlags.sampled);
+      test('should format trace flags as two-digit hex', () {
+        final span = makeFaroSpan(traceFlags: otel.TraceFlags.sampled);
 
-        expect(
-          span.traceparent,
-          '00-00000000000000000000000000000001-0000000000000001-01',
-        );
-      });
-
-      test('should preserve unsampled trace flag', () {
-        final span = createSpanWithTraceFlags(otel_api.TraceFlags.none);
-
-        expect(
-          span.traceparent,
-          '00-00000000000000000000000000000001-0000000000000001-00',
-        );
+        // The sampler controls the actual flag value; we just verify the
+        // format is a two-character hex byte.
+        expect(span.traceparent, matches(RegExp(r'-[0-9a-f]{2}$')));
       });
     });
 
     group('setAttributes with typed values:', () {
-      test('should pass string attributes to OTel span', () {
-        final span = createSpan();
-        final capturedAttributes = <otel_api.Attribute>[];
+      Span makeSpan() => makeFaroSpan(traceFlags: otel.TraceFlags.sampled);
 
-        when(() => mockOtelSpan.setAttributes(any())).thenAnswer((invocation) {
-          capturedAttributes.addAll(
-            invocation.positionalArguments[0] as List<otel_api.Attribute>,
-          );
-        });
+      test('should pass string attributes to OTel span', () {
+        final span = makeSpan();
 
         span.setAttributes({'name': 'test'});
 
-        expect(capturedAttributes.length, 1);
-        expect(capturedAttributes[0].key, 'name');
-        expect(capturedAttributes[0].value, 'test');
+        final internal = span as InternalSpan;
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(internal.otelSpan.attributes.getString('name'), 'test');
       });
 
       test('should pass int attributes to OTel span', () {
-        final span = createSpan();
-        final capturedAttributes = <otel_api.Attribute>[];
-
-        when(() => mockOtelSpan.setAttributes(any())).thenAnswer((invocation) {
-          capturedAttributes.addAll(
-            invocation.positionalArguments[0] as List<otel_api.Attribute>,
-          );
-        });
+        final span = makeSpan();
 
         span.setAttributes({'count': 42});
 
-        expect(capturedAttributes.length, 1);
-        expect(capturedAttributes[0].key, 'count');
-        expect(capturedAttributes[0].value, 42);
+        final internal = span as InternalSpan;
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(internal.otelSpan.attributes.getInt('count'), 42);
       });
 
       test('should pass double attributes to OTel span', () {
-        final span = createSpan();
-        final capturedAttributes = <otel_api.Attribute>[];
-
-        when(() => mockOtelSpan.setAttributes(any())).thenAnswer((invocation) {
-          capturedAttributes.addAll(
-            invocation.positionalArguments[0] as List<otel_api.Attribute>,
-          );
-        });
+        final span = makeSpan();
 
         span.setAttributes({'score': 99.5});
 
-        expect(capturedAttributes.length, 1);
-        expect(capturedAttributes[0].key, 'score');
-        expect(capturedAttributes[0].value, 99.5);
+        final internal = span as InternalSpan;
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(internal.otelSpan.attributes.getDouble('score'), 99.5);
       });
 
       test('should pass bool attributes to OTel span', () {
-        final span = createSpan();
-        final capturedAttributes = <otel_api.Attribute>[];
-
-        when(() => mockOtelSpan.setAttributes(any())).thenAnswer((invocation) {
-          capturedAttributes.addAll(
-            invocation.positionalArguments[0] as List<otel_api.Attribute>,
-          );
-        });
+        final span = makeSpan();
 
         span.setAttributes({'enabled': true});
 
-        expect(capturedAttributes.length, 1);
-        expect(capturedAttributes[0].key, 'enabled');
-        expect(capturedAttributes[0].value, true);
+        final internal = span as InternalSpan;
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(internal.otelSpan.attributes.getBool('enabled'), true);
       });
 
       test('should pass mixed type attributes to OTel span', () {
-        final span = createSpan();
-        final capturedAttributes = <otel_api.Attribute>[];
-
-        when(() => mockOtelSpan.setAttributes(any())).thenAnswer((invocation) {
-          capturedAttributes.addAll(
-            invocation.positionalArguments[0] as List<otel_api.Attribute>,
-          );
-        });
+        final span = makeSpan();
 
         span.setAttributes({
           'name': 'test',
@@ -259,36 +218,19 @@ void main() {
           'enabled': true,
         });
 
-        expect(capturedAttributes.length, 4);
-
-        final attrMap = {
-          for (final attr in capturedAttributes) attr.key: attr.value,
-        };
-        expect(attrMap['name'], 'test');
-        expect(attrMap['count'], 42);
-        expect(attrMap['score'], 99.5);
-        expect(attrMap['enabled'], true);
+        final internal = span as InternalSpan;
+        // ignore: invalid_use_of_visible_for_testing_member
+        final attrs = internal.otelSpan.attributes;
+        expect(attrs.getString('name'), 'test');
+        expect(attrs.getInt('count'), 42);
+        expect(attrs.getDouble('score'), 99.5);
+        expect(attrs.getBool('enabled'), true);
       });
     });
 
     group('addEvent with typed attributes:', () {
       test('should pass typed attributes to event', () {
-        final span = createSpan();
-        final capturedAttributes = <otel_api.Attribute>[];
-
-        when(
-          () => mockOtelSpan.addEvent(
-            any(),
-            attributes: any(named: 'attributes'),
-          ),
-        ).thenAnswer((invocation) {
-          final attrs =
-              invocation.namedArguments[const Symbol('attributes')]
-                  as List<otel_api.Attribute>?;
-          if (attrs != null) {
-            capturedAttributes.addAll(attrs);
-          }
-        });
+        final span = makeFaroSpan(traceFlags: otel.TraceFlags.sampled);
 
         span.addEvent(
           'test event',
@@ -300,77 +242,58 @@ void main() {
           },
         );
 
-        expect(capturedAttributes.length, 4);
+        final internal = span as InternalSpan;
+        final events = internal.otelSpan.spanEvents;
+        expect(events, isNotNull);
+        expect(events!.length, 1);
 
-        final attrMap = {
-          for (final attr in capturedAttributes) attr.key: attr.value,
-        };
-        expect(attrMap['message'], 'hello');
-        expect(attrMap['count'], 5);
-        expect(attrMap['duration'], 1.5);
-        expect(attrMap['success'], true);
+        final event = events.first;
+        expect(event.name, 'test event');
+        final attrs = event.attributes!;
+        expect(attrs.getString('message'), 'hello');
+        expect(attrs.getInt('count'), 5);
+        expect(attrs.getDouble('duration'), 1.5);
+        expect(attrs.getBool('success'), true);
       });
     });
 
     group('setAttribute with typed value:', () {
+      Span makeSpan() => makeFaroSpan(traceFlags: otel.TraceFlags.sampled);
+
       test('should pass string value to OTel span', () {
-        final span = createSpan();
-        otel_api.Attribute? capturedAttribute;
-
-        when(() => mockOtelSpan.setAttribute(any())).thenAnswer((invocation) {
-          capturedAttribute =
-              invocation.positionalArguments[0] as otel_api.Attribute;
-        });
-
+        final span = makeSpan();
         span.setAttribute('name', 'test');
 
-        expect(capturedAttribute?.key, 'name');
-        expect(capturedAttribute?.value, 'test');
+        final internal = span as InternalSpan;
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(internal.otelSpan.attributes.getString('name'), 'test');
       });
 
       test('should pass int value to OTel span via setAttribute', () {
-        final span = createSpan();
-        otel_api.Attribute? capturedAttribute;
-
-        when(() => mockOtelSpan.setAttribute(any())).thenAnswer((invocation) {
-          capturedAttribute =
-              invocation.positionalArguments[0] as otel_api.Attribute;
-        });
-
+        final span = makeSpan();
         span.setAttribute('count', 42);
 
-        expect(capturedAttribute?.key, 'count');
-        expect(capturedAttribute?.value, 42);
+        final internal = span as InternalSpan;
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(internal.otelSpan.attributes.getInt('count'), 42);
       });
 
       test('should pass double value to OTel span via setAttribute', () {
-        final span = createSpan();
-        otel_api.Attribute? capturedAttribute;
-
-        when(() => mockOtelSpan.setAttribute(any())).thenAnswer((invocation) {
-          capturedAttribute =
-              invocation.positionalArguments[0] as otel_api.Attribute;
-        });
-
+        final span = makeSpan();
         span.setAttribute('score', 99.5);
 
-        expect(capturedAttribute?.key, 'score');
-        expect(capturedAttribute?.value, 99.5);
+        final internal = span as InternalSpan;
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(internal.otelSpan.attributes.getDouble('score'), 99.5);
       });
 
       test('should pass bool value to OTel span via setAttribute', () {
-        final span = createSpan();
-        otel_api.Attribute? capturedAttribute;
-
-        when(() => mockOtelSpan.setAttribute(any())).thenAnswer((invocation) {
-          capturedAttribute =
-              invocation.positionalArguments[0] as otel_api.Attribute;
-        });
-
+        final span = makeSpan();
         span.setAttribute('enabled', true);
 
-        expect(capturedAttribute?.key, 'enabled');
-        expect(capturedAttribute?.value, true);
+        final internal = span as InternalSpan;
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(internal.otelSpan.attributes.getBool('enabled'), true);
       });
     });
   });

--- a/test/src/tracing/span_test.dart
+++ b/test/src/tracing/span_test.dart
@@ -275,6 +275,7 @@ void main() {
         expect(attrs.getString('exception.type'), contains('Exception'));
         expect(attrs.getString('exception.message'), 'Exception: boom');
         expect(attrs.getString('exception.stacktrace'), stackTrace.toString());
+        expect(attrs.getBool('exception.escaped'), isTrue);
       });
     });
 

--- a/test/src/tracing/span_test.dart
+++ b/test/src/tracing/span_test.dart
@@ -258,6 +258,27 @@ void main() {
       });
     });
 
+    group('recordException:', () {
+      test('should record an exception event on the OTel span', () {
+        final span = makeFaroSpan(traceFlags: otel.TraceFlags.sampled);
+        final stackTrace = StackTrace.current;
+
+        span.recordException(Exception('boom'), stackTrace: stackTrace);
+
+        final internal = span as InternalSpan;
+        final events = internal.otelSpan.spanEvents;
+        expect(events, isNotNull);
+        expect(events, hasLength(1));
+
+        final event = events!.single;
+        expect(event.name, 'exception');
+        final attrs = event.attributes!;
+        expect(attrs.getString('exception.type'), contains('Exception'));
+        expect(attrs.getString('exception.message'), 'Exception: boom');
+        expect(attrs.getString('exception.stacktrace'), stackTrace.toString());
+      });
+    });
+
     group('setAttribute with typed value:', () {
       Span makeSpan() => makeFaroSpan(traceFlags: otel.TraceFlags.sampled);
 

--- a/test/src/tracing/span_test.dart
+++ b/test/src/tracing/span_test.dart
@@ -134,14 +134,13 @@ void main() {
       final apiSpan = tracer.startSpan(
         'test-span',
         kind: otel.SpanKind.client,
-        spanContext:
-            traceFlags == null
-                ? null
-                : otel.OTel.spanContext(
-                  traceId: otel.OTel.traceId(),
-                  spanId: otel.OTel.spanId(),
-                  traceFlags: traceFlags,
-                ),
+        spanContext: traceFlags == null
+            ? null
+            : otel.OTel.spanContext(
+                traceId: otel.OTel.traceId(),
+                spanId: otel.OTel.spanId(),
+                traceFlags: traceFlags,
+              ),
       );
       return SpanProvider().getSpan(apiSpan, otel.Context.current);
     }

--- a/test/src/transport/batch_transport_test.dart
+++ b/test/src/transport/batch_transport_test.dart
@@ -127,8 +127,9 @@ void main() {
         expect(batchTransport.payloadSize(), equals(0));
 
         // Verify send was called with the correct payload content
-        final captured =
-            verify(() => mockBaseTransport.send(captureAny())).captured;
+        final captured = verify(
+          () => mockBaseTransport.send(captureAny()),
+        ).captured;
         expect(captured, hasLength(1));
 
         final sentPayload = captured.single as Map<String, dynamic>;

--- a/test/src/user_actions/user_action_integration_test.dart
+++ b/test/src/user_actions/user_action_integration_test.dart
@@ -35,9 +35,9 @@ void main() {
     await Future<void>.delayed(actionSettleDelay);
   }
 
-  setUp(() {
+  setUp(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    Faro.resetForTesting();
+    await Faro.resetForTesting();
     BatchTransportFactory().reset();
 
     // Mock SharedPreferences
@@ -66,7 +66,7 @@ void main() {
 
   tearDown(() async {
     await completeActiveAction(source: 'test.teardown');
-    Faro.resetForTesting();
+    await Faro.resetForTesting();
     BatchTransportFactory().reset();
   });
 

--- a/test/src/user_actions/user_action_integration_test.dart
+++ b/test/src/user_actions/user_action_integration_test.dart
@@ -367,8 +367,9 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 10));
 
         // Find the user action event
-        final captured =
-            verify(() => mockTransport.send(captureAny())).captured;
+        final captured = verify(
+          () => mockTransport.send(captureAny()),
+        ).captured;
         expect(captured, isNotEmpty);
 
         var foundUserActionEvent = false;

--- a/test/src/user_actions/user_action_ui_activity_integration_test.dart
+++ b/test/src/user_actions/user_action_ui_activity_integration_test.dart
@@ -96,9 +96,9 @@ void main() {
     registerFallbackValue(<String, dynamic>{});
   });
 
-  setUp(() {
+  setUp(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    Faro.resetForTesting();
+    await Faro.resetForTesting();
     BatchTransportFactory().reset();
     SharedPreferences.setMockInitialValues(<String, Object>{});
     PackageInfo.setMockInitialValues(
@@ -116,8 +116,8 @@ void main() {
     faro.transports = <BaseTransport>[mockTransport];
   });
 
-  tearDown(() {
-    Faro.resetForTesting();
+  tearDown(() async {
+    await Faro.resetForTesting();
     BatchTransportFactory().reset();
   });
 

--- a/test/src/webview/faro_webview_bridge_test.dart
+++ b/test/src/webview/faro_webview_bridge_test.dart
@@ -16,7 +16,7 @@ void main() {
 
   setUp(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    Faro.resetForTesting();
+    await Faro.resetForTesting();
     BatchTransportFactory().reset();
     SharedPreferences.setMockInitialValues({});
 
@@ -46,8 +46,8 @@ void main() {
     clearInteractions(mockTransport);
   });
 
-  tearDown(() {
-    Faro.resetForTesting();
+  tearDown(() async {
+    await Faro.resetForTesting();
     BatchTransportFactory().reset();
   });
 

--- a/test/src/webview/faro_webview_bridge_test.dart
+++ b/test/src/webview/faro_webview_bridge_test.dart
@@ -173,8 +173,9 @@ void main() {
           appName: 'MyWebApp',
         );
 
-        final captured =
-            verify(() => mockTransport.send(captureAny())).captured;
+        final captured = verify(
+          () => mockTransport.send(captureAny()),
+        ).captured;
         expect(captured, isNotEmpty);
 
         final payload = captured.last as Map<String, dynamic>;
@@ -198,8 +199,9 @@ void main() {
 
         bridge.linkChildSession(sessionId: 'web-session-456');
 
-        final captured =
-            verify(() => mockTransport.send(captureAny())).captured;
+        final captured = verify(
+          () => mockTransport.send(captureAny()),
+        ).captured;
         expect(captured, isNotEmpty);
 
         final payload = captured.last as Map<String, dynamic>;

--- a/tool/create_release.dart
+++ b/tool/create_release.dart
@@ -34,11 +34,10 @@ Future<String?> getPreviousTag() async {
     return null;
   }
 
-  final tags =
-      (result.stdout as String)
-          .split('\n')
-          .where((t) => t.trim().isNotEmpty && t.startsWith('v'))
-          .toList();
+  final tags = (result.stdout as String)
+      .split('\n')
+      .where((t) => t.trim().isNotEmpty && t.startsWith('v'))
+      .toList();
 
   return tags.isNotEmpty ? tags.first : null;
 }
@@ -207,7 +206,8 @@ Future<String?> enrichWithAI(String changelog, String version) async {
       'messages': [
         {
           'role': 'system',
-          'content': '''
+          'content':
+              '''
 You are writing GitHub release notes for the Grafana Faro Flutter SDK (pub.dev package: faro), a mobile observability SDK for Flutter applications.
 
 Transform raw CHANGELOG content into polished, user-friendly GitHub release notes.

--- a/tool/version_bump.dart
+++ b/tool/version_bump.dart
@@ -98,7 +98,8 @@ Future<void> updateChangelog(String version) async {
     if (unreleasedIndex != -1) {
       final beforeUnreleased = content.substring(0, unreleasedIndex);
       final afterUnreleased = content.substring(unreleasedIndex);
-      final newEntry = '''
+      final newEntry =
+          '''
 $beforeUnreleased## [Unreleased]
 
 ## [$version] - $dateStr
@@ -107,7 +108,8 @@ $afterUnreleased''';
       await file.writeAsString(newEntry);
     } else {
       // Fallback: add at the beginning if no Unreleased section found
-      final newEntry = '''
+      final newEntry =
+          '''
 ## [Unreleased]
 
 ## [$version] - $dateStr


### PR DESCRIPTION
Migrates Faro Flutter tracing from the older Workiva `opentelemetry` SDK to
`dartastic_opentelemetry` `1.1.0-beta.5`.

The Faro public tracing API is unchanged. This swaps the underlying OTel
implementation to the Dartastic SDK, which is the current candidate that may be
adopted as the official Dart OpenTelemetry SDK through the OTel governance
process.

## What changed

- Replaced Workiva OTel usage with `dartastic_opentelemetry`.
- Updated tracing internals for Dartastic's async processor/exporter lifecycle
  and typed attribute APIs.
- Added `FaroOtelBootstrap` to initialize the process-global OTel SDK once from
  Faro app/session metadata.
- Preserved the pre-init no-op tracer behavior for callers that create spans
  before `Faro.init()`.
- Ensured Faro spans use explicit instrumentation scope metadata:
  `scope.name=faro-mobile-flutter`, `scope.version=0.16.0`.
- Added local demo helpers:
  - `make run-example`
  - `make run-webview-demo`

## Validation

Verified the new implementation against the previous Workiva-based version by
running the example Flutter app and WebView demo on an Android emulator and
comparing the emitted telemetry in Grafana Cloud.

Checked:

- Flutter app logs, events, measurements, and span events are still emitted.
- WebView demo telemetry is still emitted.
- Tempo traces preserve the same important shape, including the cross-boundary
  WebView trace: Flutter `WebView` span with child web `HTTP POST` span.
- Representative simple, typed-attribute, nested, error, and WebView spans kept
  the expected resource attributes, span attributes, events, status, and
  parent/child relationships.
- Release APK size did not meaningfully increase:
  - PR: `50,692,446` bytes
  - `origin/main`: `50,522,890` bytes
  - delta: `+169,556` bytes, about `+0.16 MiB` / `+0.34%`

Also ran:

- `flutter analyze`
- `flutter test`

Note: `dartastic_opentelemetry` is intentionally pinned while the SDK is still
pre-GA and APIs may continue to change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces the underlying OpenTelemetry implementation and changes exporter/processor lifecycles to async, which could affect trace emission timing, attribute mapping, and initialization behavior.
>
> **Overview**
> Swaps the tracing backend from the Workiva `opentelemetry` SDK to pinned `dartastic_opentelemetry` (`pubspec.yaml`), updating Faro’s tracing pipeline to the new API (async `SpanExporter`/`SpanProcessor` methods and typed attribute setters).
>
> Introduces `FaroOtelBootstrap` and wires it into `Faro.init()` to initialize the process-global OTel SDK once, build resource attributes from Faro meta, and provide a test reset hook; `FaroTracerFactory` now uses `OTelAPI` so it safely degrades to a no-op tracer when Faro hasn’t been initialized.
>
> Updates span serialization (`SpanRecord`, tracing `extensions`, `Span`) to match dartastic’s model (DateTime timestamps -> unix nanos, parent context handling, status mapping, and event/link extraction), and rewrites/adds tests (including new bootstrap + e2e smoke coverage) to validate spans still flow through to `TelemetryRouter` as expected.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71712f61e8a3e5ffdc18c581e6962b62ef5d515c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

