### PR TITLE
feat: populate structured mobile meta fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `meta.device`, `meta.os`, `meta.app.installationId`, and
   `exception.fatal`, while keeping legacy flat session attributes during
   migration.
+  The duplicated flat `device_*` session attributes are kept for compatibility
+  and can be removed after collector and plugin query parity is confirmed.
 
 ## [0.16.0] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Emit structured mobile metadata in Flutter SDK payloads:
+  `meta.device`, `meta.os`, `meta.app.installationId`, and
+  `exception.fatal`, while keeping legacy flat session attributes during
+  migration.
+
 ## [0.16.0] - 2026-05-11
 
 ### Added

--- a/ios/faro/Sources/faro/CrashReportingIntegration.swift
+++ b/ios/faro/Sources/faro/CrashReportingIntegration.swift
@@ -113,6 +113,7 @@ internal struct RumExceptionFormat{
     let value: String?
     let stacktrace: Dictionary<String,Any>
     let timestamp: String
+    let fatal: Bool
 //    let context: Dictionary<String, String>?
     
     var jsonAbbreviation : [String: Any] {
@@ -121,14 +122,16 @@ internal struct RumExceptionFormat{
             "value": value ?? "",
             "stacktrace": stacktrace,
             "timestamp": timestamp,
+            "fatal": fatal,
 //            "context": context ?? ""
         ]
     }
-    init(type: String?, value: String?, stacktrace: Dictionary<String, Any>, timestamp: String) {
+    init(type: String?, value: String?, stacktrace: Dictionary<String, Any>, timestamp: String, fatal: Bool = false) {
         self.type = type
         self.value = value
         self.stacktrace = stacktrace
         self.timestamp = timestamp
+        self.fatal = fatal
 //        self.context = context
     }
     
@@ -244,7 +247,8 @@ internal struct CrashReportExporter{
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
 
         return (RumExceptionFormat(type: formattedType(for: crashReport), value: formattedValue(for: crashReport), stacktrace: ["frames":formattedStack(for: crashReport)],
-                           timestamp: dateFormatter.string(from: crashReport.systemInfo?.timestamp ?? Date())
+                           timestamp: dateFormatter.string(from: crashReport.systemInfo?.timestamp ?? Date()),
+                           fatal: true
                            // TODO: add context: binaryImages, ThreadInfo,contextData, Meta,truncation
                            //                           context: [
                            //                            "binaryImages": "",

--- a/lib/src/device_info/device_info_provider.dart
+++ b/lib/src/device_info/device_info_provider.dart
@@ -23,11 +23,13 @@ class DeviceInfoProvider {
     var deviceOs = _platformInfoProvider.operatingSystem;
     var deviceOsVersion = _platformInfoProvider.operatingSystemVersion;
     var deviceOsDetail = 'unknown';
+    String? deviceOsBuildId;
     var deviceManufacturer = 'unknown';
     var deviceModel = 'unknown';
     var deviceModelName = 'unknown';
     var deviceBrand = 'unknown';
     var deviceIsPhysical = true;
+    String? deviceType;
 
     if (_platformInfoProvider.isAndroid) {
       final androidInfo = await _deviceInfoPlugin.androidInfo;
@@ -36,6 +38,7 @@ class DeviceInfoProvider {
 
       deviceOs = 'Android';
       deviceOsVersion = release;
+      deviceOsBuildId = androidInfo.id;
       deviceOsDetail = 'Android $release (SDK $sdkInt)';
       deviceManufacturer = androidInfo.manufacturer;
       deviceModel = androidInfo.model;
@@ -58,6 +61,9 @@ class DeviceInfoProvider {
       deviceModelName = iosInfo.modelName;
       deviceBrand = iosInfo.model;
       deviceIsPhysical = iosInfo.isPhysicalDevice;
+      deviceType = iosInfo.model.toLowerCase().contains('ipad')
+          ? 'tablet'
+          : 'mobile';
     }
 
     final deviceInfo = DeviceInfo(
@@ -70,6 +76,8 @@ class DeviceInfoProvider {
       deviceModelName: deviceModelName,
       deviceBrand: deviceBrand,
       deviceIsPhysical: deviceIsPhysical,
+      deviceOsBuildId: deviceOsBuildId,
+      deviceType: deviceType,
     );
     _deviceInfo = deviceInfo;
     return deviceInfo;

--- a/lib/src/device_info/session_attributes_provider.dart
+++ b/lib/src/device_info/session_attributes_provider.dart
@@ -1,5 +1,7 @@
 import 'package:faro/src/device_info/device_id_provider.dart';
 import 'package:faro/src/device_info/device_info_provider.dart';
+import 'package:faro/src/models/device_id.dart';
+import 'package:faro/src/models/device_info.dart';
 
 class SessionAttributesProvider {
   SessionAttributesProvider({
@@ -11,9 +13,20 @@ class SessionAttributesProvider {
   final DeviceIdProvider _deviceIdProvider;
   final DeviceInfoProvider _deviceInfoProvider;
 
-  Future<Map<String, Object>> getAttributes() async {
-    final deviceId = await _deviceIdProvider.getDeviceId();
-    final deviceInfo = await _deviceInfoProvider.getDeviceInfo();
+  Future<DeviceId> getDeviceId() {
+    return _deviceIdProvider.getDeviceId();
+  }
+
+  Future<DeviceInfo> getDeviceInfo() {
+    return _deviceInfoProvider.getDeviceInfo();
+  }
+
+  Future<Map<String, Object>> getAttributes({
+    DeviceId? deviceId,
+    DeviceInfo? deviceInfo,
+  }) async {
+    deviceId ??= await getDeviceId();
+    deviceInfo ??= await getDeviceInfo();
 
     final attributes = <String, Object>{
       'dart_version': deviceInfo.dartVersion,

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -155,10 +155,16 @@ class Faro {
     final attributesProvider = await SessionAttributesProviderFactory()
         .create();
     final customAttributes = optionsConfiguration.sessionAttributes ?? {};
-    final defaultAttributes = await attributesProvider.getAttributes();
+    final deviceInfo = await attributesProvider.getDeviceInfo();
+    final deviceId = await attributesProvider.getDeviceId();
+    final defaultAttributes = await attributesProvider.getAttributes(
+      deviceId: deviceId,
+      deviceInfo: deviceInfo,
+    );
     // Merge custom attributes first, then default attributes
     // Default attributes take precedence if there are conflicts
     meta.session?.attributes = {...customAttributes, ...defaultAttributes};
+    _setDeviceAndOsMeta(deviceInfo);
 
     _nativeChannel ??= FaroNativeMethods();
     config = optionsConfiguration;
@@ -184,6 +190,7 @@ class Faro {
       appEnv: optionsConfiguration.appEnv,
       appVersion: appVersion,
       namespace: optionsConfiguration.namespace ?? '',
+      installationId: '$deviceId',
     );
 
     // Make sampling decision (once per session)
@@ -268,18 +275,40 @@ class Faro {
     required String appEnv,
     required String appVersion,
     required String? namespace,
+    String? installationId,
   }) {
     final appMeta = App(
       name: appName,
       environment: appEnv,
       version: appVersion,
       namespace: namespace,
+      installationId: installationId ?? _instance.meta.app?.installationId,
     );
     _instance.meta = Meta.fromJson({
       ..._instance.meta.toJson(),
       'app': appMeta.toJson(),
     });
     _instance._batchTransport?.updatePayloadMeta(_instance.meta);
+  }
+
+  void _setDeviceAndOsMeta(DeviceInfo deviceInfo) {
+    _instance.meta = Meta.fromJson({
+      ..._instance.meta.toJson(),
+      'device': Device(
+        manufacturer: deviceInfo.deviceManufacturer,
+        modelIdentifier: deviceInfo.deviceModel,
+        modelName: deviceInfo.deviceModelName,
+        brand: deviceInfo.deviceBrand,
+        isPhysical: deviceInfo.deviceIsPhysical,
+        type: deviceInfo.deviceType,
+      ).toJson(),
+      'os': Os(
+        name: deviceInfo.deviceOs,
+        version: deviceInfo.deviceOsVersion,
+        buildId: deviceInfo.deviceOsBuildId,
+        detail: deviceInfo.deviceOsDetail,
+      ).toJson(),
+    });
   }
 
   void _tearDownForReset() {
@@ -410,6 +439,7 @@ class Faro {
     required String value,
     StackTrace? stacktrace,
     Map<String, String>? context,
+    bool fatal = false,
   }) {
     var parsedStackTrace = <String, dynamic>{};
     if (stacktrace != null) {
@@ -421,6 +451,7 @@ class Faro {
       value,
       parsedStackTrace,
       context: context,
+      fatal: fatal,
     );
     _telemetryRouter.ingest(TelemetryItem.fromException(faroException));
   }
@@ -807,6 +838,7 @@ class Faro {
             _instance.pushError(
               type: 'crash',
               value: '$reason , status: $status',
+              fatal: true,
               context: {
                 'description': description,
                 'stacktrace': stacktrace,

--- a/lib/src/integrations/native_integration.dart
+++ b/lib/src/integrations/native_integration.dart
@@ -147,6 +147,7 @@ class NativeIntegration {
               type: 'flutter_error',
               value: 'ANR (Application Not Responding)',
               context: {'stacktrace': anrJson['stacktrace']},
+              fatal: true,
             );
           }
         } catch (_) {}

--- a/lib/src/models/app.dart
+++ b/lib/src/models/app.dart
@@ -1,16 +1,24 @@
 class App {
-  App({this.name, this.environment, this.version, this.namespace});
+  App({
+    this.name,
+    this.environment,
+    this.version,
+    this.namespace,
+    this.installationId,
+  });
 
   App.fromJson(dynamic json) {
     name = json['name'];
     version = json['version'];
     environment = json['environment'];
     namespace = json['namespace'];
+    installationId = json['installationId'];
   }
   String? name;
   String? version;
   String? environment;
   String? namespace;
+  String? installationId;
 
   Map<String, dynamic> toJson() {
     final map = <String, dynamic>{};
@@ -19,6 +27,7 @@ class App {
     map['version'] = version;
     map['environment'] = environment;
     map['namespace'] = namespace;
+    map['installationId'] = installationId;
 
     return map;
   }

--- a/lib/src/models/device.dart
+++ b/lib/src/models/device.dart
@@ -1,0 +1,49 @@
+class Device {
+  Device({
+    this.manufacturer,
+    this.modelIdentifier,
+    this.modelName,
+    this.brand,
+    this.isPhysical,
+    this.type,
+  });
+
+  Device.fromJson(dynamic json) {
+    manufacturer = json['manufacturer'];
+    modelIdentifier = json['model_identifier'];
+    modelName = json['model_name'];
+    brand = json['brand'];
+    isPhysical = json['is_physical'];
+    type = json['type'];
+  }
+
+  String? manufacturer;
+  String? modelIdentifier;
+  String? modelName;
+  String? brand;
+  bool? isPhysical;
+  String? type;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (manufacturer != null) {
+      map['manufacturer'] = manufacturer;
+    }
+    if (modelIdentifier != null) {
+      map['model_identifier'] = modelIdentifier;
+    }
+    if (modelName != null) {
+      map['model_name'] = modelName;
+    }
+    if (brand != null) {
+      map['brand'] = brand;
+    }
+    if (isPhysical != null) {
+      map['is_physical'] = isPhysical;
+    }
+    if (type != null) {
+      map['type'] = type;
+    }
+    return map;
+  }
+}

--- a/lib/src/models/device_info.dart
+++ b/lib/src/models/device_info.dart
@@ -10,6 +10,8 @@ class DeviceInfo {
     required this.deviceModelName,
     required this.deviceBrand,
     required this.deviceIsPhysical,
+    this.deviceOsBuildId,
+    this.deviceType,
   });
 
   /// The Dart runtime version.
@@ -34,6 +36,9 @@ class DeviceInfo {
   /// - iOS: "iOS 17.0", "iPadOS 18.1"
   /// - Android: "Android 14 (SDK 34)"
   final String deviceOsDetail;
+
+  /// The operating system build identifier, when available.
+  final String? deviceOsBuildId;
 
   /// The device manufacturer.
   ///
@@ -62,4 +67,7 @@ class DeviceInfo {
 
   /// Whether the device is a physical device or an emulator/simulator.
   final bool deviceIsPhysical;
+
+  /// Device form factor, when known.
+  final String? deviceType;
 }

--- a/lib/src/models/exception.dart
+++ b/lib/src/models/exception.dart
@@ -31,12 +31,19 @@ class StackFrames {
 
 class FaroException {
   /// Create a FaroException with specified type, value, and optional stacktrace and context
-  FaroException(this.type, this.value, this.stacktrace, {this.context});
+  FaroException(
+    this.type,
+    this.value,
+    this.stacktrace, {
+    this.context,
+    this.fatal = false,
+  });
 
   FaroException.fromJson(dynamic json) {
     type = json['type'];
     value = json['value'];
     timestamp = json['timestamp'];
+    fatal = json['fatal'] == true;
 
     // Safely handle stacktrace - maintain as Map<String, dynamic>
     if (json['stacktrace'] != null && json['stacktrace'] is Map) {
@@ -101,6 +108,7 @@ class FaroException {
   Map<String, dynamic>? stacktrace;
   String trace = '';
   Map<String, String>? context;
+  bool fatal = false;
   UserActionContext? action;
   String timestamp = DateTime.now().toUtc().toIso8601String();
 
@@ -110,6 +118,7 @@ class FaroException {
     map['type'] = type;
     map['value'] = value;
     map['timestamp'] = timestamp;
+    map['fatal'] = fatal;
     if (stacktrace != null) {
       map['stacktrace'] = stacktrace;
     }

--- a/lib/src/models/meta.dart
+++ b/lib/src/models/meta.dart
@@ -1,6 +1,8 @@
 import 'package:faro/src/models/app.dart';
 import 'package:faro/src/models/browser.dart';
+import 'package:faro/src/models/device.dart';
 import 'package:faro/src/models/faro_user.dart';
+import 'package:faro/src/models/os.dart';
 import 'package:faro/src/models/page.dart';
 import 'package:faro/src/models/sdk.dart';
 import 'package:faro/src/models/session.dart';
@@ -15,6 +17,8 @@ class Meta {
     this.browser,
     this.page,
     this.user,
+    this.device,
+    this.os,
   });
 
   Meta.fromJson(dynamic json) {
@@ -29,6 +33,8 @@ class Meta {
         : null;
     page = json['page'] != null ? Page.fromJson(json['page']) : null;
     user = json['user'] != null ? FaroUser.fromJson(json['user']) : null;
+    device = json['device'] != null ? Device.fromJson(json['device']) : null;
+    os = json['os'] != null ? Os.fromJson(json['os']) : null;
   }
   Session? session;
   Sdk? sdk;
@@ -37,6 +43,8 @@ class Meta {
   Browser? browser;
   Page? page;
   FaroUser? user;
+  Device? device;
+  Os? os;
 
   Map<String, dynamic> toJson() {
     final map = <String, dynamic>{};
@@ -60,6 +68,12 @@ class Meta {
     }
     if (user != null) {
       map['user'] = user!.toJson();
+    }
+    if (device != null) {
+      map['device'] = device!.toJson();
+    }
+    if (os != null) {
+      map['os'] = os!.toJson();
     }
     return map;
   }
@@ -88,6 +102,12 @@ class Meta {
     }
     if (user != null) {
       map['user'] = user!.toJson();
+    }
+    if (device != null) {
+      map['device'] = device!.toJson();
+    }
+    if (os != null) {
+      map['os'] = os!.toJson();
     }
     return map;
   }

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -1,5 +1,6 @@
 export './app.dart';
 export './browser.dart';
+export './device.dart';
 export './device_id.dart';
 export './device_info.dart';
 export './event.dart';
@@ -9,6 +10,7 @@ export './log.dart';
 export './log_level.dart';
 export './measurement.dart';
 export './meta.dart';
+export './os.dart';
 export './page.dart';
 export './payload.dart';
 export './sdk.dart';

--- a/lib/src/models/os.dart
+++ b/lib/src/models/os.dart
@@ -1,0 +1,32 @@
+class Os {
+  Os({this.name, this.version, this.buildId, this.detail});
+
+  Os.fromJson(dynamic json) {
+    name = json['name'];
+    version = json['version'];
+    buildId = json['build_id'];
+    detail = json['detail'];
+  }
+
+  String? name;
+  String? version;
+  String? buildId;
+  String? detail;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (name != null) {
+      map['name'] = name;
+    }
+    if (version != null) {
+      map['version'] = version;
+    }
+    if (buildId != null) {
+      map['build_id'] = buildId;
+    }
+    if (detail != null) {
+      map['detail'] = detail;
+    }
+    return map;
+  }
+}

--- a/test/src/device_info/device_info_provider_test.dart
+++ b/test/src/device_info/device_info_provider_test.dart
@@ -63,6 +63,7 @@ void main() {
       when(
         () => mockAndroidDeviceInfo.version,
       ).thenReturn(mockAndroidBuildVersion);
+      when(() => mockAndroidDeviceInfo.id).thenReturn('RQ3A');
       when(() => mockAndroidDeviceInfo.manufacturer).thenReturn('Google');
       when(() => mockAndroidDeviceInfo.model).thenReturn('Pixel 4');
       when(() => mockAndroidDeviceInfo.brand).thenReturn('Google');
@@ -73,12 +74,14 @@ void main() {
       expect(deviceInfo.dartVersion, 'Some-dart-version');
       expect(deviceInfo.deviceOs, 'Android');
       expect(deviceInfo.deviceOsVersion, '11');
+      expect(deviceInfo.deviceOsBuildId, 'RQ3A');
       expect(deviceInfo.deviceOsDetail, 'Android 11 (SDK 30)');
       expect(deviceInfo.deviceManufacturer, 'Google');
       expect(deviceInfo.deviceModel, 'Pixel 4');
       expect(deviceInfo.deviceModelName, 'Pixel 4');
       expect(deviceInfo.deviceBrand, 'Google');
       expect(deviceInfo.deviceIsPhysical, true);
+      expect(deviceInfo.deviceType, isNull);
     });
 
     test('should return correct device info for iOS', () async {
@@ -101,13 +104,37 @@ void main() {
       expect(deviceInfo.dartVersion, 'Some-dart-version');
       expect(deviceInfo.deviceOs, 'iOS');
       expect(deviceInfo.deviceOsVersion, '14.4');
+      expect(deviceInfo.deviceOsBuildId, isNull);
       expect(deviceInfo.deviceOsDetail, 'iOS 14.4');
       expect(deviceInfo.deviceManufacturer, 'apple');
       expect(deviceInfo.deviceModel, 'iPhone12,1');
       expect(deviceInfo.deviceModelName, 'iPhone 11');
       expect(deviceInfo.deviceBrand, 'iPhone');
       expect(deviceInfo.deviceIsPhysical, true);
+      expect(deviceInfo.deviceType, 'mobile');
     });
+
+    for (final model in ['iPad', 'iPad Simulator']) {
+      test('should classify $model as tablet', () async {
+        when(() => mockPlatformInfoProvider.isAndroid).thenReturn(false);
+        when(() => mockPlatformInfoProvider.isIOS).thenReturn(true);
+
+        when(() => mockIosDeviceInfo.systemName).thenReturn('iOS');
+        when(() => mockIosDeviceInfo.systemVersion).thenReturn('18.1');
+
+        final mockIosUtsname = MockIosUtsname();
+        when(() => mockIosUtsname.machine).thenReturn('iPad14,3');
+
+        when(() => mockIosDeviceInfo.utsname).thenReturn(mockIosUtsname);
+        when(() => mockIosDeviceInfo.model).thenReturn(model);
+        when(() => mockIosDeviceInfo.modelName).thenReturn('iPad Pro');
+        when(() => mockIosDeviceInfo.isPhysicalDevice).thenReturn(true);
+
+        final deviceInfo = await sut.getDeviceInfo();
+
+        expect(deviceInfo.deviceType, 'tablet');
+      });
+    }
 
     test(
       'should return correct device info when not iOS and not Android',
@@ -120,12 +147,14 @@ void main() {
         expect(deviceInfo.dartVersion, 'Some-dart-version');
         expect(deviceInfo.deviceOs, 'Some-OS');
         expect(deviceInfo.deviceOsVersion, 'Some-OS-version');
+        expect(deviceInfo.deviceOsBuildId, isNull);
         expect(deviceInfo.deviceOsDetail, 'unknown');
         expect(deviceInfo.deviceManufacturer, 'unknown');
         expect(deviceInfo.deviceModel, 'unknown');
         expect(deviceInfo.deviceModelName, 'unknown');
         expect(deviceInfo.deviceBrand, 'unknown');
         expect(deviceInfo.deviceIsPhysical, true);
+        expect(deviceInfo.deviceType, isNull);
       },
     );
   });

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -108,6 +108,9 @@ void main() {
 
     test('init called with no error', () async {
       TestWidgetsFlutterBinding.ensureInitialized();
+      SharedPreferences.setMockInitialValues({
+        'device_id': 'test-installation-id',
+      });
       final rumConfig = FaroConfig(
         appName: appName,
         appVersion: appVersion,
@@ -125,6 +128,19 @@ void main() {
       expect(app?.name, rumConfig.appName);
       expect(app?.version, rumConfig.appVersion);
       expect(app?.environment, rumConfig.appEnv);
+      expect(app?.installationId, 'test-installation-id');
+      expect(Faro().meta.device?.manufacturer, isNotNull);
+      expect(Faro().meta.device?.modelIdentifier, isNotNull);
+      expect(Faro().meta.device?.modelName, isNotNull);
+      expect(Faro().meta.device?.brand, isNotNull);
+      expect(Faro().meta.device?.isPhysical, isNotNull);
+      expect(Faro().meta.os?.name, isNotNull);
+      expect(Faro().meta.os?.version, isNotNull);
+      expect(Faro().meta.os?.detail, isNotNull);
+      expect(
+        Faro().meta.session?.attributes?['device_id'],
+        'test-installation-id',
+      );
       verify(() => mockBatchTransport.addEvent(any())).called(1);
     });
 
@@ -223,6 +239,26 @@ void main() {
       expect(Faro().meta.app?.version, appVersion);
     });
 
+    test('set App Meta data preserves installationId', () {
+      Faro().setAppMeta(
+        appName: appName,
+        appEnv: appEnv,
+        appVersion: appVersion,
+        namespace: appNamespace,
+        installationId: 'install-id',
+      );
+
+      Faro().setAppMeta(
+        appName: 'UpdatedApp',
+        appEnv: appEnv,
+        appVersion: appVersion,
+        namespace: appNamespace,
+      );
+
+      expect(Faro().meta.app?.name, 'UpdatedApp');
+      expect(Faro().meta.app?.installationId, 'install-id');
+    });
+
     test('set user meta data ', () async {
       await Faro().init(
         optionsConfiguration: FaroConfig(
@@ -302,7 +338,22 @@ void main() {
         value: flutterErrorDetails.exception.toString(),
         stacktrace: flutterErrorDetails.stack,
       );
-      verify(() => mockBatchTransport.addExceptions(any())).called(1);
+      final capturedException =
+          verify(
+                () => mockBatchTransport.addExceptions(captureAny()),
+              ).captured.single
+              as FaroException;
+      expect(capturedException.fatal, isFalse);
+    });
+
+    test('send fatal Error Logs', () {
+      Faro().pushError(type: 'crash', value: 'Native crash', fatal: true);
+      final capturedException =
+          verify(
+                () => mockBatchTransport.addExceptions(captureAny()),
+              ).captured.single
+              as FaroException;
+      expect(capturedException.fatal, isTrue);
     });
 
     test('send custom measurement', () {

--- a/test/src/models/exception_test.dart
+++ b/test/src/models/exception_test.dart
@@ -20,7 +20,20 @@ void main() {
       expect(exception.stacktrace, isA<Map<String, dynamic>>());
       expect(exception.context, isA<Map<String, String>>());
       expect(exception.context!['key'], equals('value'));
+      expect(exception.fatal, isFalse);
       expect(exception.timestamp, isNotNull);
+    });
+
+    test('should create a fatal FaroException', () {
+      final exception = FaroException(
+        'crash',
+        'App crashed',
+        null,
+        fatal: true,
+      );
+
+      expect(exception.fatal, isTrue);
+      expect(exception.toJson()['fatal'], isTrue);
     });
 
     test('should create a FaroException with null stacktrace', () {
@@ -57,6 +70,7 @@ void main() {
         'value': 'Error message',
         'stacktrace': {'frames': '[]'},
         'timestamp': '2023-01-01T12:00:00.000Z',
+        'fatal': true,
         'context': {'key': 'value'},
       };
 
@@ -67,6 +81,7 @@ void main() {
       expect(exception.stacktrace, isA<Map<String, dynamic>>());
       expect(exception.context, isA<Map<String, String>>());
       expect(exception.context!['key'], equals('value'));
+      expect(exception.fatal, isTrue);
       expect(exception.timestamp, equals('2023-01-01T12:00:00.000Z'));
     });
 
@@ -211,6 +226,7 @@ void main() {
 
       expect(json['type'], equals('error_type'));
       expect(json['value'], equals('Error message'));
+      expect(json['fatal'], isFalse);
       expect(json['stacktrace'], isA<Map<String, dynamic>>());
       expect(json['context'], isA<Map<String, String>>());
       expect(encoded, isNotNull);

--- a/test/src/models/mobile_meta_test.dart
+++ b/test/src/models/mobile_meta_test.dart
@@ -1,0 +1,118 @@
+import 'package:faro/src/models/models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Mobile meta models:', () {
+    test('Device serializes to Faro spec field names', () {
+      final device = Device(
+        manufacturer: 'apple',
+        modelIdentifier: 'iPhone16,1',
+        modelName: 'iPhone 15 Pro',
+        brand: 'iPhone',
+        isPhysical: true,
+        type: 'mobile',
+      );
+
+      expect(device.toJson(), {
+        'manufacturer': 'apple',
+        'model_identifier': 'iPhone16,1',
+        'model_name': 'iPhone 15 Pro',
+        'brand': 'iPhone',
+        'is_physical': true,
+        'type': 'mobile',
+      });
+    });
+
+    test('Os serializes to Faro spec field names', () {
+      final os = Os(
+        name: 'iOS',
+        version: '18.1',
+        buildId: '22B83',
+        detail: 'iOS 18.1',
+      );
+
+      expect(os.toJson(), {
+        'name': 'iOS',
+        'version': '18.1',
+        'build_id': '22B83',
+        'detail': 'iOS 18.1',
+      });
+    });
+
+    test('App serializes installationId', () {
+      final app = App(
+        name: 'QuickPizza',
+        version: '1.0.0',
+        environment: 'prod',
+        namespace: 'flutter',
+        installationId: 'install-id',
+      );
+
+      expect(app.toJson()['installationId'], 'install-id');
+    });
+
+    test('Meta includes structured device and OS fields', () {
+      final meta = Meta(
+        device: Device(
+          manufacturer: 'Google',
+          modelIdentifier: 'Pixel 8',
+          modelName: 'Pixel 8',
+          brand: 'google',
+          isPhysical: false,
+          type: 'mobile',
+        ),
+        os: Os(
+          name: 'Android',
+          version: '15',
+          buildId: 'BP1A',
+          detail: 'Android 15 (SDK 35)',
+        ),
+      );
+
+      expect(meta.toJson()['device']['model_identifier'], 'Pixel 8');
+      expect(meta.toJson()['os']['build_id'], 'BP1A');
+    });
+
+    test(
+      'Payload serializes structured mobile meta with legacy attributes',
+      () {
+        final payload = Payload(
+          Meta(
+            app: App(name: 'QuickPizza', installationId: 'install-id'),
+            session: Session(
+              'session-id',
+              attributes: {'device_id': 'install-id'},
+            ),
+            device: Device(
+              manufacturer: 'apple',
+              modelIdentifier: 'iPad14,3',
+              modelName: 'iPad Pro',
+              brand: 'iPad',
+              isPhysical: false,
+              type: 'tablet',
+            ),
+            os: Os(name: 'iOS', version: '18.1', detail: 'iOS 18.1'),
+          ),
+        );
+
+        final meta = payload.toJson()['meta'];
+
+        expect(meta['app']['installationId'], 'install-id');
+        expect(meta['session']['attributes']['device_id'], 'install-id');
+        expect(meta['device'], {
+          'manufacturer': 'apple',
+          'model_identifier': 'iPad14,3',
+          'model_name': 'iPad Pro',
+          'brand': 'iPad',
+          'is_physical': false,
+          'type': 'tablet',
+        });
+        expect(meta['os'], {
+          'name': 'iOS',
+          'version': '18.1',
+          'detail': 'iOS 18.1',
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

Populates the new structured Faro mobile payload fields from the existing Flutter SDK device/app/error sources:

- `meta.device`
- `meta.os`
- `meta.app.installationId`
- `exception.fatal`

The old flat `session.attributes` values are kept for migration compatibility. Once collector/plugin parity is confirmed and downstream queries have moved to the structured fields, the duplicated flat mobile device/OS fields can be removed in a follow-up release.

## Related Issue(s)

Fixes #221  
Related to grafana/app-o11y-kwl#3504

## Type of Change

- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Screenshots / Payload Proof

Captured from a real example-app run against a local collector:

<img width="1180" height="1220" alt="Faro Flutter payload proof" src="https://github.com/user-attachments/assets/1baa8542-ea00-4e6c-838e-99b3b19e9544" />

## Tests

Validated locally with:

- `dart format --set-exit-if-changed lib test`
- `git diff --check`
- `flutter analyze`
- `flutter test` (`622` tests passed)

Test coverage added/updated for:

- structured `meta.device` / `meta.os` serialization using Faro spec field names
- `meta.app.installationId` serialization
- payload serialization with both structured fields and legacy `session.attributes`
- Android/iOS device info mapping, including iPad/iPad Simulator tablet detection
- `exception.fatal` defaulting to `false`
- native crash / explicit fatal error path setting `fatal = true`
- `setAppMeta` preserving the generated installation id

Sample app verification:

- Ran the Flutter example app on Android emulator against a local test collector.
- Captured 28 real Faro POST payloads.
- Verified outbound payloads include `meta.app.installationId`, `meta.device`, `meta.os`, and legacy flat `session.attributes.device_*` fields.
- Triggered the example app diagnostics flow with “Throw Exception” and verified the emitted exception payload includes `fatal: false`.

## Additional Notes

A few implementation choices worth calling out for review:

- `app.installationId` reuses the SDK’s existing persisted install/device id.
- Legacy flat `session.attributes` are intentionally kept for migration compatibility.
- Android `device.type` is omitted instead of guessed because the current source does not reliably distinguish phones from tablets.
- iOS `os.build_id` is omitted because `device_info_plus` does not expose the real iOS build id; sending the kernel string would be misleading.
- Android native crashes, iOS PLCrashReporter crashes, and ANRs set `exception.fatal = true`; handled Flutter/Dart errors remain non-fatal.
