### PR TITLE
fix(ios): preserve stack frames in native crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parsed into structured frames (e.g. sanitized, obfuscated, or free-form
   lines) are now kept as raw text in the frame's `function` field.
   ([#102](https://github.com/grafana/faro-flutter-sdk/issues/102))
+- iOS native crash reports no longer lose all stack frames: a broken
+  work-in-progress sanitization step in `CrashReportingIntegration`
+  unconditionally replaced non-empty stack traces with an empty array
+  before export. The dead sanitization has been removed so frames flow
+  through to the exported crash payload. Load/parse failures of pending
+  crash reports are now logged with a clearer message before the report
+  is purged. ([#220](https://github.com/grafana/faro-flutter-sdk/issues/220))
 
 ## [0.16.0] - 2026-05-11
 

--- a/example/android/app/src/main/java/com/example/rum_sdk_example/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/rum_sdk_example/MainActivity.java
@@ -1,6 +1,27 @@
 package com.grafana.faro_example;
 
+import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.plugin.common.MethodChannel;
 
 public class MainActivity extends FlutterActivity {
+    private static final String CHANNEL = "faro_example/crash";
+
+    @Override
+    public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+        super.configureFlutterEngine(flutterEngine);
+        new MethodChannel(
+                flutterEngine.getDartExecutor().getBinaryMessenger(), CHANNEL)
+                .setMethodCallHandler((call, result) -> {
+                    if (call.method.equals("crashNative")) {
+                        // Intentional native crash for validating crash
+                        // reporting: dereference a null on the main thread.
+                        String value = null;
+                        value.length();
+                    } else {
+                        result.notImplemented();
+                    }
+                });
+    }
 }

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -3,6 +3,8 @@ import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  private var crashChannel: FlutterMethodChannel?
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -12,5 +14,27 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "FaroExampleCrash") {
+      let channel = FlutterMethodChannel(
+        name: "faro_example/crash",
+        binaryMessenger: registrar.messenger()
+      )
+      channel.setMethodCallHandler { (call, _) in
+        if call.method == "crashNative" {
+          // Intentional native crash for validating crash reporting:
+          // force-unwrap a value that is nil at runtime.
+          let value = AppDelegate.alwaysNil()
+          print(value!)
+        }
+      }
+      self.crashChannel = channel
+    }
+  }
+
+  // Returns nil, but the compiler cannot prove it, so the force-unwrap at
+  // the call site traps at runtime instead of being a compile-time error.
+  private static func alwaysNil() -> String? {
+    return nil
   }
 }

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -20,12 +20,14 @@ import UIKit
         name: "faro_example/crash",
         binaryMessenger: registrar.messenger()
       )
-      channel.setMethodCallHandler { (call, _) in
+      channel.setMethodCallHandler { (call, result) in
         if call.method == "crashNative" {
           // Intentional native crash for validating crash reporting:
           // force-unwrap a value that is nil at runtime.
           let value = AppDelegate.alwaysNil()
           print(value!)
+        } else {
+          result(FlutterMethodNotImplemented)
         }
       }
       self.crashChannel = channel

--- a/example/lib/features/app_diagnostics/domain/app_diagnostics_demo_service.dart
+++ b/example/lib/features/app_diagnostics/domain/app_diagnostics_demo_service.dart
@@ -1,5 +1,6 @@
 import 'package:faro/faro.dart';
 import 'package:faro_example/shared/models/demo_log_entry.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 typedef AppDiagnosticsLogCallback =
@@ -12,6 +13,26 @@ final appDiagnosticsDemoServiceProvider = Provider<AppDiagnosticsDemoService>(
 /// Runs the error and ANR demos shown in the example app.
 class AppDiagnosticsDemoService {
   const AppDiagnosticsDemoService();
+
+  static const MethodChannel _crashChannel = MethodChannel(
+    'faro_example/crash',
+  );
+
+  /// Triggers a native crash (force-unwrap of nil on iOS, null dereference
+  /// on Android) to validate the SDK's native crash reporting. The process
+  /// terminates; the crash is reported on the next launch.
+  Future<void> triggerNativeCrash(AppDiagnosticsLogCallback log) async {
+    log(
+      'Triggering a native crash. The app will terminate; relaunch to '
+      'let the SDK report it.',
+      tone: DemoLogTone.warning,
+    );
+
+    // Yield so the warning can paint before the process dies.
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    await _crashChannel.invokeMethod<void>('crashNative');
+  }
 
   void triggerUnhandledError(AppDiagnosticsLogCallback log) {
     log(

--- a/example/lib/features/app_diagnostics/presentation/app_diagnostics_page.dart
+++ b/example/lib/features/app_diagnostics/presentation/app_diagnostics_page.dart
@@ -93,6 +93,12 @@ class AppDiagnosticsPage extends ConsumerWidget {
                       isRunning: uiState.isRunning,
                       onPressed: () => actions.simulateAnr(10),
                     ),
+                    _DiagnosticsButton(
+                      label: 'Native Crash',
+                      icon: Icons.dangerous,
+                      isRunning: uiState.isRunning,
+                      onPressed: actions.triggerNativeCrash,
+                    ),
                   ],
                 ),
               ],

--- a/example/lib/features/app_diagnostics/presentation/app_diagnostics_page_view_model.dart
+++ b/example/lib/features/app_diagnostics/presentation/app_diagnostics_page_view_model.dart
@@ -31,6 +31,7 @@ abstract interface class AppDiagnosticsPageActions {
   void triggerUnhandledException();
   void pushCustomTraceError();
   Future<void> simulateAnr(int seconds);
+  Future<void> triggerNativeCrash();
 }
 
 class _AppDiagnosticsPageViewModel extends Notifier<AppDiagnosticsPageUiState>
@@ -81,6 +82,11 @@ class _AppDiagnosticsPageViewModel extends Notifier<AppDiagnosticsPageUiState>
     } finally {
       state = state.copyWith(isRunning: false);
     }
+  }
+
+  @override
+  Future<void> triggerNativeCrash() async {
+    await _service.triggerNativeCrash(_addLog);
   }
 }
 

--- a/ios/faro/Sources/faro/CrashReportingIntegration.swift
+++ b/ios/faro/Sources/faro/CrashReportingIntegration.swift
@@ -39,10 +39,16 @@ class  CrashReportingIntegration {
                 // format crash report to send to grafana / send to separate storage
                 sendCrashReport(crash: exporter.export(crashReport: crashReport), config: crashReporterConfig)
             } catch let error {
-                print("CrashReporter failed to load and parse with error: \(error)")
+                // The pending report is purged below even on failure, so a
+                // corrupt report cannot cause repeated failures on every
+                // launch — but it also means this crash report is lost.
+                print(
+                    "Faro CrashReportingIntegration: failed to load/parse " +
+                    "pending crash report; discarding it. Error: \(error)"
+                )
             }
         }
-        
+
         crashReporter.purgePendingCrashReport()
         
     }
@@ -297,8 +303,8 @@ internal struct CrashReportExporter{
         guard let stackFrames = mostMeaningfulStackFrames else {
             return []
         }
-        
-        return sanitized(stackFrames: stackFrames).map { stackframe in
+
+        return stackFrames.map { stackframe in
             return stackframe.jsonRepresentation
         }
     }
@@ -323,18 +329,6 @@ internal struct CrashReportExporter{
                 "path": \(crashReport.processInfo?.processPath ?? ""),
                 "codeType": \(cpuArchitecture ?? ""),
             """
-    }
-    
-    // MARK: - Sanitizing
-    
-    private func sanitized(stackFrames: [StackFrame]) -> [StackFrame] {
-        guard let _ = stackFrames.last else {
-            return stackFrames
-        }
-        return []
-        func asDictionary(){
-            
-        }
     }
 
 }


### PR DESCRIPTION
## Description

Fixes a bug where **every captured iOS native crash was exported with an empty
stack trace**.

`CrashReportExporter.sanitized(stackFrames:)` in `CrashReportingIntegration`
was a non-functional work-in-progress stub: for any non-empty input it
returned `[]` (and contained an unreachable, empty nested function). Since
`formattedStack(for:)` mapped `sanitized(stackFrames:)` to the exported
payload, every crash with frames lost all of them.

This PR removes the dead `sanitized` step (and its only call site), so frames
flow straight through to the exported crash payload. The catch block around
loading/parsing a pending crash report now logs a clearer message before the
report is purged.

It also adds a **"Native Crash" button** to the example app's App Diagnostics
page (force-unwrap of nil on iOS, null dereference on Android, via a method
channel) so the native crash pipeline can be exercised directly — this is how
the fix was validated (see below).

### Validation

Validated on a **real device** (iPhone 15 Pro, iOS 26.5, release build, no
debugger). Triggering the native crash and relaunching produced a crash
report carrying **18 stack frames** in `exceptions[0].stacktrace.frames`
(where the previous behavior produced 0). PLCrashReporter capture works, and
the frames are preserved by this fix.

End-to-end delivery to the collector is still blocked by a **separate**,
already-tracked issue (#269): iOS crashes are sent via an out-of-band POST
(`x-api-token` header + minimal envelope) that the collector does not ingest.
That is out of scope here; this PR makes the captured frames correct so that,
once #269 is addressed, crashes arrive with usable stack traces. Frames are
unsymbolicated raw addresses in release builds (dSYM upload is the separate
#265 work).

## Related Issue(s)

Closes #220
Related to #269, #265

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

There is no Swift unit-test harness in the repo; the fix is verified by a
real-device crash capture (18 frames) and `flutter build ios` compilation.
The example-app crash trigger follows the existing (untested) App Diagnostics
demo pattern.

## Additional Notes

The example-app change is not part of the published `faro` package, so it is
intentionally not listed in the CHANGELOG.

## Screenshot of updated example app

<img width="350" height="759" alt="IMG_9034" src="https://github.com/user-attachments/assets/42202b1a-deb0-449c-8cd5-c8d032688a92" />

