### PR TITLE
fix(exceptions): preserve stack trace lines that do not match expected format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   download the canonical archive pub.dev serves and attest those bytes via
   `actions/attest-build-provenance`. Consumers can verify with
   `gh attestation verify <tarball> --repo grafana/faro-flutter-sdk`.
+### Fixed
+
+- Preserve stack trace lines that do not match the expected Dart VM format
+  instead of silently dropping the whole stack trace. Lines that cannot be
+  parsed into structured frames (e.g. sanitized, obfuscated, or free-form
+  lines) are now kept as raw text in the frame's `function` field.
+  ([#102](https://github.com/grafana/faro-flutter-sdk/issues/102))
 
 ## [0.16.0] - 2026-05-11
 

--- a/example/lib/features/app_diagnostics/domain/app_diagnostics_demo_service.dart
+++ b/example/lib/features/app_diagnostics/domain/app_diagnostics_demo_service.dart
@@ -1,3 +1,4 @@
+import 'package:faro/faro.dart';
 import 'package:faro_example/shared/models/demo_log_entry.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -32,6 +33,30 @@ class AppDiagnosticsDemoService {
     Future<void>.delayed(const Duration(milliseconds: 10), () {
       throw Exception('This is an Exception! ${DateTime.now()}');
     });
+  }
+
+  void pushCustomTraceError(AppDiagnosticsLogCallback log) {
+    log(
+      'Pushing an error with a non-standard stack trace.',
+      tone: DemoLogTone.warning,
+    );
+
+    // A stack trace in a format Faro does not natively parse: a normal
+    // Dart frame, a token with no spaces (which previously crashed the
+    // parser), a stack_trace-package line, and a free-form note. See #102.
+    final customTrace = StackTrace.fromString(
+      '#0      MyWidget.build '
+      '(package:my_app/widgets/my_widget.dart:42:13)\n'
+      'sanitized_frame_without_spaces\n'
+      'package:my_app/foo.dart 10:5  Foo.bar\n'
+      'some free-form diagnostic note',
+    );
+
+    Faro().pushError(
+      type: 'custom_stacktrace_demo',
+      value: 'Custom-trace error ${DateTime.now()}',
+      stacktrace: customTrace,
+    );
   }
 
   Future<void> simulateAnr({

--- a/example/lib/features/app_diagnostics/presentation/app_diagnostics_page.dart
+++ b/example/lib/features/app_diagnostics/presentation/app_diagnostics_page.dart
@@ -76,6 +76,12 @@ class AppDiagnosticsPage extends ConsumerWidget {
                       onPressed: actions.triggerUnhandledException,
                     ),
                     _DiagnosticsButton(
+                      label: 'Custom-Trace Error',
+                      icon: Icons.bug_report,
+                      isRunning: uiState.isRunning,
+                      onPressed: actions.pushCustomTraceError,
+                    ),
+                    _DiagnosticsButton(
                       label: 'Simulate ANR (8s)',
                       icon: Icons.hourglass_bottom,
                       isRunning: uiState.isRunning,

--- a/example/lib/features/app_diagnostics/presentation/app_diagnostics_page_view_model.dart
+++ b/example/lib/features/app_diagnostics/presentation/app_diagnostics_page_view_model.dart
@@ -29,6 +29,7 @@ abstract interface class AppDiagnosticsPageActions {
   void clearLog();
   void triggerUnhandledError();
   void triggerUnhandledException();
+  void pushCustomTraceError();
   Future<void> simulateAnr(int seconds);
 }
 
@@ -65,6 +66,11 @@ class _AppDiagnosticsPageViewModel extends Notifier<AppDiagnosticsPageUiState>
   @override
   void triggerUnhandledException() {
     _service.triggerUnhandledException(_addLog);
+  }
+
+  @override
+  void pushCustomTraceError() {
+    _service.pushCustomTraceError(_addLog);
   }
 
   @override

--- a/lib/src/models/exception.dart
+++ b/lib/src/models/exception.dart
@@ -136,24 +136,39 @@ class FaroException {
     final stackFrames = ls.convert(stacktrace.toString());
     final parsedStackFrames = <Map<String, dynamic>>[];
     for (final stackFrame in stackFrames) {
-      final sf = stackFrame.split(' ');
-      const pattern =
-          '.*((?<module>[a-zA-Z]*):(?<filename>[a-zA-Z-_/.]*):(?<lineno>[0-9]*):(?<colno>[0-9]*)).*';
-      final regExp = RegExp(pattern);
-      final regExpMatch = regExp.firstMatch(sf[sf.length - 1]);
-      final filename =
-          "${regExpMatch?.namedGroup("module")}:${regExpMatch?.namedGroup("filename")}";
-      final lineno = regExpMatch?.namedGroup('lineno');
-      final colno = regExpMatch?.namedGroup('colno');
-      parsedStackFrames.add(
-        StackFrames(
-          filename,
-          sf[sf.length - 2],
-          int.parse(lineno ?? '0'),
-          int.parse(colno ?? '0'),
-        ).toJson(),
-      );
+      if (stackFrame.trim().isEmpty) {
+        continue;
+      }
+      parsedStackFrames.add(_parseStackFrameLine(stackFrame).toJson());
     }
     return parsedStackFrames;
+  }
+
+  /// Parses a single stack trace line into a [StackFrames] entry.
+  ///
+  /// Lines matching the expected Dart VM format (a source location such as
+  /// `package:my_app/my_file.dart:10:5` as the last token) are parsed into
+  /// structured frames. Any other line is preserved as-is in the `function`
+  /// field so that no stack trace information is silently dropped
+  /// (see issue #102).
+  static StackFrames _parseStackFrameLine(String stackFrame) {
+    const pattern =
+        '.*((?<module>[a-zA-Z]*):(?<filename>[a-zA-Z-_/.]*):(?<lineno>[0-9]*):(?<colno>[0-9]*)).*';
+    final regExp = RegExp(pattern);
+    final sf = stackFrame.split(' ');
+    final regExpMatch = regExp.firstMatch(sf[sf.length - 1]);
+    final lineno = int.tryParse(regExpMatch?.namedGroup('lineno') ?? '');
+    final colno = int.tryParse(regExpMatch?.namedGroup('colno') ?? '');
+    if (regExpMatch == null ||
+        sf.length < 2 ||
+        lineno == null ||
+        colno == null) {
+      // The line does not match the expected format. Preserve the raw line
+      // instead of dropping the information.
+      return StackFrames('', stackFrame.trim(), 0, 0);
+    }
+    final filename =
+        "${regExpMatch.namedGroup("module")}:${regExpMatch.namedGroup("filename")}";
+    return StackFrames(filename, sf[sf.length - 2], lineno, colno);
   }
 }

--- a/test/src/models/exception_test.dart
+++ b/test/src/models/exception_test.dart
@@ -265,5 +265,149 @@ void main() {
       expect(frames[0]['filename'], contains('app/file.dart'));
       expect(frames[1]['filename'], contains('app/another_file.dart'));
     });
+
+    group('stackTraceParse with non-standard formats (issue #102):', () {
+      test('should parse sanitized (trimmed) standard frames', () {
+        // Simulates a user sanitizer that trims each line before rejoining
+        // (see issue #102) - frames keep the "#N" index but lose padding.
+        final sanitizedStackTrace = StackTrace.fromString(
+          '#0 MyClass.myMethod (package:my_app/my_file.dart:10:5)\n'
+          '#1 OtherClass.otherMethod (package:my_app/other.dart:20:7)',
+        );
+
+        final frames = FaroException.stackTraceParse(sanitizedStackTrace);
+
+        expect(frames.length, equals(2));
+        expect(frames[0]['filename'], contains('my_app/my_file.dart'));
+        expect(frames[0]['function'], equals('MyClass.myMethod'));
+        expect(frames[0]['lineno'], equals(10));
+        expect(frames[0]['colno'], equals(5));
+        expect(frames[1]['filename'], contains('my_app/other.dart'));
+        expect(frames[1]['function'], equals('OtherClass.otherMethod'));
+        expect(frames[1]['lineno'], equals(20));
+        expect(frames[1]['colno'], equals(7));
+      });
+
+      test('should parse frames without a leading "#N" index', () {
+        final stackTrace = StackTrace.fromString(
+          'MyClass.myMethod (package:my_app/my_file.dart:10:5)',
+        );
+
+        final frames = FaroException.stackTraceParse(stackTrace);
+
+        expect(frames.length, equals(1));
+        expect(frames[0]['filename'], contains('my_app/my_file.dart'));
+        expect(frames[0]['function'], equals('MyClass.myMethod'));
+        expect(frames[0]['lineno'], equals(10));
+        expect(frames[0]['colno'], equals(5));
+      });
+
+      test('should preserve lines in package:stack_trace Trace format', () {
+        final stackTrace = StackTrace.fromString(
+          'package:my_app/my_file.dart 10:5  MyClass.myMethod',
+        );
+
+        final frames = FaroException.stackTraceParse(stackTrace);
+
+        expect(frames.length, equals(1));
+        expect(
+          frames[0]['function'],
+          equals('package:my_app/my_file.dart 10:5  MyClass.myMethod'),
+        );
+      });
+
+      test('should preserve free-form lines without spaces', () {
+        // A single-token line used to throw a RangeError, which dropped
+        // the entire stack trace.
+        final stackTrace = StackTrace.fromString('some-free-form-line');
+
+        final frames = FaroException.stackTraceParse(stackTrace);
+
+        expect(frames.length, equals(1));
+        expect(frames[0]['function'], equals('some-free-form-line'));
+      });
+
+      test('should preserve obfuscated release-mode android frames', () {
+        final stackTrace = StackTrace.fromString(
+          '#00 abs 0000000000043b8f virt 00000000001fdb8f '
+          '_kDartIsolateSnapshotInstructions+0x1e3b8f\n'
+          '#01 abs 0000000000043c12 virt 00000000001fdc12 '
+          '_kDartIsolateSnapshotInstructions+0x1e3c12',
+        );
+
+        final frames = FaroException.stackTraceParse(stackTrace);
+
+        expect(frames.length, equals(2));
+        expect(
+          frames[0]['function'],
+          equals(
+            '#00 abs 0000000000043b8f virt 00000000001fdb8f '
+            '_kDartIsolateSnapshotInstructions+0x1e3b8f',
+          ),
+        );
+        expect(
+          frames[1]['function'],
+          equals(
+            '#01 abs 0000000000043c12 virt 00000000001fdc12 '
+            '_kDartIsolateSnapshotInstructions+0x1e3c12',
+          ),
+        );
+      });
+
+      test('should preserve asynchronous suspension markers', () {
+        final stackTrace = StackTrace.fromString('<asynchronous suspension>');
+
+        final frames = FaroException.stackTraceParse(stackTrace);
+
+        expect(frames.length, equals(1));
+        expect(frames[0]['function'], equals('<asynchronous suspension>'));
+      });
+
+      test('should preserve frames missing a column number', () {
+        final stackTrace = StackTrace.fromString(
+          '#0      main (package:app/file.dart:10)',
+        );
+
+        final frames = FaroException.stackTraceParse(stackTrace);
+
+        expect(frames.length, equals(1));
+        expect(
+          frames[0]['function'],
+          equals('#0      main (package:app/file.dart:10)'),
+        );
+      });
+
+      test('should not drop parsable frames when mixed with free-form '
+          'lines', () {
+        final stackTrace = StackTrace.fromString(
+          '#0      SomeClass.someMethod (package:app/file.dart:10:5)\n'
+          'free-form-line\n'
+          '#1      Other.otherMethod (package:app/other_file.dart:20:10)',
+        );
+
+        final frames = FaroException.stackTraceParse(stackTrace);
+
+        expect(frames.length, equals(3));
+        expect(frames[0]['filename'], contains('app/file.dart'));
+        expect(frames[0]['function'], equals('SomeClass.someMethod'));
+        expect(frames[1]['function'], equals('free-form-line'));
+        expect(frames[2]['filename'], contains('app/other_file.dart'));
+        expect(frames[2]['function'], equals('Other.otherMethod'));
+      });
+
+      test('should skip blank lines', () {
+        final stackTrace = StackTrace.fromString(
+          '#0      SomeClass.someMethod (package:app/file.dart:10:5)\n'
+          '\n'
+          '#1      Other.otherMethod (package:app/other_file.dart:20:10)',
+        );
+
+        final frames = FaroException.stackTraceParse(stackTrace);
+
+        expect(frames.length, equals(2));
+        expect(frames[0]['function'], equals('SomeClass.someMethod'));
+        expect(frames[1]['function'], equals('Other.otherMethod'));
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

Fixes a bug where passing `pushError` a stack trace whose lines don't match
the SDK's expected format caused **all** stack frame data to be silently lost.

`FaroException.stackTraceParse` split each line on spaces and indexed
`sf[sf.length - 2]`. A line with **no space** made that index `sf[-1]`, throwing
a `RangeError` that aborted the entire parse — and since `pushError` calls
`stackTraceParse` without a try/catch, the error propagated and the whole
exception was dropped. (`int.parse` on empty regex groups could also throw, and
non-matching lines became junk `null:null` frames.)

This came up for a user who sanitized their traces (filtering framework lines,
trimming) before reporting them — producing `stack_trace`-package-format lines
the parser didn't recognize.

### Fix

Parsing is now **per-line and total** via `_parseStackFrameLine`:

- Well-formed Dart frames produce **byte-for-byte identical output** to before
  (verified against the existing happy-path tests — no regression for normal
  traces).
- Any line that can't be parsed into structured fields is **preserved** (the
  raw line becomes the frame's function) instead of crashing the parse or being
  dropped. Blank lines are skipped.

So whatever format you provide, the information is kept rather than lost.

### Validation

- **Unit tests** (144 new lines): the reporter's exact sanitized-trace case
  plus obfuscated, async-marker, `stack_trace`-format, and no-space inputs.
- **End-to-end on the Android emulator + Grafana Cloud:** added a "Custom-Trace
  Error" button to the example app's App Diagnostics page that pushes an error
  with a non-standard trace (including the no-space line that previously
  destroyed the parse). The exception arrives in Grafana with **all four lines
  preserved as frames** — confirming the fix works through real ingestion, not
  just in unit tests.

## Related Issue(s)

Closes #102

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Additional Notes

A pre-existing cosmetic quirk (the `package` module prefix renders as an empty
string before the filename's colon) is intentionally left untouched so the
happy-path output stays byte-for-byte identical; it can be a separate follow-up.

The example-app demo button is not part of the published `faro` package, so it
is intentionally not listed in the CHANGELOG.
