### PR TITLE
chore: bump version to v0.17.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-01
+
 ### Changed
 
 - Renamed the SDK-generated install identifier model and provider to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.17.0] - 2026-07-01
+## [0.17.0-beta.1] - 2026-07-01
 
 ### Changed
 
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InstallationId` / `InstallationIdProvider`. The persisted `device_id`
   storage key and legacy flat `session.attributes['device_id']` payload key are
   unchanged for migration compatibility.
+- Swapped the underlying OpenTelemetry implementation from the Workiva
+  `opentelemetry` Dart package to `dartastic_opentelemetry` for tracing.
+  ([#242](https://github.com/grafana/faro-flutter-sdk/pull/242))
 
 ### Deprecated
 
@@ -37,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   download the canonical archive pub.dev serves and attest those bytes via
   `actions/attest-build-provenance`. Consumers can verify with
   `gh attestation verify <tarball> --repo grafana/faro-flutter-sdk`.
+
 ### Fixed
 
 - Preserve stack trace lines that do not match the expected Dart VM format

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.16.0'
+version '0.17.0'
 
 buildscript {
     repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.17.0'
+version '0.17.0-beta.1'
 
 buildscript {
     repositories {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -199,7 +199,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.17.0"
+    version: "0.17.0-beta.1"
   ffi:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -199,7 +199,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.16.0"
+    version: "0.17.0"
   ffi:
     dependency: transitive
     description:

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.16.0'
+  s.version          = '0.17.0'
   s.summary          = 'Grafana Faro SDK for Flutter - mobile observability and real user monitoring.'
   s.description      = <<-DESC
 Grafana Faro SDK for Flutter applications. Monitor your Flutter app with ease

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.17.0'
+  s.version          = '0.17.0-beta.1'
   s.summary          = 'Grafana Faro SDK for Flutter - mobile observability and real user monitoring.'
   s.description      = <<-DESC
 Grafana Faro SDK for Flutter applications. Monitor your Flutter app with ease

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,7 +1,7 @@
 /// Constants for the Faro Flutter SDK
 class FaroConstants {
   /// The version of the Faro Flutter SDK
-  static const String sdkVersion = '0.17.0';
+  static const String sdkVersion = '0.17.0-beta.1';
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-mobile-flutter';

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,7 +1,7 @@
 /// Constants for the Faro Flutter SDK
 class FaroConstants {
   /// The version of the Faro Flutter SDK
-  static const String sdkVersion = '0.16.0';
+  static const String sdkVersion = '0.17.0';
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-mobile-flutter';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.16.0
+version: 0.17.0
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.17.0
+version: 0.17.0-beta.1
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   connectivity_plus: ">=6.1.2 <8.0.0"
-  dartastic_opentelemetry: 1.1.0-beta.5
+  dartastic_opentelemetry: ">=1.1.0-beta.5 <1.2.0"
   dartypod: ^0.2.0
   device_info_plus: ">=12.3.0 <14.0.0"
   equatable: ^2.0.8


### PR DESCRIPTION
## Summary

Release `0.17.0-beta.1`.

- **Version bump** to `0.17.0-beta.1` across `pubspec.yaml`, `ios/faro.podspec`, `android/build.gradle`, and `lib/src/util/constants.dart`; CHANGELOG `[Unreleased]` promoted to `[0.17.0-beta.1]`.
- **Published as a pre-release** because the SDK now depends on `dartastic_opentelemetry`, whose `1.x` line is beta-only on pub.dev (latest stable is `0.9.5`). pub.dev flags a stable package depending on a pre-release, which fails the publish dry-run gate — so `0.17.0` ships as `0.17.0-beta.1`. Constraint bounded to `">=1.1.0-beta.5 <1.2.0"`.
- **CHANGELOG**: added the missing entry for the OpenTelemetry backend swap (Workiva `opentelemetry` → `dartastic_opentelemetry`, #242).

`flutter pub publish --dry-run` passes with 0 warnings; tests, analyzer, formatting, and Android native unit tests pass.

_PR description authored by Claude on Domas's behalf._