### PR TITLE
fix(tool): support pre-release versions in create_release

### DIFF
--- a/test/tool/create_release_test.dart
+++ b/test/tool/create_release_test.dart
@@ -90,6 +90,74 @@ void main() {
       expect(extracted, startsWith('### Added'));
       expect(extracted, endsWith('- Feature X'));
     });
+
+    test('extracts content for a pre-release version', () {
+      final content = _joinLines([
+        '# Changelog',
+        '',
+        '## [Unreleased]',
+        '',
+        '## [0.17.0-beta.1] - 2026-07-01',
+        '',
+        '### Changed',
+        '- Beta change',
+        '',
+        '## [0.16.0] - 2026-05-11',
+        '- Stable stuff',
+      ]);
+
+      final extracted = extractChangelogForVersion(content, '0.17.0-beta.1');
+
+      expect(extracted, contains('- Beta change'));
+      expect(extracted, isNot(contains('- Stable stuff')));
+    });
+  });
+
+  group('parseVersion:', () {
+    test('parses a plain major.minor.patch version', () {
+      expect(parseVersion('version: 0.16.0'), '0.16.0');
+    });
+
+    test('preserves a pre-release identifier', () {
+      expect(parseVersion('version: 0.17.0-beta.1'), '0.17.0-beta.1');
+    });
+
+    test('preserves build metadata', () {
+      expect(parseVersion('version: 1.2.3+42'), '1.2.3+42');
+    });
+
+    test('preserves both pre-release and build metadata', () {
+      expect(parseVersion('version: 1.2.3-rc.2+42'), '1.2.3-rc.2+42');
+    });
+
+    test('reads the version line from full pubspec content', () {
+      final content = _joinLines([
+        'name: faro',
+        'description: Grafana Faro SDK for Flutter.',
+        'version: 0.17.0-beta.1',
+        'homepage: https://grafana.com',
+      ]);
+
+      expect(parseVersion(content), '0.17.0-beta.1');
+    });
+
+    test('returns null when no version line is present', () {
+      expect(parseVersion('name: faro\ndescription: no version here'), isNull);
+    });
+  });
+
+  group('isPrerelease:', () {
+    test('is false for a stable version', () {
+      expect(isPrerelease('0.17.0'), isFalse);
+    });
+
+    test('is true for a pre-release version', () {
+      expect(isPrerelease('0.17.0-beta.1'), isTrue);
+    });
+
+    test('is false for build metadata only', () {
+      expect(isPrerelease('1.2.3+42'), isFalse);
+    });
   });
 }
 

--- a/tool/create_release.dart
+++ b/tool/create_release.dart
@@ -18,12 +18,28 @@ class Colors {
 Future<String> getVersion() async {
   final file = File('pubspec.yaml');
   final content = await file.readAsString();
-  final match = RegExp(r'version:\s*(\d+\.\d+\.\d+)').firstMatch(content);
-  if (match == null) {
+  final version = parseVersion(content);
+  if (version == null) {
     throw Exception('Could not find version in pubspec.yaml');
   }
-  return match.group(1)!;
+  return version;
 }
+
+/// Parse the SemVer version string from pubspec.yaml content.
+///
+/// Captures the full version including any pre-release (`-beta.1`) and build
+/// metadata (`+42`) identifiers, so pre-release releases tag and look up their
+/// changelog correctly. Returns null when no version line is found.
+String? parseVersion(String content) {
+  final match = RegExp(
+    r'version:\s*(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)',
+  ).firstMatch(content);
+  return match?.group(1);
+}
+
+/// Whether a version string denotes a pre-release (has a `-` identifier),
+/// e.g. `0.17.0-beta.1`. Build metadata (`+42`) alone is not a pre-release.
+bool isPrerelease(String version) => version.contains('-');
 
 /// Get the previous git tag
 Future<String?> getPreviousTag() async {
@@ -153,7 +169,12 @@ Future<bool> createAndPushTag(String tag) async {
 }
 
 /// Create GitHub release using gh CLI
-Future<bool> createGitHubRelease(String tag, String title, String body) async {
+Future<bool> createGitHubRelease(
+  String tag,
+  String title,
+  String body, {
+  bool prerelease = false,
+}) async {
   final result = await Process.run('gh', [
     'release',
     'create',
@@ -162,6 +183,7 @@ Future<bool> createGitHubRelease(String tag, String title, String body) async {
     title,
     '--notes',
     body,
+    if (prerelease) '--prerelease',
   ]);
 
   if (result.exitCode != 0) {
@@ -343,10 +365,11 @@ Future<void> main(List<String> args) async {
   // Get version and create tag name
   final version = await getVersion();
   final tag = 'v$version';
+  final prerelease = isPrerelease(version);
 
   stdout.writeln(
     '${Colors.blue}📦 Creating release for '
-    'Faro Flutter SDK $tag${Colors.reset}',
+    'Faro Flutter SDK $tag${prerelease ? ' (pre-release)' : ''}${Colors.reset}',
   );
   stdout.writeln('');
 
@@ -435,7 +458,8 @@ Future<void> main(List<String> args) async {
   stdout.writeln('  ${Colors.green}•${Colors.reset} Push tag to origin');
   stdout.writeln(
     '  ${Colors.green}•${Colors.reset} Create '
-    'GitHub release with above notes',
+    'GitHub release with above notes'
+    '${prerelease ? ' (marked as pre-release)' : ''}',
   );
   stdout.writeln('');
 
@@ -470,7 +494,12 @@ Future<void> main(List<String> args) async {
   stdout.write('Creating GitHub release... ');
   final releaseTitle = 'v$version';
   try {
-    if (!await createGitHubRelease(tag, releaseTitle, releaseNotes)) {
+    if (!await createGitHubRelease(
+      tag,
+      releaseTitle,
+      releaseNotes,
+      prerelease: prerelease,
+    )) {
       stderr.writeln('');
       stderr.writeln(
         '${Colors.yellow}Tag was pushed but GitHub '


### PR DESCRIPTION
## Summary

`dart tool/create_release.dart` couldn't cut a pre-release. Its version regex captured only `\d+\.\d+\.\d+`, dropping the `-beta.1` suffix — so it built the wrong tag (`v0.17.0` instead of `v0.17.0-beta.1`) and then failed looking up the changelog section.

- [tool/create_release.dart](tool/create_release.dart) — extract a pure, tested `parseVersion` that preserves the full SemVer string (pre-release + build metadata); add `isPrerelease`.
- [tool/create_release.dart](tool/create_release.dart) — pass `--prerelease` to `gh release create` when the version has a pre-release identifier, so it isn't surfaced as "Latest".
- [test/tool/create_release_test.dart](test/tool/create_release_test.dart) — unit tests for `parseVersion`, `isPrerelease`, and pre-release changelog extraction.

Unblocks the `0.17.0-beta.1` release, which currently can't be tagged via the tool.

_PR description authored by Claude on Domas's behalf._