### PR TITLE
fix(release): retry archive download; annotate release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,31 +76,35 @@ jobs:
           NAME: ${{ steps.pkg.outputs.name }}
           VERSION: ${{ steps.pkg.outputs.version }}
         run: |
-          # pub.dev is eventually consistent — poll until the new version is
-          # queryable. Typical propagation is well under a minute, but publish
-          # is non-idempotent so it is worth waiting longer before failing.
+          # pub.dev is eventually consistent — and the version metadata surfaces
+          # *before* the published archive is downloadable, so polling only the
+          # metadata API breaks the loop too early and the archive download then
+          # 404s. publish is non-idempotent, so poll until BOTH the metadata is
+          # queryable AND the tarball actually downloads before giving up.
           api_url="https://pub.dev/api/packages/${NAME}/versions/${VERSION}"
-          archive_url=""
           expected_sha=""
+          downloaded=""
           for attempt in {1..60}; do
             response=$(curl -fsSL "$api_url" || echo "")
             archive_url=$(echo "$response" | jq -r '.archive_url // empty')
             expected_sha=$(echo "$response" | jq -r '.archive_sha256 // empty')
-            if [ -n "$archive_url" ]; then
+            # curl -f exits non-zero on the transient archive 404; guarding it in
+            # the `if` keeps `set -e` from killing the step so we retry instead.
+            if [ -n "$archive_url" ] && curl -fsSL -o package.tar.gz "$archive_url"; then
+              downloaded="yes"
               break
             fi
-            echo "::notice::pub.dev has not surfaced ${NAME}@${VERSION} yet (attempt ${attempt}/60); sleeping 10s"
+            echo "::notice::pub.dev has not fully surfaced ${NAME}@${VERSION} yet (attempt ${attempt}/60); sleeping 10s"
             sleep 10
           done
-          if [ -z "$archive_url" ]; then
-            echo "::error::pub.dev did not surface ${NAME}@${VERSION} within ~10 minutes; published but unattested"
+          if [ -z "$downloaded" ]; then
+            echo "::error::pub.dev did not surface a downloadable ${NAME}@${VERSION} archive within ~10 minutes; published but unattested"
             exit 1
           fi
           if [ -z "$expected_sha" ]; then
             echo "::error::pub.dev surfaced ${NAME}@${VERSION} but did not return archive_sha256"
             exit 1
           fi
-          curl -fsSL -o package.tar.gz "$archive_url"
           actual_sha=$(sha256sum package.tar.gz | awk '{print $1}')
           if [ "$expected_sha" != "$actual_sha" ]; then
             echo "::error::sha256 mismatch: pub.dev reports ${expected_sha}, downloaded ${actual_sha}"

--- a/tool/create_release.dart
+++ b/tool/create_release.dart
@@ -145,8 +145,17 @@ Future<bool> tagExists(String tag) async {
 
 /// Create and push git tag
 Future<bool> createAndPushTag(String tag) async {
-  // Create tag
-  var result = await Process.run('git', ['tag', tag]);
+  // Create an annotated tag (-m). A lightweight `git tag <name>` fails with
+  // "fatal: no tag message?" for anyone whose git config forces annotated or
+  // signed tags (tag.forceSignAnnotated / tag.gpgSign); annotating always works
+  // and signing, when configured, is applied transparently.
+  var result = await Process.run('git', [
+    'tag',
+    '-a',
+    '-m',
+    'Release $tag',
+    tag,
+  ]);
   if (result.exitCode != 0) {
     stderr.writeln(
       '${Colors.red}Failed to create tag: ${result.stderr}${Colors.reset}',


### PR DESCRIPTION
## Summary

Two release-path fixes surfaced while cutting `v0.17.0-beta.1`:

- [publish.yml](.github/workflows/publish.yml) — the "Fetch published archive from pub.dev" step polled only the pub.dev **metadata** API, but the version metadata surfaces *before* the archive is downloadable. The loop broke on attempt 1 and the unguarded `curl -o package.tar.gz` then 404'd (exit 22) under `set -e`, failing the run even though `dart pub publish` succeeded. Fold the download into the poll loop and guard it in the `if` condition so a transient archive 404 retries instead of killing the step. (This is what failed on the `v0.17.0-beta.1` publish — the package published fine but the run went red.)
- [tool/create_release.dart](tool/create_release.dart) — `git tag <name>` (lightweight) fails with `fatal: no tag message?` for anyone whose git config forces annotated/signed tags (`tag.forceSignAnnotated` / `tag.gpgSign`). Create an annotated tag (`-a -m`) instead; signing, when configured, is applied transparently.

Tests, analyzer, and formatting pass; the retry loop was verified locally to survive a transient 404 under `set -e -o pipefail`.

_PR description authored by Claude on Domas's behalf._