### PR TITLE
fix(offline): survive malformed cache data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Offline transport is now resilient to malformed cache data
+  ([#22](https://github.com/grafana/faro-flutter-sdk/issues/22)).
+  A corrupt cached entry (e.g. from a partial write or schema drift) is
+  now skipped and purged instead of aborting the read and permanently
+  blocking all remaining cached telemetry. Additionally, payloads whose
+  user-supplied log context or event attributes cannot be JSON-encoded
+  (a `DateTime`, custom object, or non-finite double) are dropped with a
+  type-only diagnostic rather than failing the cache write.
+
 ## [0.17.0-beta.1] - 2026-07-01
 
 ### Changed

--- a/lib/src/offline_transport/offline_transport.dart
+++ b/lib/src/offline_transport/offline_transport.dart
@@ -77,19 +77,53 @@ class OfflineTransport extends BaseTransport {
     }
   }
 
+  /// Writes the payload to the cache file.
+  ///
+  /// Failure policy: payloads that cannot be JSON-encoded (for example a
+  /// user-supplied attribute containing a [DateTime], a custom object, or a
+  /// non-finite double) are dropped. A payload that cannot be encoded for
+  /// the cache could not be encoded for upload to the collector later
+  /// either, so dropping it keeps the cache consistent with what online
+  /// delivery accepts.
   Future<void> _writeToFile(Payload payload) async {
     await _withFileLock(() async {
-      final file = await _getCacheFile();
       final logJson = {
         'timestamp': DateTime.now().millisecondsSinceEpoch,
         'payload': payload.toJson(),
       };
+      final encodedLogJson = _encodeJsonSafely(logJson);
+      if (encodedLogJson == null) {
+        return;
+      }
+      final file = await _getCacheFile();
       await file.writeAsString(
-        '${jsonEncode(logJson)}\n',
+        '$encodedLogJson\n',
         mode: FileMode.append,
         flush: true,
       );
     });
+  }
+
+  /// Encodes [json] to a JSON string, or returns null if encoding fails.
+  ///
+  /// Diagnostics only mention value/error types, never the values
+  /// themselves, to avoid leaking potentially sensitive payload data.
+  String? _encodeJsonSafely(Map<String, dynamic> json) {
+    try {
+      return jsonEncode(json);
+    } catch (error) {
+      var details = error.runtimeType.toString();
+      if (error is JsonUnsupportedObjectError) {
+        details =
+            'unsupported value of type '
+            '${error.unsupportedObject.runtimeType}';
+      }
+      log(
+        'OfflineTransport: Failed to JSON-encode payload ($details). '
+        'Dropping this payload.',
+      );
+      return null;
+    }
   }
 
   Future<void> _readFromFile() async {
@@ -118,12 +152,18 @@ class OfflineTransport extends BaseTransport {
           continue;
         }
 
-        final timestamp = logJson['timestamp'] as int?;
-        final payload = Payload.fromJson(logJson['payload']);
-
-        if (timestamp == null) {
+        final timestamp = logJson['timestamp'];
+        if (timestamp is! int) {
           log(
             'OfflineTransport: Failed to parse timestamp in payload. Skipping this payload.',
+          );
+          continue;
+        }
+
+        final payload = _parsePayloadSafely(logJson['payload']);
+        if (payload == null) {
+          log(
+            'OfflineTransport: Failed to parse cached payload. Skipping this payload.',
           );
           continue;
         }
@@ -146,6 +186,19 @@ class OfflineTransport extends BaseTransport {
       }
       await file.writeAsString(updatedFileContent, flush: true);
     });
+  }
+
+  /// Parses a cached payload, or returns null if parsing fails.
+  ///
+  /// Corrupt cache entries must not break processing of the remaining
+  /// entries, so failures are swallowed and the entry is dropped.
+  Payload? _parsePayloadSafely(dynamic payloadJson) {
+    try {
+      return Payload.fromJson(payloadJson);
+    } catch (error) {
+      // Return null if parsing fails.
+      return null;
+    }
   }
 
   Map<String, dynamic>? _parseJsonSafely(String jsonString) {

--- a/test/src/offline_transport/offline_transport_test.dart
+++ b/test/src/offline_transport/offline_transport_test.dart
@@ -1,0 +1,227 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:faro/src/faro.dart';
+import 'package:faro/src/offline_transport/internet_connectivity_service.dart';
+import 'package:faro/src/offline_transport/offline_transport.dart';
+import 'package:faro/src/transport/faro_base_transport.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockInternetConnectivityService extends Mock
+    implements InternetConnectivityService {}
+
+class MockTransport extends Mock implements BaseTransport {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+
+  late Directory tempDir;
+  late MockInternetConnectivityService mockConnectivityService;
+  late StreamController<bool> connectivityController;
+
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('faro_offline_test');
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, (call) async {
+          if (call.method == 'getApplicationDocumentsDirectory') {
+            return tempDir.path;
+          }
+          return null;
+        });
+
+    connectivityController = StreamController<bool>.broadcast();
+    mockConnectivityService = MockInternetConnectivityService();
+    when(() => mockConnectivityService.isOnline).thenReturn(false);
+    when(
+      () => mockConnectivityService.onConnectivityChanged,
+    ).thenAnswer((_) => connectivityController.stream);
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
+    await connectivityController.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+    await Faro.resetForTesting();
+  });
+
+  OfflineTransport createTransport() {
+    return OfflineTransport(
+      internetConnectivityService: mockConnectivityService,
+    );
+  }
+
+  File cacheFile() {
+    return File('${tempDir.path}/rum_log.json');
+  }
+
+  Map<String, dynamic> buildEventPayloadJson({
+    Map<String, dynamic>? attributes,
+  }) {
+    return <String, dynamic>{
+      'events': [
+        <String, dynamic>{
+          'name': 'test_event',
+          'domain': 'flutter',
+          'timestamp': '2026-01-01T00:00:00.000Z',
+          'attributes': attributes ?? <String, dynamic>{'key': 'value'},
+        },
+      ],
+    };
+  }
+
+  group('OfflineTransport write path:', () {
+    test('caches valid payload when offline', () async {
+      final transport = createTransport();
+
+      await transport.send(buildEventPayloadJson());
+
+      final lines = await cacheFile().readAsLines();
+      expect(lines, hasLength(1));
+      final cachedJson = jsonDecode(lines.first) as Map<String, dynamic>;
+      expect(cachedJson['timestamp'], isA<int>());
+      final cachedPayload = cachedJson['payload'] as Map<String, dynamic>;
+      final cachedEvents = cachedPayload['events'] as List<dynamic>;
+      expect(cachedEvents, hasLength(1));
+      final cachedEvent = cachedEvents.first as Map<String, dynamic>;
+      expect(cachedEvent['name'], 'test_event');
+    });
+
+    test(
+      'does not crash and drops payload with non-encodable attribute',
+      () async {
+        final transport = createTransport();
+        final payloadJson = buildEventPayloadJson(
+          attributes: <String, dynamic>{'when': DateTime.now()},
+        );
+
+        await expectLater(transport.send(payloadJson), completes);
+
+        // Nothing should be persisted for the dropped payload, and the
+        // cache file should not even be created for it.
+        expect(cacheFile().existsSync(), isFalse);
+      },
+    );
+
+    test('does not crash and drops payload with non-finite double', () async {
+      final transport = createTransport();
+      final payloadJson = buildEventPayloadJson(
+        attributes: <String, dynamic>{'value': double.nan},
+      );
+
+      await expectLater(transport.send(payloadJson), completes);
+
+      expect(cacheFile().existsSync(), isFalse);
+    });
+
+    test(
+      'keeps caching valid payloads after a non-encodable payload',
+      () async {
+        final transport = createTransport();
+        final badPayloadJson = buildEventPayloadJson(
+          attributes: <String, dynamic>{'object': Object()},
+        );
+
+        await transport.send(badPayloadJson);
+        await transport.send(buildEventPayloadJson());
+
+        final lines = await cacheFile().readAsLines();
+        expect(lines, hasLength(1));
+        final cachedJson = jsonDecode(lines.first) as Map<String, dynamic>;
+        expect(cachedJson['payload'], isNotNull);
+      },
+    );
+  });
+
+  group('OfflineTransport read path:', () {
+    test('skips corrupt cached lines and still sends valid ones when '
+        'back online', () async {
+      final validLine = jsonEncode(<String, dynamic>{
+        'timestamp': DateTime.now().millisecondsSinceEpoch,
+        'payload': buildEventPayloadJson(),
+      });
+      final corruptLines = [
+        // Not JSON at all.
+        'not-json-at-all',
+        // Valid JSON but the payload cannot be parsed.
+        jsonEncode(<String, dynamic>{
+          'timestamp': DateTime.now().millisecondsSinceEpoch,
+          'payload': 'garbage',
+        }),
+        // Valid JSON but the timestamp has the wrong type.
+        jsonEncode(<String, dynamic>{
+          'timestamp': 'not-an-int',
+          'payload': buildEventPayloadJson(),
+        }),
+      ];
+      await cacheFile().writeAsString(
+        '${corruptLines.join('\n')}\n$validLine\n',
+      );
+
+      final mockTransport = MockTransport();
+      when(() => mockTransport.send(any())).thenAnswer((_) async {});
+      Faro().transports = [mockTransport];
+
+      createTransport();
+      connectivityController.add(true);
+
+      await untilCalled(() => mockTransport.send(any()));
+      verify(() => mockTransport.send(any())).called(1);
+
+      // Wait for the cache file rewrite: all corrupt lines are dropped
+      // and the successfully sent line is removed.
+      const maxAttempts = 100;
+      var attempts = 0;
+      while (cacheFile().readAsStringSync().isNotEmpty &&
+          attempts < maxAttempts) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        attempts++;
+      }
+      expect(cacheFile().readAsStringSync(), isEmpty);
+    });
+
+    test('retains valid lines whose send fails and still drops corrupt '
+        'lines', () async {
+      final validLine = jsonEncode(<String, dynamic>{
+        'timestamp': DateTime.now().millisecondsSinceEpoch,
+        'payload': buildEventPayloadJson(),
+      });
+      // A corrupt line must be dropped regardless of send outcome.
+      const corruptLine = 'not-json-at-all';
+      await cacheFile().writeAsString('$corruptLine\n$validLine\n');
+
+      final mockTransport = MockTransport();
+      when(
+        () => mockTransport.send(any()),
+      ).thenAnswer((_) async => throw Exception('network failure'));
+      Faro().transports = [mockTransport];
+
+      createTransport();
+      connectivityController.add(true);
+
+      await untilCalled(() => mockTransport.send(any()));
+
+      // The failed-but-valid line is written back; the corrupt line is gone.
+      const maxAttempts = 100;
+      var attempts = 0;
+      while (cacheFile().readAsStringSync() != '$validLine\n' &&
+          attempts < maxAttempts) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        attempts++;
+      }
+      expect(cacheFile().readAsStringSync(), '$validLine\n');
+    });
+  });
+}


### PR DESCRIPTION
## Description

Hardens the offline transport cache against two failure modes:

- **Read path (primary):** A corrupt cached entry (unparseable payload or
  wrong-typed timestamp) is now skipped and purged instead of aborting the
  read. Previously a single bad line permanently poisoned the cache and
  blocked all remaining cached telemetry from being sent after reconnecting.
- **Write path (secondary):** Payloads whose user-supplied log `context` or
  event `attributes` cannot be JSON-encoded (a `DateTime`, custom object, or
  non-finite double) are dropped with a type-only diagnostic instead of
  failing the cache write. Diagnostics never include payload contents.

Note: `Measurement.values` and exception context are already sanitized
upstream, so only logs and events can reach the write guard. The
batch-level drop granularity (one non-encodable item drops its whole
batch) is being tracked as a separate follow-up for per-item sanitization
at ingest.

## Related Issue(s)

Fixes #22

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Additional Notes

Hard to validate on-device, so verified via unit tests, `flutter analyze`,
and `dart format`. New tests in
`test/src/offline_transport/offline_transport_test.dart` cover both paths:
corrupt-line skipping, non-encodable payload drops (DateTime / NaN /
custom object), and retention of valid-but-unsent lines on send failure.

Made with [Cursor](https://cursor.com)