### PR TITLE
docs: document iOS SwiftPM checkout folder-name requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,11 +32,20 @@ Before you begin, ensure you have the following installed:
 ### Fork and Clone
 
 1. Fork the repository on GitHub
-2. Clone your fork locally:
+2. Clone your fork locally into a folder named `faro`:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/faro-flutter-sdk.git
-   cd faro-flutter-sdk
+   git clone https://github.com/YOUR_USERNAME/faro-flutter-sdk.git faro
+   cd faro
    ```
+
+   > **iOS note:** The Dart package is named `faro`. Swift Package Manager
+   > derives a package's identity from its directory name, so the iOS example
+   > only builds via SwiftPM when the repository is checked out into a folder
+   > named `faro`. Cloning into the default `faro-flutter-sdk` folder fails with
+   > `unable to override package 'faro' because its identity 'faro-flutter-sdk'`
+   > `doesn't match override's identity (directory name) 'faro'`. This only
+   > affects local development (path/git checkouts); apps that depend on `faro`
+   > from pub.dev are unaffected.
 3. Add the upstream repository as a remote:
    ```bash
    git remote add upstream https://github.com/grafana/faro-flutter-sdk.git

--- a/example/README.md
+++ b/example/README.md
@@ -88,6 +88,29 @@ See `lib/features/tracing/` for the reference implementation.
    `run-example.sh` uses `example/api-config.json` and forwards any extra args
    to `flutter run`, e.g. `./tool/run-example.sh -d emulator-5554 --release`.
 
+### Troubleshooting: iOS SwiftPM build fails with a package identity error
+
+If `flutter build ios` / `flutter run` on iOS fails with:
+
+```
+unable to override package 'faro' because its identity 'faro-flutter-sdk'
+doesn't match override's identity (directory name) 'faro'
+```
+
+your repository is checked out in a folder whose name isn't `faro`. Swift
+Package Manager derives a package's identity from its directory name, and this
+package is named `faro`. Rename the repository folder to `faro` (or clone into
+one), then regenerate:
+
+```bash
+flutter clean && flutter pub get
+```
+
+This only affects local development (path/git checkouts) because the example
+depends on the SDK via a path override; apps that depend on `faro` from pub.dev
+are unaffected. This is a known Swift Package Manager behavior: a package's
+identity is derived from its directory name.
+
 ## Features Demonstrated
 
 The example app showcases various Faro SDK features:


### PR DESCRIPTION
## Description

The Dart package is named `faro`, and Swift Package Manager derives a package's
identity from its directory name. Because the example app depends on the SDK via
a path override (`pubspec_overrides.yaml`), the iOS example only builds via
SwiftPM when the repository is checked out into a folder named `faro`. Cloning
into the default `faro-flutter-sdk` folder (the repo name) fails during package
resolution with:

    unable to override package 'faro' because its identity 'faro-flutter-sdk'
    doesn't match override's identity (directory name) 'faro'

This PR documents the requirement and workaround:
- `CONTRIBUTING.md`: clone into a `faro` folder, with an iOS note explaining why.
- `example/README.md`: new troubleshooting entry for the identity error.

## Related Issue(s)

N/A

## Type of Change

- [x] 📝 Documentation

## Checklist

- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (documentation only)
- [ ] I have updated the CHANGELOG.md under the "Unreleased" section — N/A (contributor/example docs are not part of the published package)

## Additional Notes

- Verified by reproduction: copying the checkout to `/tmp/faro-flutter-sdk` and
  building the iOS example (simulator) fails with the identity error; renaming
  the same copy to `/tmp/faro` builds successfully. Only the folder name differs.
- This is not covered by CI: all workflow jobs run on `ubuntu-latest` and the
  example is only built for Android (`flutter build apk`), so there is no iOS
  build to surface this. A macOS iOS-build job (checked out into a `faro` folder)
  could be a future follow-up.
- Only affects local development; apps depending on `faro` from pub.dev are
  unaffected (no path override → no identity clash).

Made with [Cursor](https://cursor.com)