### PR TITLE
fix(offline): add timeout and robust error handling to connectivity probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   user-supplied log context or event attributes cannot be JSON-encoded
   (a `DateTime`, custom object, or non-finite double) are dropped with a
   type-only diagnostic rather than failing the cache write.
+- **Offline transport connectivity probe reliability**
+  ([#11](https://github.com/grafana/faro-flutter-sdk/issues/11)): The DNS
+  lookup used by `OfflineTransport` to confirm internet access now has a
+  5-second timeout (previously it could hang indefinitely on some
+  platforms, stalling online/offline decisions) and catches all probe
+  errors instead of only `SocketException`. Any probe failure is still
+  treated as offline: while offline, payloads are cached on disk and
+  flushed once connectivity returns, whereas a send attempted while
+  actually offline is dropped without retry — so a false "offline" only
+  costs disk usage, while a false "online" would risk permanent data
+  loss. The lookup function is also injectable for testing via the new
+  optional `addressLookup` and `lookupTimeout` parameters on
+  `InternetConnectivityService`.
 
 ## [0.17.0-beta.1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actually offline is dropped without retry — so a false "offline" only
   costs disk usage, while a false "online" would risk permanent data
   loss. The lookup function is also injectable for testing via the new
-  optional `addressLookup` and `lookupTimeout` parameters on
-  `InternetConnectivityService`.
+  required `addressLookup` parameter and optional `lookupTimeout`
+  parameter on `InternetConnectivityService`.
 
 ## [0.17.0-beta.1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flushed once connectivity returns, whereas a send attempted while
   actually offline is dropped without retry — so a false "offline" only
   costs disk usage, while a false "online" would risk permanent data
-  loss. The lookup function is also injectable for testing via the new
-  required `addressLookup` parameter and optional `lookupTimeout`
-  parameter on `InternetConnectivityService`.
+  loss. Overlapping probes from rapid connectivity changes are now also
+  ordered: a stale probe result that completes after a newer probe can no
+  longer overwrite the newer online/offline state. The lookup function is
+  also injectable for testing via the new required `addressLookup`
+  parameter and optional `lookupTimeout` parameter on
+  `InternetConnectivityService`.
 
 ## [0.17.0-beta.1] - 2026-07-01
 

--- a/lib/src/offline_transport/internet_connectivity_service.dart
+++ b/lib/src/offline_transport/internet_connectivity_service.dart
@@ -50,6 +50,16 @@ class InternetConnectivityService {
   _connectivityChangedSubscription;
   bool _isOnline = true;
 
+  /// Identifies the most recently started connectivity update.
+  ///
+  /// Connectivity events can overlap: a slow DNS probe from an older event
+  /// may complete (or time out) after a newer event's probe has already
+  /// resolved. Each [_handleConnectivityResults] call registers its own
+  /// token here and only applies its probe result if its token is still
+  /// the latest one — otherwise a newer update has taken over and the
+  /// stale result is discarded (last caller wins).
+  Object? _latestProbeToken;
+
   bool get isOnline => _isOnline;
 
   Stream<bool> get onConnectivityChanged {
@@ -84,11 +94,20 @@ class InternetConnectivityService {
   Future<void> _handleConnectivityResults(
     List<ConnectivityResult> results,
   ) async {
+    final probeToken = Object();
+    _latestProbeToken = probeToken;
     final result = results.firstOrNull ?? ConnectivityResult.none;
     if (result == ConnectivityResult.none) {
       _setOnline(false);
     } else {
-      _setOnline(await _isConnectedToInternet());
+      final isOnline = await _isConnectedToInternet();
+      if (!identical(probeToken, _latestProbeToken)) {
+        // A newer connectivity update started while this probe was in
+        // flight; its result owns the state now. Applying this stale
+        // result could mark a working connection offline (or vice versa).
+        return;
+      }
+      _setOnline(isOnline);
     }
   }
 

--- a/lib/src/offline_transport/internet_connectivity_service.dart
+++ b/lib/src/offline_transport/internet_connectivity_service.dart
@@ -3,19 +3,49 @@ import 'dart:io';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:faro/src/offline_transport/connectivity_checker.dart';
 
+/// Signature of the DNS lookup used to probe actual internet access.
+///
+/// Matches the shape of [InternetAddress.lookup] and exists as an
+/// injectable seam so tests can simulate slow, failing, or blocked DNS
+/// resolution without real network access.
+typedef InternetAddressLookup =
+    Future<List<InternetAddress>> Function(String host);
+
+/// Tracks whether the device currently has working internet access.
+///
+/// Combines connectivity_plus network-state changes with a DNS probe of
+/// [internetConnectionCheckerUrl] to distinguish "connected to a network"
+/// from "actually able to reach the internet".
 class InternetConnectivityService {
+  /// Creates the service and immediately starts monitoring connectivity.
+  ///
+  /// [addressLookup] performs the DNS probe; production wires
+  /// [InternetAddress.lookup] via [InternetConnectivityServiceFactory], while
+  /// tests inject a fake. [lookupTimeout] bounds each probe and defaults to
+  /// [defaultLookupTimeout].
   InternetConnectivityService({
     required ConnectivityChecker connectivity,
     required String internetConnectionCheckerUrl,
+    required InternetAddressLookup addressLookup,
+    Duration lookupTimeout = defaultLookupTimeout,
   }) : _connectivity = connectivity,
-       _internetConnectionCheckerUrl = internetConnectionCheckerUrl {
+       _internetConnectionCheckerUrl = internetConnectionCheckerUrl,
+       _addressLookup = addressLookup,
+       _lookupTimeout = lookupTimeout {
     _checkConnectivity();
     _monitorConnectivity();
   }
 
+  /// Default upper bound for a single DNS probe. On some platforms an
+  /// unbounded [InternetAddress.lookup] can hang for a long time, which
+  /// would stall online/offline decisions.
+  static const Duration defaultLookupTimeout = Duration(seconds: 5);
+
   final ConnectivityChecker _connectivity;
   final _connectivityController = StreamController<bool>.broadcast();
   final String _internetConnectionCheckerUrl;
+  final InternetAddressLookup _addressLookup;
+  final Duration _lookupTimeout;
   StreamSubscription<List<ConnectivityResult>>?
   _connectivityChangedSubscription;
   bool _isOnline = true;
@@ -62,13 +92,29 @@ class InternetConnectivityService {
     }
   }
 
+  /// Probes internet access via a DNS lookup, bounded by [_lookupTimeout].
+  ///
+  /// Any probe failure (timeout, socket error, or unexpected platform
+  /// error) is treated as offline. This is deliberately conservative:
+  /// while reported offline, payloads are cached on disk by
+  /// `OfflineTransport` and flushed when connectivity returns, whereas a
+  /// send attempted while actually offline is dropped by `FaroTransport`
+  /// without retry. A false "offline" therefore only costs disk usage,
+  /// while a false "online" risks permanent data loss.
   Future<bool> _isConnectedToInternet() async {
     try {
-      final result = await InternetAddress.lookup(
+      final result = await _addressLookup(
         _internetConnectionCheckerUrl,
-      );
+      ).timeout(_lookupTimeout);
       return result.isNotEmpty && result[0].rawAddress.isNotEmpty;
+    } on TimeoutException catch (_) {
+      return false;
     } on SocketException catch (_) {
+      return false;
+    } catch (_) {
+      // DNS probes can fail in unexpected ways (blocked resolvers,
+      // platform errors). Never let a probe error escape and never
+      // report online without a successful probe.
       return false;
     }
   }
@@ -80,6 +126,7 @@ class InternetConnectivityServiceFactory {
     return InternetConnectivityService(
       connectivity: ConnectivityCheckerFactory().create(),
       internetConnectionCheckerUrl: checkerUrl,
+      addressLookup: InternetAddress.lookup,
     );
   }
 }

--- a/test/src/offline_transport/internet_connectivity_service_test.dart
+++ b/test/src/offline_transport/internet_connectivity_service_test.dart
@@ -202,6 +202,42 @@ void main() {
         expect(service.isOnline, false);
       });
 
+      test(
+        'ignores a stale probe result that completes after a newer probe',
+        () async {
+          final probes = <Completer<List<InternetAddress>>>[];
+          service = InternetConnectivityService(
+            connectivity: mockConnectivity,
+            internetConnectionCheckerUrl: 'probe.example',
+            addressLookup: (host) {
+              final probe = Completer<List<InternetAddress>>();
+              probes.add(probe);
+              return probe.future;
+            },
+          );
+
+          // First connectivity event: probe 1 starts and stays pending
+          // (slow DNS resolution).
+          fakeConnectivityController.add([ConnectivityResult.wifi]);
+          await waitForAsyncWork();
+
+          // Second connectivity event: probe 2 starts and succeeds
+          // quickly -> online.
+          fakeConnectivityController.add([ConnectivityResult.mobile]);
+          await waitForAsyncWork();
+          expect(probes.length, 2);
+          probes[1].complete([InternetAddress('1.1.1.1')]);
+          await waitForAsyncWork();
+          expect(service.isOnline, true);
+
+          // The stale probe 1 now completes as a failure. It must not
+          // overwrite the newer online state.
+          probes[0].complete(<InternetAddress>[]);
+          await waitForAsyncWork();
+          expect(service.isOnline, true);
+        },
+      );
+
       test('returns false when lookup returns an asynchronous error', () async {
         service = InternetConnectivityService(
           connectivity: mockConnectivity,

--- a/test/src/offline_transport/internet_connectivity_service_test.dart
+++ b/test/src/offline_transport/internet_connectivity_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:faro/src/offline_transport/connectivity_checker.dart';
@@ -36,6 +37,7 @@ void main() {
     service = InternetConnectivityService(
       connectivity: mockConnectivity,
       internetConnectionCheckerUrl: 'localhost',
+      addressLookup: InternetAddress.lookup,
     );
   });
 
@@ -52,6 +54,7 @@ void main() {
         final service = InternetConnectivityService(
           connectivity: mockConnectivity,
           internetConnectionCheckerUrl: 'localhost',
+          addressLookup: InternetAddress.lookup,
         );
 
         await waitForAsyncWork();
@@ -65,6 +68,7 @@ void main() {
         final service = InternetConnectivityService(
           connectivity: mockConnectivity,
           internetConnectionCheckerUrl: 'localhost',
+          addressLookup: InternetAddress.lookup,
         );
 
         await waitForAsyncWork();
@@ -93,6 +97,7 @@ void main() {
           service = InternetConnectivityService(
             connectivity: mockConnectivity,
             internetConnectionCheckerUrl: 'invalid.domain.that.does.not.exist',
+            addressLookup: InternetAddress.lookup,
           );
 
           fakeConnectivityController.add([ConnectivityResult.wifi]);
@@ -102,6 +107,115 @@ void main() {
           expect(service.isOnline, false);
         },
       );
+
+      test('returns true when injected lookup resolves an address', () async {
+        service = InternetConnectivityService(
+          connectivity: mockConnectivity,
+          internetConnectionCheckerUrl: 'probe.example',
+          addressLookup: (host) async => [InternetAddress('1.1.1.1')],
+        );
+
+        fakeConnectivityController.add([ConnectivityResult.wifi]);
+        await waitForAsyncWork();
+
+        expect(service.isOnline, true);
+      });
+
+      test('returns false when lookup resolves no addresses', () async {
+        service = InternetConnectivityService(
+          connectivity: mockConnectivity,
+          internetConnectionCheckerUrl: 'probe.example',
+          addressLookup: (host) async => [],
+        );
+
+        fakeConnectivityController.add([ConnectivityResult.wifi]);
+        await waitForAsyncWork();
+
+        expect(service.isOnline, false);
+      });
+
+      test('returns false when lookup hangs longer than the timeout', () async {
+        final neverCompletes = Completer<List<InternetAddress>>();
+        service = InternetConnectivityService(
+          connectivity: mockConnectivity,
+          internetConnectionCheckerUrl: 'probe.example',
+          addressLookup: (host) => neverCompletes.future,
+          lookupTimeout: const Duration(milliseconds: 10),
+        );
+
+        fakeConnectivityController.add([ConnectivityResult.wifi]);
+        await waitForAsyncWork();
+
+        expect(service.isOnline, false);
+      });
+
+      test(
+        'recovers to online once a hanging lookup starts succeeding',
+        () async {
+          var shouldHang = true;
+          service = InternetConnectivityService(
+            connectivity: mockConnectivity,
+            internetConnectionCheckerUrl: 'probe.example',
+            addressLookup: (host) {
+              if (shouldHang) {
+                return Completer<List<InternetAddress>>().future;
+              }
+              return Future.value([InternetAddress('1.1.1.1')]);
+            },
+            lookupTimeout: const Duration(milliseconds: 10),
+          );
+
+          fakeConnectivityController.add([ConnectivityResult.wifi]);
+          await waitForAsyncWork();
+          expect(service.isOnline, false);
+
+          shouldHang = false;
+          fakeConnectivityController.add([ConnectivityResult.mobile]);
+          await waitForAsyncWork();
+          expect(service.isOnline, true);
+        },
+      );
+
+      test('returns false when lookup throws a SocketException', () async {
+        service = InternetConnectivityService(
+          connectivity: mockConnectivity,
+          internetConnectionCheckerUrl: 'probe.example',
+          addressLookup: (host) => throw const SocketException('no route'),
+        );
+
+        fakeConnectivityController.add([ConnectivityResult.wifi]);
+        await waitForAsyncWork();
+
+        expect(service.isOnline, false);
+      });
+
+      test('returns false when lookup throws a non-socket error', () async {
+        service = InternetConnectivityService(
+          connectivity: mockConnectivity,
+          internetConnectionCheckerUrl: 'probe.example',
+          addressLookup: (host) => throw StateError('platform failure'),
+        );
+
+        fakeConnectivityController.add([ConnectivityResult.wifi]);
+        await waitForAsyncWork();
+
+        expect(service.isOnline, false);
+      });
+
+      test('returns false when lookup returns an asynchronous error', () async {
+        service = InternetConnectivityService(
+          connectivity: mockConnectivity,
+          internetConnectionCheckerUrl: 'probe.example',
+          addressLookup: (host) async {
+            throw const OSError('lookup blocked', 11);
+          },
+        );
+
+        fakeConnectivityController.add([ConnectivityResult.wifi]);
+        await waitForAsyncWork();
+
+        expect(service.isOnline, false);
+      });
     });
 
     group('onConnectivityChanged:', () {


### PR DESCRIPTION
## Description

The DNS probe used by `OfflineTransport` (via `InternetConnectivityService`) to
confirm real internet access had two reliability gaps:

- `InternetAddress.lookup` had **no timeout** — on some platforms it can hang for
  a long time, stalling online/offline decisions.
- Only `SocketException` was caught, letting other probe errors propagate.

This PR hardens the probe:

- Bounds the lookup with a 5s timeout (`defaultLookupTimeout`); a timed-out probe
  counts as a failed probe (⇒ offline).
- Catches `TimeoutException`, `SocketException`, and any other probe error.
- Keeps **probe-failure ⇒ offline** semantics deliberately: payloads cached while
  offline are flushed when connectivity returns, whereas a send attempted while
  actually offline is dropped by `FaroTransport` without retry. A false "offline"
  only costs disk usage; a false "online" risks permanent data loss.
- Makes the lookup an explicit **required** dependency wired via the factory
  (`InternetAddress.lookup`) and injectable for tests; adds optional
  `lookupTimeout`. Public API otherwise unchanged.

Validated on a real Android device (offline → cache → reconnect → flush, 0
payloads dropped) and cross-checked server-side in Loki. Unit tests cover the
timeout and error branches.

## Related Issue(s)

Related to #11

> Note: this **hardens** the existing probe; it does not implement the broader
> connectivity re-architecture #11 envisions. See the follow-up analysis I've
> added to #11 for the proposed "outcome-driven delivery" direction.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation (dartdoc added)
- [x] I have added tests that prove my fix is effective
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Additional Notes

This intentionally does **not** close #11. The full rework (outcome-driven
delivery, failure taxonomy, bounded cache) is captured as follow-up in the issue.

Made with [Cursor](https://cursor.com)