### PR TITLE
feat(session): rotate session on inactivity and max lifetime (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Session rotation** (#52): Sessions now rotate automatically after
+  15 minutes of inactivity or 4 hours of total lifetime (fixed to match
+  the Faro session definition and the collector's server-side
+  validation). On
+  rotation a new session id is generated, a `session_extend` event is
+  emitted (the initial session emits `session_start`), and the previous
+  id is recorded in the `previousSession` attribute so backends can link
+  sessions. Automatic vitals (CPU, memory, etc.) count as activity only
+  while the app is in the foreground: a foregrounded but idle app (e.g.
+  a user reading a screen) stays in one session, while a backgrounded
+  app's vitals cannot keep its session alive. Sampling is not
+  re-evaluated on rotation. See the Reference docs for full details.
+
 ### Fixed
 
 - Offline transport is now resilient to malformed cache data

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -299,6 +299,32 @@ To explicitly clear any persisted user on app start, use the sentinel value:
 initialUser: FaroUser.cleared(), // Start with no user, ignore persisted data
 ```
 
+### Session Lifecycle & Rotation
+
+Faro tracks a session id that groups all telemetry from a single period of use. Matching the [Faro session definition](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/session-tracking/), a session is automatically **rotated** (a new session id is generated) when either threshold is reached:
+
+- **Inactivity**: no app/user activity for 15 minutes, or
+- **Max lifetime**: the session has been alive for 4 hours.
+
+These thresholds are fixed and not configurable: the Grafana Cloud Faro receiver enforces the same windows server-side and drops telemetry from sessions that exceed them, so a longer client-side value would cause silent data loss.
+
+**Lifecycle events.** Faro emits an event whenever the session id changes, so you can follow the user journey in Grafana:
+
+| Event           | When                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `session_start` | The initial session, emitted once when the SDK initializes                           |
+| `session_extend` | A rotation: a new session was auto-created because the inactivity or lifetime timeout was reached |
+
+**Linking rotated sessions.** On rotation, the previous session id is recorded in the `previousSession` session attribute, so backends can link a rotated session back to its predecessor. Existing custom session attributes are preserved across rotation. All telemetry created after a rotation — events, logs, exceptions, and spans — automatically carries the new session id.
+
+**What counts as activity.** Telemetry that originates from app or user behavior extends the inactivity window: events, logs, exceptions, app-developer measurements, user interactions, view changes, and app lifecycle events. Spans count too — each exported span emits a Faro event that flows through the same path, so tracked HTTP requests and custom spans keep the session alive.
+
+Automatic vitals measurements pushed by the SDK itself (CPU, memory, refresh rate, frame stats, ANR count, app start) count as activity **only while the app is in the foreground**. This keeps a single session for a foregrounded but idle app (e.g. a user reading a screen without tapping), while ensuring a backgrounded app's session still expires — the Dart isolate keeps running while backgrounded on Android, so if background vitals counted they would keep the session alive indefinitely.
+
+Session expiry is evaluated lazily on the next ingested telemetry item (there is no periodic rotation timer). The triggering telemetry is attributed to the new session.
+
+> **Sampling note:** the session sampling decision is made once at initialization and is **not** re-evaluated on rotation (see [Session Sampling](#session-sampling)).
+
 ---
 
 ## User Interaction & Navigation
@@ -1111,7 +1137,7 @@ Faro().runApp(
 
 **How it works:**
 
-- The sampling decision is made once per session at initialization time
+- The sampling decision is made once at initialization time and applies for the whole app run, including across [session rotations](#session-lifecycle--rotation)
 - When a session is not sampled, all telemetry (events, logs, exceptions, measurements, traces) is silently dropped
 - A debug log is emitted when a session is not sampled, for transparency during development
 - Invalid return values (< 0.0 or > 1.0) are clamped to the valid range
@@ -1131,8 +1157,8 @@ Faro().runApp(
 
 **Notes:**
 
-- Sampling is head-based: the decision is made at SDK initialization and remains consistent for the entire session
-- This aligns with [Faro Web SDK sampling behavior](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/sampling/)
+- Sampling is head-based: the decision is made at SDK initialization and remains consistent for the whole app run (it is not re-evaluated when the session rotates)
+- The broader [Faro sampling model](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/sampling/) re-samples per rotated session; matching that in the Flutter SDK is planned as a follow-up (#284)
 
 **Use cases:**
 

--- a/example/README.md
+++ b/example/README.md
@@ -177,15 +177,15 @@ Key implementation features shown in this example:
 ## QA Smoke Test Configuration
 
 The example app supports optional QA dart-define keys that inject session
-attributes and an initial user at startup, removing the need to patch source
-code for automated smoke tests.
+attributes and an initial user at startup, removing the need to patch
+source code for automated smoke tests.
 
 | Key | Type | Purpose |
 |-----|------|---------|
 | `FARO_QA_RUN_ID` | string | Adds `qa_run_id` to session attributes |
 | `FARO_QA_INITIAL_USER_JSON` | stringified JSON | Sets the initial `FaroUser` |
 
-Both keys are optional. When absent or empty, the app behaves normally.
+All keys are optional. When absent or empty, the app behaves normally.
 
 All configuration lives in `api-config.json` and is passed via a single flag:
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4096M
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -411,10 +411,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -427,10 +427,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -776,26 +776,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/core/current_time_provider.dart
+++ b/lib/src/core/current_time_provider.dart
@@ -1,0 +1,7 @@
+import 'package:dartypod/dartypod.dart';
+
+/// Provides the current time.
+typedef CurrentTimeProvider = DateTime Function();
+
+/// Shared source of the current time, overridable in tests.
+final currentTimeProvider = Provider<CurrentTimeProvider>((_) => DateTime.now);

--- a/lib/src/core/pod.dart
+++ b/lib/src/core/pod.dart
@@ -2,3 +2,11 @@ import 'package:dartypod/dartypod.dart';
 
 /// Global dependency container for the SDK.
 final pod = Pod();
+
+/// Scope for singletons whose lifetime is tied to a single `Faro.init`.
+///
+/// Providers in this scope are rebuilt on each initialization:
+/// `Faro.resetForTesting` clears the scope with
+/// `pod.clearScope(faroInitScope)`, so the next `init` resolves fresh
+/// instances instead of leaking state across runs.
+const faroInitScope = CustomScope('faroInit');

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -364,7 +364,8 @@ class Faro {
       _didAttachUiActivityMonitor = false;
     }
     // Evict the per-init singletons (session manager, app lifecycle
-    // service) so the next init resolves fresh instances.
+    // service) so the next init resolves fresh instances. Disposable
+    // instances (e.g. NativeIntegration's vitals timer) are cleaned up here.
     pod.clearScope(faroInitScope);
     _isInitialized = false;
   }

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -17,7 +17,10 @@ import 'package:faro/src/integrations/native_integration.dart';
 import 'package:faro/src/integrations/on_error_integration.dart';
 import 'package:faro/src/models/models.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
+import 'package:faro/src/session/app_lifecycle_service.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
 import 'package:faro/src/session/session_id_provider.dart';
+import 'package:faro/src/session/session_manager.dart';
 import 'package:faro/src/session/session_sampling_provider.dart';
 import 'package:faro/src/tracing/faro_otel_bootstrap.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
@@ -92,10 +95,7 @@ class Faro {
   bool get isSampled => _isSampled;
 
   Meta meta = Meta(
-    session: Session(
-      SessionIdProviderFactory().create().sessionId,
-      attributes: {},
-    ),
+    session: Session(_sessionIdProvider.sessionId, attributes: {}),
     sdk: Sdk(FaroConstants.sdkName, FaroConstants.sdkVersion),
     app: App(name: '', environment: '', version: ''),
     view: ViewMeta('default'),
@@ -108,7 +108,13 @@ class Faro {
 
   FaroNativeMethods? get nativeChannel => _nativeChannel;
 
+  static SessionIdProvider get _sessionIdProvider =>
+      pod.resolve(sessionIdProviderProvider);
+
   TelemetryRouter get _telemetryRouter => pod.resolve(telemetryRouterProvider);
+
+  NativeIntegration get _nativeIntegration =>
+      pod.resolve(nativeIntegrationProvider);
 
   UserActionsService get _userActionsService =>
       pod.resolve(userActionsServiceProvider);
@@ -116,7 +122,7 @@ class Faro {
   UserActionUiActivityMonitor get _userActionUiActivityMonitor =>
       pod.resolve(userActionUiActivityMonitorProvider);
 
-  FaroTracer get _tracer => FaroTracerFactory().create();
+  FaroTracer get _tracer => pod.resolve(faroTracerProvider);
 
   @visibleForTesting
   set nativeChannel(FaroNativeMethods? nativeChannel) {
@@ -209,6 +215,9 @@ class Faro {
     _batchTransport = batchTransport;
     pod.overrideProvider(batchTransportProvider, (_) => batchTransport);
 
+    final sessionManager = pod.resolve(sessionManagerProvider)
+      ..addListener(_onSessionChanged);
+
     if (config?.transports == null) {
       Faro()._transports.add(
         FaroTransport(
@@ -234,7 +243,7 @@ class Faro {
       );
     }
     if (Platform.isAndroid || Platform.isIOS) {
-      NativeIntegration.instance.init(
+      _nativeIntegration.init(
         memusage: optionsConfiguration.memoryUsageVitals,
         cpuusage: optionsConfiguration.cpuUsageVitals,
         anr: optionsConfiguration.anrTracking,
@@ -243,11 +252,17 @@ class Faro {
       );
     }
     await FaroOtelBootstrap.initialize();
-    _instance.pushEvent('session_start');
+    // Announce the initial session; the listener emits `session_start`.
+    sessionManager.start();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      NativeIntegration.instance.getAppStart();
+      _nativeIntegration.getAppStart();
     });
-    _widgetsBindingObserver = FaroWidgetsBindingObserver();
+
+    final appLifecycleService = pod.resolve(appLifecycleServiceProvider);
+    _widgetsBindingObserver = FaroWidgetsBindingObserver(
+      appLifecycleService: appLifecycleService,
+      nativeIntegration: _nativeIntegration,
+    );
     WidgetsBinding.instance.addObserver(_widgetsBindingObserver!);
     if (optionsConfiguration.enableUiActivityMonitoring) {
       _userActionUiActivityMonitor.attach();
@@ -309,6 +324,34 @@ class Faro {
     });
   }
 
+  void _onSessionChanged({
+    required String currentId,
+    String? previousId,
+    required SessionStartTrigger trigger,
+  }) {
+    final attributes = <String, dynamic>{...?meta.session?.attributes};
+    if (previousId != null) {
+      attributes['previousSession'] = previousId;
+    }
+
+    meta = Meta.fromJson({
+      ...meta.toJson(),
+      'session': Session(currentId, attributes: attributes).toJson(),
+    });
+    _batchTransport?.updatePayloadMeta(meta);
+
+    final eventName = trigger == SessionStartTrigger.initial
+        ? 'session_start'
+        : 'session_extend';
+    // Lifecycle events bypass user-action buffering and never count as
+    // session activity (SDK-emitted, not app/user behavior).
+    _telemetryRouter.ingest(
+      TelemetryItem.fromEvent(Event(eventName)),
+      skipBuffer: true,
+      activity: SessionActivityKind.none,
+    );
+  }
+
   void _tearDownForReset() {
     final widgetsBindingObserver = _widgetsBindingObserver;
     if (widgetsBindingObserver != null) {
@@ -320,6 +363,9 @@ class Faro {
       _userActionUiActivityMonitor.detach();
       _didAttachUiActivityMonitor = false;
     }
+    // Evict the per-init singletons (session manager, app lifecycle
+    // service) so the next init resolves fresh instances.
+    pod.clearScope(faroInitScope);
     _isInitialized = false;
   }
 

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -224,7 +224,7 @@ class Faro {
           collectorUrl: optionsConfiguration.collectorUrl ?? '',
           apiKey: optionsConfiguration.apiKey,
           maxBufferLimit: config?.maxBufferLimit,
-          sessionId: meta.session?.id,
+          sessionIdResolver: () => _sessionIdProvider.sessionId,
           headers: optionsConfiguration.collectorHeaders,
         ),
       );

--- a/lib/src/faro_widgets_binding_observer.dart
+++ b/lib/src/faro_widgets_binding_observer.dart
@@ -1,18 +1,30 @@
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/integrations/native_integration.dart';
+import 'package:faro/src/session/app_lifecycle_service.dart';
 import 'package:flutter/cupertino.dart';
 
 class FaroWidgetsBindingObserver extends WidgetsBindingObserver {
+  FaroWidgetsBindingObserver({
+    required AppLifecycleService appLifecycleService,
+    required NativeIntegration nativeIntegration,
+  }) : _appLifecycleService = appLifecycleService,
+       _nativeIntegration = nativeIntegration;
+
+  final AppLifecycleService _appLifecycleService;
+  final NativeIntegration _nativeIntegration;
   AppLifecycleState? _previousState;
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
+    // Keep the shared foreground state current; see AppLifecycleService
+    // for how it is used.
+    _appLifecycleService.updateFromLifecycleState(state);
     if (state == AppLifecycleState.resumed) {
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-        NativeIntegration.instance.getWarmStart();
+        _nativeIntegration.getWarmStart();
       });
-      NativeIntegration.instance.setWarmStart();
+      _nativeIntegration.setWarmStart();
     }
 
     Faro().pushEvent(

--- a/lib/src/integrations/native_integration.dart
+++ b/lib/src/integrations/native_integration.dart
@@ -15,7 +15,7 @@ import 'package:flutter/services.dart';
 
 /// NativeIntegration provides access to native platform metrics and events
 /// such as memory usage, CPU usage, ANR detection, and crash reporting.
-class NativeIntegration {
+class NativeIntegration implements Disposable {
   NativeIntegration({required TelemetryRouter telemetryRouter})
     : _telemetryRouter = telemetryRouter;
 
@@ -23,6 +23,7 @@ class NativeIntegration {
   final MethodChannel _channel = const MethodChannel('faro');
 
   int _warmStart = 0;
+  Timer? _vitalsTimer;
 
   /// Initialize the native integration with the specified features
   ///
@@ -48,6 +49,24 @@ class NativeIntegration {
     );
     initRefreshRate();
     initializeMethodChannel();
+  }
+
+  /// Cancels the periodic vitals timer and detaches the method channel
+  /// handler.
+  ///
+  /// Invoked by dartypod when [nativeIntegrationProvider]'s scope is cleared.
+  /// This instance is scoped to a single `Faro.init`; without teardown its
+  /// timer would keep firing and holding the (now stale) telemetry router and
+  /// session manager alive after `Faro.resetForTesting` or a re-init.
+  ///
+  /// Detaching the handler is safe because disposal always runs before the
+  /// next `Faro.init` registers a new handler on the shared `'faro'` channel;
+  /// it is never disposed after a newer instance has taken over.
+  @override
+  void dispose() {
+    _vitalsTimer?.cancel();
+    _vitalsTimer = null;
+    _channel.setMethodCallHandler(null);
   }
 
   /// Pushes an SDK-emitted vitals measurement, marked
@@ -113,7 +132,8 @@ class NativeIntegration {
     Duration setSendUsageInterval = const Duration(seconds: 60),
   }) {
     if (memusage || cpuusage || anr || refreshrate) {
-      Timer.periodic(setSendUsageInterval, (timer) {
+      _vitalsTimer?.cancel();
+      _vitalsTimer = Timer.periodic(setSendUsageInterval, (timer) {
         if (memusage) {
           _pushMemoryUsage();
         }
@@ -223,8 +243,9 @@ class NativeIntegration {
 /// Provides the [NativeIntegration].
 ///
 /// Lives in [faroInitScope] so each `Faro.init` gets a fresh instance
-/// wired to the current telemetry router, and it is evicted by
-/// `Faro.resetForTesting`.
+/// wired to the current telemetry router. Clearing the scope in
+/// `Faro.resetForTesting` disposes it (see [NativeIntegration.dispose]),
+/// cancelling the vitals timer so it cannot outlive its `Faro.init`.
 final nativeIntegrationProvider = Provider<NativeIntegration>(
   (pod) =>
       NativeIntegration(telemetryRouter: pod.resolve(telemetryRouterProvider)),

--- a/lib/src/integrations/native_integration.dart
+++ b/lib/src/integrations/native_integration.dart
@@ -3,17 +3,26 @@ import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
 
+import 'package:dartypod/dartypod.dart';
+import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/models/log_level.dart';
+import 'package:faro/src/models/measurement.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/user_actions/telemetry_router.dart';
+import 'package:faro/src/user_actions/user_action_types.dart';
 import 'package:flutter/services.dart';
 
 /// NativeIntegration provides access to native platform metrics and events
 /// such as memory usage, CPU usage, ANR detection, and crash reporting.
 class NativeIntegration {
+  NativeIntegration({required TelemetryRouter telemetryRouter})
+    : _telemetryRouter = telemetryRouter;
+
+  final TelemetryRouter _telemetryRouter;
   final MethodChannel _channel = const MethodChannel('faro');
 
-  static final NativeIntegration instance = NativeIntegration();
-  static int warmStart = 0;
+  int _warmStart = 0;
 
   /// Initialize the native integration with the specified features
   ///
@@ -41,6 +50,16 @@ class NativeIntegration {
     initializeMethodChannel();
   }
 
+  /// Pushes an SDK-emitted vitals measurement, marked
+  /// [SessionActivityKind.foregroundOnly] so it only extends the session
+  /// while the app is foregrounded (see [SessionManager] for the rationale).
+  void _pushVitalsMeasurement(Map<String, dynamic>? values, String type) {
+    _telemetryRouter.ingest(
+      TelemetryItem.fromMeasurement(Measurement(values, type)),
+      activity: SessionActivityKind.foregroundOnly,
+    );
+  }
+
   /// Initialize refresh rate monitoring
   Future<void> initRefreshRate() async {
     try {
@@ -55,7 +74,7 @@ class NativeIntegration {
     try {
       final appStart = await Faro().nativeChannel?.getAppStart();
       if (appStart != null) {
-        Faro().pushMeasurement({
+        _pushVitalsMeasurement({
           'appStartDuration': appStart['appStartDuration'],
           'coldStart': 1,
         }, 'app_startup');
@@ -67,16 +86,16 @@ class NativeIntegration {
 
   /// Set timestamp for warm start measurement
   void setWarmStart() {
-    warmStart = DateTime.now().millisecondsSinceEpoch;
+    _warmStart = DateTime.now().millisecondsSinceEpoch;
   }
 
   /// Get app start metrics for warm start
   Future<void> getWarmStart() async {
     try {
       final warmStartDuration =
-          DateTime.now().millisecondsSinceEpoch - warmStart;
+          DateTime.now().millisecondsSinceEpoch - _warmStart;
       if (warmStartDuration > 0) {
-        Faro().pushMeasurement({
+        _pushVitalsMeasurement({
           'appStartDuration': warmStartDuration,
           'coldStart': 0,
         }, 'app_startup');
@@ -119,14 +138,14 @@ class NativeIntegration {
     final refreshRate = await Faro().nativeChannel?.getRefreshRate();
     log('refreshRate $refreshRate');
     if (refreshRate != null) {
-      Faro().pushMeasurement({'refresh_rate': refreshRate}, 'app_refresh_rate');
+      _pushVitalsMeasurement({'refresh_rate': refreshRate}, 'app_refresh_rate');
     }
   }
 
   Future<void> _pushCpuUsage() async {
     final cpuUsage = await Faro().nativeChannel?.getCpuUsage();
     if (cpuUsage! > 0.0 && cpuUsage < 100.0) {
-      Faro().pushMeasurement({'cpu_usage': cpuUsage}, 'app_cpu_usage');
+      _pushVitalsMeasurement({'cpu_usage': cpuUsage}, 'app_cpu_usage');
     }
   }
 
@@ -135,7 +154,7 @@ class NativeIntegration {
 
     if (anr != null && anr.isNotEmpty) {
       // Push the ANR count as a measurement
-      Faro().pushMeasurement({'anr_count': anr.length}, 'anr');
+      _pushVitalsMeasurement({'anr_count': anr.length}, 'anr');
 
       // Log each ANR as a warning with its stacktrace
       for (final anrItem in anr) {
@@ -157,11 +176,11 @@ class NativeIntegration {
 
   Future<void> _pushMemoryUsage() async {
     final memUsage = await Faro().nativeChannel?.getMemoryUsage();
-    Faro().pushMeasurement({'mem_usage': memUsage}, 'app_memory');
+    _pushVitalsMeasurement({'mem_usage': memUsage}, 'app_memory');
   }
 
-  static void initializeMethodChannel() {
-    instance._channel.setMethodCallHandler((call) async {
+  void initializeMethodChannel() {
+    _channel.setMethodCallHandler((call) async {
       try {
         switch (call.method) {
           case 'lastCrashReport':
@@ -172,7 +191,7 @@ class NativeIntegration {
 
           case 'onFrozenFrame':
             if (call.arguments != null) {
-              Faro().pushMeasurement({
+              _pushVitalsMeasurement({
                 'frozen_frames': call.arguments,
               }, 'app_frozen_frame');
             }
@@ -180,7 +199,7 @@ class NativeIntegration {
 
           case 'onRefreshRate':
             if (call.arguments != null) {
-              Faro().pushMeasurement({
+              _pushVitalsMeasurement({
                 'refresh_rate': call.arguments,
               }, 'app_refresh_rate');
             }
@@ -188,7 +207,7 @@ class NativeIntegration {
 
           case 'onSlowFrames':
             if (call.arguments != null) {
-              Faro().pushMeasurement({
+              _pushVitalsMeasurement({
                 'slow_frames': call.arguments,
               }, 'app_frames_rate');
             }
@@ -200,3 +219,14 @@ class NativeIntegration {
     });
   }
 }
+
+/// Provides the [NativeIntegration].
+///
+/// Lives in [faroInitScope] so each `Faro.init` gets a fresh instance
+/// wired to the current telemetry router, and it is evicted by
+/// `Faro.resetForTesting`.
+final nativeIntegrationProvider = Provider<NativeIntegration>(
+  (pod) =>
+      NativeIntegration(telemetryRouter: pod.resolve(telemetryRouterProvider)),
+  scope: faroInitScope,
+);

--- a/lib/src/session/app_lifecycle_service.dart
+++ b/lib/src/session/app_lifecycle_service.dart
@@ -1,0 +1,41 @@
+import 'package:dartypod/dartypod.dart';
+import 'package:faro/src/core/pod.dart';
+import 'package:flutter/widgets.dart';
+
+/// Tracks whether the app is currently in the foreground.
+///
+/// Single source of truth for the app's foreground/background state,
+/// updated from `FaroWidgetsBindingObserver` and read by consumers that
+/// vary behavior by foreground state (e.g. the telemetry router's
+/// foreground-gated session activity).
+class AppLifecycleService {
+  bool _isInForeground = true;
+
+  /// Whether the app is currently in the foreground (visible and
+  /// interactive).
+  ///
+  /// Defaults to `true`: the SDK initializes while the app is
+  /// foregrounded, before the first lifecycle callback arrives.
+  bool get isInForeground => _isInForeground;
+
+  /// Updates the foreground flag from an [AppLifecycleState].
+  ///
+  /// Only [AppLifecycleState.resumed] counts as foreground. `inactive`,
+  /// `paused`, `hidden` and `detached` are treated as background so
+  /// passive vitals stop extending the session (e.g. the screen is
+  /// locked or the app is backgrounded).
+  void updateFromLifecycleState(AppLifecycleState state) {
+    _isInForeground = state == AppLifecycleState.resumed;
+  }
+}
+
+/// Provides the shared [AppLifecycleService].
+///
+/// The widgets binding observer (writer) and the telemetry router
+/// (reader) resolve the same instance, so the router always reads live
+/// foreground state. Lives in [faroInitScope] so each `Faro.init` starts
+/// from a fresh foreground instance (evicted by `Faro.resetForTesting`).
+final appLifecycleServiceProvider = Provider(
+  (_) => AppLifecycleService(),
+  scope: faroInitScope,
+);

--- a/lib/src/session/session_activity_kind.dart
+++ b/lib/src/session/session_activity_kind.dart
@@ -1,0 +1,11 @@
+/// Classifies telemetry by how it affects the session inactivity window.
+enum SessionActivityKind {
+  /// Always extends the inactivity window.
+  active,
+
+  /// Extends the window only while the app is in the foreground.
+  foregroundOnly,
+
+  /// Never extends the window (e.g. SDK lifecycle events).
+  none,
+}

--- a/lib/src/session/session_activity_policy.dart
+++ b/lib/src/session/session_activity_policy.dart
@@ -1,0 +1,29 @@
+import 'package:dartypod/dartypod.dart';
+import 'package:faro/src/core/pod.dart';
+import 'package:faro/src/session/app_lifecycle_service.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+
+/// Decides whether a telemetry item extends the session inactivity
+/// window, based on its [SessionActivityKind] and the current app state.
+class SessionActivityPolicy {
+  SessionActivityPolicy(this._appLifecycleService);
+
+  final AppLifecycleService _appLifecycleService;
+
+  /// Whether telemetry classified as [kind] records session activity.
+  bool recordsActivity(SessionActivityKind kind) {
+    switch (kind) {
+      case SessionActivityKind.active:
+        return true;
+      case SessionActivityKind.foregroundOnly:
+        return _appLifecycleService.isInForeground;
+      case SessionActivityKind.none:
+        return false;
+    }
+  }
+}
+
+final sessionActivityPolicyProvider = Provider(
+  (pod) => SessionActivityPolicy(pod.resolve(appLifecycleServiceProvider)),
+  scope: faroInitScope,
+);

--- a/lib/src/session/session_id_provider.dart
+++ b/lib/src/session/session_id_provider.dart
@@ -1,14 +1,16 @@
+import 'package:dartypod/dartypod.dart';
 import 'package:faro/src/util/short_id.dart';
 
+/// Holds the current session id, regenerated on rotation.
 class SessionIdProvider {
-  final sessionId = generateShortId();
-}
+  String _sessionId = generateShortId();
 
-class SessionIdProviderFactory {
-  static SessionIdProvider? _sessionIdProvider;
+  String get sessionId => _sessionId;
 
-  SessionIdProvider create() {
-    _sessionIdProvider ??= SessionIdProvider();
-    return _sessionIdProvider!;
+  String rotateSessionId() {
+    return _sessionId = generateShortId();
   }
 }
+
+/// Provides the shared [SessionIdProvider] (a process-wide singleton).
+final sessionIdProviderProvider = Provider((_) => SessionIdProvider());

--- a/lib/src/session/session_manager.dart
+++ b/lib/src/session/session_manager.dart
@@ -1,0 +1,172 @@
+import 'package:dartypod/dartypod.dart';
+import 'package:faro/src/core/current_time_provider.dart';
+import 'package:faro/src/core/pod.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/session/session_activity_policy.dart';
+import 'package:faro/src/session/session_id_provider.dart';
+
+/// Why a session became active.
+enum SessionStartTrigger {
+  /// The first session after the SDK started (via [SessionManager.start]).
+  initial,
+
+  /// A rotation triggered by inactivity or maximum lifetime.
+  rotation,
+}
+
+/// Called when a new session becomes active.
+///
+/// [trigger] identifies whether this is the initial session or a rotation.
+typedef SessionChangedListener =
+    void Function({
+      required String currentId,
+      String? previousId,
+      required SessionStartTrigger trigger,
+    });
+
+/// Tracks session validity and rotates the session when it expires.
+///
+/// A session expires when either:
+/// - no activity has been recorded for [inactivityTimeout]
+///   (Faro default: 15 minutes), or
+/// - the session has been alive for [maxLifetime]
+///   (Faro default: 4 hours).
+///
+/// Expiry is checked lazily when telemetry is ingested, not by a timer.
+class SessionManager {
+  SessionManager({
+    required SessionIdProvider sessionIdProvider,
+    required SessionActivityPolicy activityPolicy,
+    this.inactivityTimeout = defaultInactivityTimeout,
+    this.maxLifetime = defaultMaxLifetime,
+    CurrentTimeProvider? currentTimeProvider,
+  }) : assert(
+         inactivityTimeout > Duration.zero,
+         'inactivityTimeout must be positive',
+       ),
+       assert(maxLifetime > Duration.zero, 'maxLifetime must be positive'),
+       _sessionIdProvider = sessionIdProvider,
+       _activityPolicy = activityPolicy,
+       _currentTimeProvider = currentTimeProvider ?? DateTime.now {
+    final now = _currentTimeProvider();
+    _startedAt = now;
+    _lastActivityAt = now;
+  }
+
+  /// Default inactivity timeout before a session expires (15 minutes).
+  static const Duration defaultInactivityTimeout = Duration(minutes: 15);
+
+  /// Default maximum total session lifetime (4 hours).
+  static const Duration defaultMaxLifetime = Duration(hours: 4);
+
+  /// Inactivity period after which the session expires.
+  final Duration inactivityTimeout;
+
+  /// Maximum total lifetime of a session.
+  final Duration maxLifetime;
+
+  final SessionIdProvider _sessionIdProvider;
+  final SessionActivityPolicy _activityPolicy;
+  final CurrentTimeProvider _currentTimeProvider;
+  final List<SessionChangedListener> _listeners = [];
+
+  late DateTime _startedAt;
+  late DateTime _lastActivityAt;
+  String? _previousSessionId;
+  bool _isRotating = false;
+  bool _isActive = false;
+
+  /// When the current session started.
+  DateTime get startedAt => _startedAt;
+
+  /// When activity was last recorded for the current session.
+  DateTime get lastActivityAt => _lastActivityAt;
+
+  /// The id of the currently active session.
+  String get currentSessionId => _sessionIdProvider.sessionId;
+
+  /// The id of the session that preceded the current one, if known.
+  String? get previousSessionId => _previousSessionId;
+
+  /// Registers [listener] to be notified of session lifecycle changes.
+  void addListener(SessionChangedListener listener) {
+    _listeners.add(listener);
+  }
+
+  /// Activates session tracking and announces the initial session.
+  ///
+  /// Until this runs, [checkSession] is a no-op. Calling [start] resets
+  /// the timing baseline to now and notifies listeners so they can emit
+  /// the initial `session_start`.
+  void start() {
+    final now = _currentTimeProvider();
+    _startedAt = now;
+    _lastActivityAt = now;
+    _isActive = true;
+    _notifySessionStarted(trigger: SessionStartTrigger.initial);
+  }
+
+  /// Checks session validity and records activity per [activity].
+  ///
+  /// Call this before attributing telemetry to the session. If the
+  /// session has expired, it rotates first so the triggering telemetry
+  /// belongs to the new session.
+  ///
+  /// [activity] classifies the telemetry; the [SessionActivityPolicy]
+  /// decides whether it extends the inactivity window.
+  ///
+  /// Re-entrant calls made while rotation runs are ignored.
+  void checkSession({required SessionActivityKind activity}) {
+    if (!_isActive || _isRotating) {
+      return;
+    }
+    final now = _currentTimeProvider();
+    if (_isExpired(now)) {
+      _rotate(now);
+    } else if (_activityPolicy.recordsActivity(activity)) {
+      _lastActivityAt = now;
+    }
+  }
+
+  /// Rotates the session and notifies listeners.
+  void _rotate(DateTime now) {
+    _isRotating = true;
+    try {
+      final previousId = _sessionIdProvider.sessionId;
+      _sessionIdProvider.rotateSessionId();
+      _startedAt = now;
+      _lastActivityAt = now;
+      _previousSessionId = previousId;
+      _notifySessionStarted(trigger: SessionStartTrigger.rotation);
+    } finally {
+      _isRotating = false;
+    }
+  }
+
+  void _notifySessionStarted({required SessionStartTrigger trigger}) {
+    final currentId = _sessionIdProvider.sessionId;
+    final previousId = _previousSessionId;
+    for (final listener in _listeners) {
+      listener(currentId: currentId, previousId: previousId, trigger: trigger);
+    }
+  }
+
+  bool _isExpired(DateTime now) {
+    if (now.difference(_startedAt) >= maxLifetime) {
+      return true;
+    }
+    return now.difference(_lastActivityAt) >= inactivityTimeout;
+  }
+}
+
+/// Provides the [SessionManager].
+///
+/// Lives in [faroInitScope] so each `Faro.init` gets a fresh manager.
+final sessionManagerProvider = Provider<SessionManager>(
+  (pod) => SessionManager(
+    sessionIdProvider: pod.resolve(sessionIdProviderProvider),
+    activityPolicy: pod.resolve(sessionActivityPolicyProvider),
+    currentTimeProvider: pod.resolve(currentTimeProvider),
+  ),
+  scope: faroInitScope,
+);

--- a/lib/src/tracing/faro_otel_bootstrap.dart
+++ b/lib/src/tracing/faro_otel_bootstrap.dart
@@ -24,7 +24,7 @@ class FaroOtelBootstrap {
       // which involves async shutdown work that can hang under Flutter's
       // fake-async test environment. Once initialized, just refresh the
       // Faro tracer wrapper so it observes the latest pod state.
-      FaroTracerFactory.reset();
+      pod.clearScope(tracerScope);
       return;
     }
 
@@ -52,7 +52,7 @@ class FaroOtelBootstrap {
       detectPlatformResources: false,
     );
 
-    FaroTracerFactory.reset();
+    pod.clearScope(tracerScope);
     _initialized = true;
   }
 
@@ -62,7 +62,7 @@ class FaroOtelBootstrap {
       // ignore: invalid_use_of_visible_for_testing_member
       await otel.OTel.reset();
     }
-    FaroTracerFactory.reset();
+    pod.clearScope(tracerScope);
     _initialized = false;
   }
 

--- a/lib/src/tracing/faro_tracer.dart
+++ b/lib/src/tracing/faro_tracer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
+import 'package:dartypod/dartypod.dart';
 import 'package:faro/src/session/session_id_provider.dart';
 import 'package:faro/src/tracing/faro_zone_span_manager.dart';
 import 'package:faro/src/tracing/span.dart';
@@ -117,37 +118,22 @@ class FaroTracer {
   }
 }
 
-class FaroTracerFactory {
-  static FaroTracer? _faroTracer;
+/// Scope for [faroTracerProvider]. Cleared when the tracer wrapper must be
+/// rebuilt without re-initializing the process-global OTel SDK.
+const tracerScope = CustomScope('tracer');
 
-  /// Resets the cached tracer. Visible for testing.
-  static void reset() {
-    _faroTracer = null;
-  }
-
-  FaroTracer create() {
-    final cached = _faroTracer;
-    if (cached != null) {
-      return cached;
-    }
-
-    // Use OTelAPI directly so we degrade to a no-op tracer if the Faro
-    // bootstrap (which calls OTel.initialize) hasn't run yet — e.g. when
-    // FaroHttpTrackingClient is used in unit tests that never call Faro.init.
-    final otelTracer = otel.OTelAPI.tracerProvider().getTracer(
-      FaroConstants.sdkName,
-      version: FaroConstants.sdkVersion,
-    );
-    final faroZoneSpanManager = FaroZoneSpanManagerFactory().create();
-    final sessionIdProvider = SessionIdProviderFactory().create();
-
-    final faroTracer = FaroTracer(
-      otelTracer: otelTracer,
-      faroZoneSpanManager: faroZoneSpanManager,
-      sessionIdProvider: sessionIdProvider,
-    );
-    _faroTracer = faroTracer;
-
-    return faroTracer;
-  }
-}
+/// Provides the shared [FaroTracer].
+final faroTracerProvider = Provider<FaroTracer>((pod) {
+  // Use OTelAPI directly so we degrade to a no-op tracer if the Faro
+  // bootstrap (which calls OTel.initialize) hasn't run yet — e.g. when
+  // FaroHttpTrackingClient is used in unit tests that never call Faro.init.
+  final otelTracer = otel.OTelAPI.tracerProvider().getTracer(
+    FaroConstants.sdkName,
+    version: FaroConstants.sdkVersion,
+  );
+  return FaroTracer(
+    otelTracer: otelTracer,
+    faroZoneSpanManager: FaroZoneSpanManagerFactory().create(),
+    sessionIdProvider: pod.resolve(sessionIdProviderProvider),
+  );
+}, scope: tracerScope);

--- a/lib/src/transport/faro_transport.dart
+++ b/lib/src/transport/faro_transport.dart
@@ -7,21 +7,39 @@ import 'package:faro/src/transport/faro_base_transport.dart';
 import 'package:faro/src/transport/task_buffer.dart';
 import 'package:http/http.dart' as http;
 
+/// Resolves the current session id to send in the `x-faro-session-id` header.
+typedef SessionIdResolver = String Function();
+
 class FaroTransport extends BaseTransport {
   FaroTransport({
     required this.collectorUrl,
     required this.apiKey,
-    this.sessionId,
+    required SessionIdResolver sessionIdResolver,
     int? maxBufferLimit,
     this.headers,
-  }) {
+    http.Client? httpClient,
+  }) : _sessionIdResolver = sessionIdResolver,
+       _httpClient = httpClient {
     _taskBuffer = TaskBuffer(maxBufferLimit ?? 30);
   }
   final String collectorUrl;
   final String apiKey;
-  final String? sessionId;
+
+  /// Resolves the current session id at send time.
+  ///
+  /// The `x-faro-session-id` header identifies the session the client
+  /// currently considers active — the receiver uses it for server-side
+  /// session validation and accounting, independently of the session id
+  /// carried in the payload body. Resolving it live keeps the header on the
+  /// active session even when a rotation happened after this transport was
+  /// created, or when an older cached payload is replayed offline.
+  final SessionIdResolver _sessionIdResolver;
   TaskBuffer<dynamic>? _taskBuffer;
   final Map<String, String>? headers;
+
+  /// Optional HTTP client seam for tests. When null, the top-level
+  /// [http.post] is used so production behavior is unchanged.
+  final http.Client? _httpClient;
 
   @override
   Future<void> send(Map<String, dynamic> payloadJson) async {
@@ -32,17 +50,17 @@ class FaroTransport extends BaseTransport {
 
     try {
       final encodedPayload = jsonEncode(payloadJson);
-      final sessionId = this.sessionId;
 
       final headers = {
         'Content-Type': 'application/json',
         'x-api-key': apiKey,
-        'x-faro-session-id': ?sessionId,
+        'x-faro-session-id': _sessionIdResolver(),
         ...?this.headers,
       };
 
+      final post = _httpClient?.post ?? http.post;
       final response = await _taskBuffer?.add(() {
-        return http.post(
+        return post(
           Uri.parse(collectorUrl),
           headers: headers,
           body: encodedPayload,

--- a/lib/src/user_actions/telemetry_router.dart
+++ b/lib/src/user_actions/telemetry_router.dart
@@ -1,4 +1,7 @@
 import 'package:dartypod/dartypod.dart';
+import 'package:faro/src/core/pod.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/session/session_manager.dart';
 import 'package:faro/src/transport/batch_transport.dart';
 import 'package:faro/src/user_actions/telemetry_item_dispatcher.dart';
 import 'package:faro/src/user_actions/user_action_types.dart';
@@ -9,11 +12,14 @@ class TelemetryRouter {
   TelemetryRouter({
     required BatchTransportResolver transportResolver,
     required UserActionsService userActionsService,
+    required SessionManager sessionManager,
   }) : _transportResolver = transportResolver,
-       _userActionsService = userActionsService;
+       _userActionsService = userActionsService,
+       _sessionManager = sessionManager;
 
   final BatchTransportResolver _transportResolver;
   final UserActionsService _userActionsService;
+  final SessionManager _sessionManager;
 
   /// Ingests a telemetry item and dispatches it according to routing
   /// rules.
@@ -24,7 +30,16 @@ class TelemetryRouter {
   ///
   /// If [skipBuffer] is `true`, the item bypasses user action buffering
   /// and is dispatched to transport immediately.
-  void ingest(TelemetryItem item, {bool skipBuffer = false}) {
+  ///
+  /// [activity] classifies how this item affects the session inactivity
+  /// window (see [SessionActivityKind]).
+  void ingest(
+    TelemetryItem item, {
+    bool skipBuffer = false,
+    SessionActivityKind activity = SessionActivityKind.active,
+  }) {
+    _sessionManager.checkSession(activity: activity);
+
     if (!skipBuffer &&
         _shouldBuffer(item.type) &&
         _userActionsService.tryBuffer(item)) {
@@ -46,9 +61,11 @@ class TelemetryRouter {
   }
 }
 
-final telemetryRouterProvider = Provider((pod) {
-  return TelemetryRouter(
-    transportResolver: pod.resolve(batchTransportResolverProvider),
+final telemetryRouterProvider = Provider<TelemetryRouter>(
+  (pod) => TelemetryRouter(
     userActionsService: pod.resolve(userActionsServiceProvider),
-  );
-});
+    transportResolver: pod.resolve(batchTransportResolverProvider),
+    sessionManager: pod.resolve(sessionManagerProvider),
+  ),
+  scope: faroInitScope,
+);

--- a/test/src/faro_widgets_binding_observer_test.dart
+++ b/test/src/faro_widgets_binding_observer_test.dart
@@ -1,0 +1,61 @@
+import 'package:faro/src/faro.dart';
+import 'package:faro/src/faro_widgets_binding_observer.dart';
+import 'package:faro/src/integrations/native_integration.dart';
+import 'package:faro/src/session/app_lifecycle_service.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockFaro extends Mock implements Faro {}
+
+class MockNativeIntegration extends Mock implements NativeIntegration {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockFaro mockFaro;
+  late MockNativeIntegration mockNativeIntegration;
+  late AppLifecycleService lifecycleService;
+
+  setUp(() {
+    mockFaro = MockFaro();
+    mockNativeIntegration = MockNativeIntegration();
+    lifecycleService = AppLifecycleService();
+    Faro.instance = mockFaro;
+
+    when(
+      () => mockFaro.pushEvent(any(), attributes: any(named: 'attributes')),
+    ).thenReturn(null);
+  });
+
+  group('FaroWidgetsBindingObserver:', () {
+    test('updates AppLifecycleService on lifecycle change', () {
+      final observer = FaroWidgetsBindingObserver(
+        appLifecycleService: lifecycleService,
+        nativeIntegration: mockNativeIntegration,
+      );
+
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      expect(lifecycleService.isInForeground, isFalse);
+
+      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      expect(lifecycleService.isInForeground, isTrue);
+    });
+
+    test('emits app_lifecycle_changed events', () {
+      final observer = FaroWidgetsBindingObserver(
+        appLifecycleService: lifecycleService,
+        nativeIntegration: mockNativeIntegration,
+      );
+
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+
+      verify(
+        () => mockFaro.pushEvent(
+          'app_lifecycle_changed',
+          attributes: {'fromState': '', 'toState': 'paused'},
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/test/src/integrations/native_integration_test.dart
+++ b/test/src/integrations/native_integration_test.dart
@@ -1,3 +1,5 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/integrations/native_integration.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
@@ -48,6 +50,12 @@ void main() {
     Faro.instance = mockFaro;
   });
 
+  tearDown(() {
+    // Undo any pod mutations made by the scope-teardown test.
+    pod.removeOverride(telemetryRouterProvider);
+    pod.clearScope(faroInitScope);
+  });
+
   group('NativeIntegration', () {
     test('init initializes refresh rate and method channel', () async {
       nativeIntegration.init(
@@ -83,5 +91,36 @@ void main() {
         expect(router.activities, [SessionActivityKind.foregroundOnly]);
       },
     );
+
+    test('clearing faroInitScope stops the vitals timer', () {
+      fakeAsync((async) {
+        // Resolve the provider-built instance (as Faro.init does) wired to a
+        // router we can observe.
+        pod.overrideProvider(telemetryRouterProvider, (_) => router);
+        final integration = pod.resolve(nativeIntegrationProvider);
+
+        integration.init(
+          memusage: true,
+          setSendUsageInterval: const Duration(seconds: 10),
+        );
+
+        async.elapse(const Duration(seconds: 10));
+        final countBeforeClear = router.ingested.length;
+        expect(countBeforeClear, greaterThan(0));
+
+        // Simulate Faro.resetForTesting()/re-init: evict the per-init
+        // instance from its scope.
+        pod.clearScope(faroInitScope);
+
+        // The evicted instance's timer must stop; otherwise it keeps
+        // ingesting into the stale router and session manager.
+        async.elapse(const Duration(seconds: 30));
+        expect(
+          router.ingested.length,
+          countBeforeClear,
+          reason: 'timer from the evicted instance must not keep firing',
+        );
+      });
+    });
   });
 }

--- a/test/src/integrations/native_integration_test.dart
+++ b/test/src/integrations/native_integration_test.dart
@@ -1,6 +1,9 @@
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/integrations/native_integration.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/user_actions/telemetry_router.dart';
+import 'package:faro/src/user_actions/user_action_types.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -8,16 +11,33 @@ class MockFaro extends Mock implements Faro {}
 
 class MockNativeChannel extends Mock implements FaroNativeMethods {}
 
+class _RecordingRouter implements TelemetryRouter {
+  final List<TelemetryItem> ingested = [];
+  final List<SessionActivityKind> activities = [];
+
+  @override
+  void ingest(
+    TelemetryItem item, {
+    bool skipBuffer = false,
+    SessionActivityKind activity = SessionActivityKind.active,
+  }) {
+    ingested.add(item);
+    activities.add(activity);
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   late MockFaro mockFaro;
   late MockNativeChannel mockNativeChannel;
   late NativeIntegration nativeIntegration;
+  late _RecordingRouter router;
 
   setUp(() {
     mockFaro = MockFaro();
     mockNativeChannel = MockNativeChannel();
-    nativeIntegration = NativeIntegration();
+    router = _RecordingRouter();
+    nativeIntegration = NativeIntegration(telemetryRouter: router);
 
     when(() => mockFaro.nativeChannel).thenReturn(mockNativeChannel);
     when(
@@ -46,7 +66,22 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 10));
       nativeIntegration.getWarmStart();
 
-      verify(() => mockFaro.pushMeasurement(any(), 'app_startup')).called(1);
+      expect(router.ingested, hasLength(1));
+      final measurement = router.ingested.single.asMeasurement;
+      expect(measurement?.type, 'app_startup');
     });
+
+    test(
+      'vitals measurements are ingested as foreground-gated telemetry',
+      () async {
+        nativeIntegration.setWarmStart();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        nativeIntegration.getWarmStart();
+
+        // Automatic vitals use foregroundOnly; SessionActivityPolicy decides
+        // whether they extend the session based on foreground state.
+        expect(router.activities, [SessionActivityKind.foregroundOnly]);
+      },
+    );
   });
 }

--- a/test/src/session/app_lifecycle_service_test.dart
+++ b/test/src/session/app_lifecycle_service_test.dart
@@ -1,0 +1,39 @@
+import 'package:faro/src/session/app_lifecycle_service.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppLifecycleService:', () {
+    test('defaults to foreground', () {
+      expect(AppLifecycleService().isInForeground, isTrue);
+    });
+
+    test('resumed counts as foreground', () {
+      final service = AppLifecycleService()
+        ..updateFromLifecycleState(AppLifecycleState.paused);
+      expect(service.isInForeground, isFalse);
+
+      service.updateFromLifecycleState(AppLifecycleState.resumed);
+      expect(service.isInForeground, isTrue);
+    });
+
+    test('inactive, paused, hidden and detached count as background', () {
+      final service = AppLifecycleService();
+      for (final state in const [
+        AppLifecycleState.inactive,
+        AppLifecycleState.paused,
+        AppLifecycleState.hidden,
+        AppLifecycleState.detached,
+      ]) {
+        service
+          ..updateFromLifecycleState(AppLifecycleState.resumed)
+          ..updateFromLifecycleState(state);
+        expect(
+          service.isInForeground,
+          isFalse,
+          reason: '$state should be treated as background',
+        );
+      }
+    });
+  });
+}

--- a/test/src/session/session_activity_policy_test.dart
+++ b/test/src/session/session_activity_policy_test.dart
@@ -1,0 +1,41 @@
+import 'package:faro/src/session/app_lifecycle_service.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/session/session_activity_policy.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SessionActivityPolicy:', () {
+    late AppLifecycleService lifecycle;
+    late SessionActivityPolicy policy;
+
+    setUp(() {
+      lifecycle = AppLifecycleService();
+      policy = SessionActivityPolicy(lifecycle);
+    });
+
+    test('active always records activity, even when backgrounded', () {
+      lifecycle.updateFromLifecycleState(AppLifecycleState.paused);
+      expect(policy.recordsActivity(SessionActivityKind.active), isTrue);
+    });
+
+    test('none never records activity, even when foregrounded', () {
+      lifecycle.updateFromLifecycleState(AppLifecycleState.resumed);
+      expect(policy.recordsActivity(SessionActivityKind.none), isFalse);
+    });
+
+    test('foregroundOnly records activity only while in the foreground', () {
+      lifecycle.updateFromLifecycleState(AppLifecycleState.resumed);
+      expect(
+        policy.recordsActivity(SessionActivityKind.foregroundOnly),
+        isTrue,
+      );
+
+      lifecycle.updateFromLifecycleState(AppLifecycleState.paused);
+      expect(
+        policy.recordsActivity(SessionActivityKind.foregroundOnly),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/src/session/session_id_provider_test.dart
+++ b/test/src/session/session_id_provider_test.dart
@@ -51,6 +51,17 @@ void main() {
       expect(firstAccess, equals(secondAccess));
     });
 
+    test('should generate a new session ID on rotateSessionId', () {
+      final sut = SessionIdProvider();
+      final initialSessionId = sut.sessionId;
+
+      final rotatedSessionId = sut.rotateSessionId();
+
+      expect(rotatedSessionId, isNot(equals(initialSessionId)));
+      expect(sut.sessionId, equals(rotatedSessionId));
+      expect(RegExp(r'^[a-zA-Z0-9]{10}$').hasMatch(rotatedSessionId), isTrue);
+    });
+
     test('should generate session IDs matching expected pattern', () {
       // Generate multiple IDs to test pattern consistency
       for (var i = 0; i < 10; i++) {
@@ -65,62 +76,6 @@ void main() {
         );
       }
     });
-  });
-
-  group('SessionIdProviderFactory:', () {
-    late SessionIdProviderFactory sut;
-
-    setUp(() {
-      sut = SessionIdProviderFactory();
-    });
-
-    test('should create a SessionIdProvider instance', () {
-      final provider = sut.create();
-
-      expect(provider, isA<SessionIdProvider>());
-      expect(provider.sessionId, isNotEmpty);
-    });
-
-    test(
-      'should return the same instance on multiple calls (singleton behavior)',
-      () {
-        final provider1 = sut.create();
-        final provider2 = sut.create();
-
-        expect(identical(provider1, provider2), isTrue);
-        expect(provider1.sessionId, equals(provider2.sessionId));
-      },
-    );
-
-    test('should return same instance across different factory instances', () {
-      final factory1 = SessionIdProviderFactory();
-      final factory2 = SessionIdProviderFactory();
-
-      final provider1 = factory1.create();
-      final provider2 = factory2.create();
-
-      expect(identical(provider1, provider2), isTrue);
-      expect(provider1.sessionId, equals(provider2.sessionId));
-    });
-
-    test(
-      'should maintain singleton state after multiple factory instantiations',
-      () {
-        final factory1 = SessionIdProviderFactory();
-        final provider1 = factory1.create();
-
-        final factory2 = SessionIdProviderFactory();
-        final provider2 = factory2.create();
-
-        final factory3 = SessionIdProviderFactory();
-        final provider3 = factory3.create();
-
-        expect(identical(provider1, provider2), isTrue);
-        expect(identical(provider2, provider3), isTrue);
-        expect(provider1.sessionId, equals(provider2.sessionId));
-        expect(provider2.sessionId, equals(provider3.sessionId));
-      },
-    );
   });
 
   group('SessionIdProvider _generateSessionID static method:', () {

--- a/test/src/session/session_manager_test.dart
+++ b/test/src/session/session_manager_test.dart
@@ -1,0 +1,370 @@
+import 'package:faro/src/session/app_lifecycle_service.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/session/session_activity_policy.dart';
+import 'package:faro/src/session/session_id_provider.dart';
+import 'package:faro/src/session/session_manager.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Records session lifecycle notifications for assertions.
+///
+/// Register [onSessionChanged] via [SessionManager.addListener].
+class _RecordingObserver {
+  int startedCount = 0;
+  String? lastCurrentId;
+  String? lastPreviousId;
+  SessionStartTrigger? lastTrigger;
+
+  /// Optional hook invoked inside [onSessionChanged], used to simulate
+  /// telemetry that re-enters the manager during rotation.
+  void Function()? onStarted;
+
+  void reset() {
+    startedCount = 0;
+    lastCurrentId = null;
+    lastPreviousId = null;
+    lastTrigger = null;
+  }
+
+  void onSessionChanged({
+    required String currentId,
+    String? previousId,
+    required SessionStartTrigger trigger,
+  }) {
+    startedCount++;
+    lastCurrentId = currentId;
+    lastPreviousId = previousId;
+    lastTrigger = trigger;
+    onStarted?.call();
+  }
+}
+
+void main() {
+  group('SessionManager:', () {
+    const inactivityTimeout = Duration(minutes: 15);
+    const maxLifetime = Duration(hours: 4);
+
+    late DateTime now;
+    late _RecordingObserver observer;
+
+    // Builds an inert manager wired to [observer]. Call `start()` before
+    // exercising `checkSession` (see [createManager]).
+    SessionManager buildManager({
+      Duration inactivity = inactivityTimeout,
+      Duration lifetime = maxLifetime,
+      AppLifecycleService? lifecycleService,
+    }) {
+      final lifecycle = lifecycleService ?? AppLifecycleService();
+      return SessionManager(
+        sessionIdProvider: SessionIdProvider(),
+        activityPolicy: SessionActivityPolicy(lifecycle),
+        inactivityTimeout: inactivity,
+        maxLifetime: lifetime,
+        currentTimeProvider: () => now,
+      )..addListener(observer.onSessionChanged);
+    }
+
+    // Builds a started (active) manager and clears the observer, so
+    // subsequent `startedCount` reflects rotations only.
+    SessionManager createManager({
+      Duration inactivity = inactivityTimeout,
+      Duration lifetime = maxLifetime,
+      AppLifecycleService? lifecycleService,
+    }) {
+      final manager = buildManager(
+        inactivity: inactivity,
+        lifetime: lifetime,
+        lifecycleService: lifecycleService,
+      )..start();
+      observer.reset();
+      return manager;
+    }
+
+    setUp(() {
+      now = DateTime(2026, 6, 10, 12);
+      observer = _RecordingObserver();
+    });
+
+    test('does not rotate when activity is within thresholds', () {
+      final manager = createManager();
+
+      now = now.add(const Duration(minutes: 14, seconds: 59));
+      manager.checkSession(activity: SessionActivityKind.active);
+
+      expect(observer.startedCount, 0);
+      expect(manager.lastActivityAt, now);
+    });
+
+    test('rotates when inactivity reaches the timeout', () {
+      final manager = createManager();
+
+      now = now.add(inactivityTimeout);
+      manager.checkSession(activity: SessionActivityKind.active);
+
+      expect(observer.startedCount, 1);
+    });
+
+    test('rotates when lifetime reaches the max, despite activity', () {
+      final manager = createManager();
+
+      // Stay active every 10 minutes; inactivity never expires.
+      const step = Duration(minutes: 10);
+      final deadline = now.add(maxLifetime);
+      while (now.add(step).isBefore(deadline)) {
+        now = now.add(step);
+        manager.checkSession(activity: SessionActivityKind.active);
+      }
+      expect(observer.startedCount, 0);
+
+      now = deadline;
+      manager.checkSession(activity: SessionActivityKind.active);
+
+      expect(observer.startedCount, 1);
+    });
+
+    test('resets started and lastActivity on rotation', () {
+      final manager = createManager();
+
+      now = now.add(inactivityTimeout);
+      manager.checkSession(activity: SessionActivityKind.active);
+      expect(observer.startedCount, 1);
+      expect(manager.startedAt, now);
+      expect(manager.lastActivityAt, now);
+
+      // New session is fresh: just under the threshold does not rotate.
+      now = now.add(const Duration(minutes: 14));
+      manager.checkSession(activity: SessionActivityKind.active);
+      expect(observer.startedCount, 1);
+
+      // But crossing the threshold from the rotated session does.
+      now = now.add(inactivityTimeout);
+      manager.checkSession(activity: SessionActivityKind.active);
+      expect(observer.startedCount, 2);
+    });
+
+    test('generates a new id and tracks the previous one on rotation', () {
+      final manager = createManager();
+      final initialId = manager.currentSessionId;
+      expect(manager.previousSessionId, isNull);
+
+      now = now.add(inactivityTimeout);
+      manager.checkSession(activity: SessionActivityKind.active);
+
+      expect(manager.currentSessionId, isNot(initialId));
+      expect(manager.previousSessionId, initialId);
+      expect(observer.lastCurrentId, manager.currentSessionId);
+      expect(observer.lastPreviousId, initialId);
+      expect(observer.lastTrigger, SessionStartTrigger.rotation);
+    });
+
+    test('start() announces the initial session with a null previous id', () {
+      final manager = buildManager();
+
+      manager.start();
+
+      expect(observer.startedCount, 1);
+      expect(observer.lastCurrentId, manager.currentSessionId);
+      expect(observer.lastPreviousId, isNull);
+      expect(observer.lastTrigger, SessionStartTrigger.initial);
+    });
+
+    test('is inert until start(): does not rotate before activation', () {
+      final manager = buildManager();
+
+      // Well past the inactivity timeout, but the manager is inert until
+      // start(), so nothing rotates.
+      now = now.add(const Duration(hours: 1));
+      manager.checkSession(activity: SessionActivityKind.active);
+
+      expect(observer.startedCount, 0);
+    });
+
+    test('records activity to keep the session alive', () {
+      final manager = createManager();
+
+      for (var i = 0; i < 10; i++) {
+        now = now.add(const Duration(minutes: 10));
+        manager.checkSession(activity: SessionActivityKind.active);
+      }
+
+      expect(observer.startedCount, 0);
+    });
+
+    test('ignores re-entrant calls during rotation', () {
+      final manager = createManager();
+      // Set the hook after start()/reset so it only fires on rotation.
+      // Simulates the rotation emitting a session_extend event that
+      // flows back through the ingestion path.
+      observer.onStarted = () =>
+          manager.checkSession(activity: SessionActivityKind.active);
+
+      now = now.add(inactivityTimeout);
+      manager.checkSession(activity: SessionActivityKind.active);
+
+      expect(observer.startedCount, 1);
+    });
+
+    test('respects custom durations', () {
+      final manager = createManager(
+        inactivity: const Duration(seconds: 30),
+        lifetime: const Duration(minutes: 5),
+      );
+
+      now = now.add(const Duration(seconds: 29));
+      manager.checkSession(activity: SessionActivityKind.active);
+      expect(observer.startedCount, 0);
+
+      now = now.add(const Duration(seconds: 30));
+      manager.checkSession(activity: SessionActivityKind.active);
+      expect(observer.startedCount, 1);
+    });
+
+    test('rotates on custom max lifetime', () {
+      final manager = createManager(
+        inactivity: const Duration(minutes: 1),
+        lifetime: const Duration(minutes: 2),
+      );
+
+      now = now.add(const Duration(seconds: 50));
+      manager.checkSession(activity: SessionActivityKind.active);
+      now = now.add(const Duration(seconds: 50));
+      manager.checkSession(activity: SessionActivityKind.active);
+      expect(observer.startedCount, 0);
+
+      now = now.add(const Duration(seconds: 50));
+      manager.checkSession(activity: SessionActivityKind.active);
+      expect(observer.startedCount, 1);
+    });
+
+    group('SessionActivityKind.none:', () {
+      test('does not extend the session', () {
+        final manager = createManager();
+        final sessionStart = now;
+
+        // SDK lifecycle events (e.g. session_extend) never move
+        // lastActivity forward.
+        now = now.add(const Duration(minutes: 5));
+        manager.checkSession(activity: SessionActivityKind.none);
+        now = now.add(const Duration(minutes: 5));
+        manager.checkSession(activity: SessionActivityKind.none);
+
+        expect(observer.startedCount, 0);
+        expect(manager.lastActivityAt, sessionStart);
+      });
+
+      test('still rotates the session once expired', () {
+        final manager = createManager();
+
+        // None-kind ingests below the threshold without extending.
+        now = now.add(const Duration(minutes: 10));
+        manager.checkSession(activity: SessionActivityKind.none);
+        expect(observer.startedCount, 0);
+
+        // The first ingest past the inactivity threshold rotates the
+        // session even though it does not record activity.
+        now = now.add(const Duration(minutes: 5));
+        manager.checkSession(activity: SessionActivityKind.none);
+
+        expect(observer.startedCount, 1);
+        expect(manager.startedAt, now);
+        expect(manager.lastActivityAt, now);
+      });
+
+      test('rotates repeatedly while only none-kind telemetry flows', () {
+        final manager = createManager();
+
+        for (var i = 0; i < 3; i++) {
+          for (var j = 0; j < 3; j++) {
+            now = now.add(const Duration(minutes: 5));
+            manager.checkSession(activity: SessionActivityKind.none);
+          }
+        }
+
+        expect(observer.startedCount, 3);
+      });
+
+      test('does not prevent active telemetry from extending', () {
+        final manager = createManager();
+
+        for (var i = 0; i < 10; i++) {
+          now = now.add(const Duration(minutes: 7));
+          manager.checkSession(activity: SessionActivityKind.none);
+          now = now.add(const Duration(minutes: 7));
+          manager.checkSession(activity: SessionActivityKind.active);
+        }
+
+        expect(observer.startedCount, 0);
+      });
+
+      test('still rotates on max lifetime', () {
+        final manager = createManager(
+          inactivity: const Duration(minutes: 1),
+          lifetime: const Duration(minutes: 3),
+        );
+
+        for (var i = 0; i < 5; i++) {
+          now = now.add(const Duration(seconds: 30));
+          manager.checkSession(activity: SessionActivityKind.active);
+        }
+        expect(observer.startedCount, 0);
+
+        now = now.add(const Duration(seconds: 30));
+        manager.checkSession(activity: SessionActivityKind.none);
+        expect(observer.startedCount, 1);
+      });
+    });
+
+    group('SessionActivityKind.foregroundOnly:', () {
+      test('extends the session while foregrounded', () {
+        final lifecycle = AppLifecycleService()
+          ..updateFromLifecycleState(AppLifecycleState.resumed);
+        final manager = createManager(lifecycleService: lifecycle);
+        final sessionStart = now;
+
+        now = now.add(const Duration(minutes: 10));
+        manager.checkSession(activity: SessionActivityKind.foregroundOnly);
+
+        expect(observer.startedCount, 0);
+        expect(manager.lastActivityAt, isNot(sessionStart));
+      });
+
+      test('does not extend the session while backgrounded', () {
+        final lifecycle = AppLifecycleService()
+          ..updateFromLifecycleState(AppLifecycleState.paused);
+        final manager = createManager(lifecycleService: lifecycle);
+        final sessionStart = now;
+
+        now = now.add(const Duration(minutes: 10));
+        manager.checkSession(activity: SessionActivityKind.foregroundOnly);
+
+        expect(observer.startedCount, 0);
+        expect(manager.lastActivityAt, sessionStart);
+      });
+
+      test('rotates once expired even when backgrounded', () {
+        final lifecycle = AppLifecycleService()
+          ..updateFromLifecycleState(AppLifecycleState.paused);
+        final manager = createManager(lifecycleService: lifecycle);
+
+        now = now.add(inactivityTimeout);
+        manager.checkSession(activity: SessionActivityKind.foregroundOnly);
+
+        expect(observer.startedCount, 1);
+      });
+    });
+
+    test('asserts on non-positive inactivity timeout', () {
+      expect(
+        () => createManager(inactivity: Duration.zero),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('asserts on non-positive max lifetime', () {
+      expect(
+        () => createManager(lifetime: const Duration(seconds: -1)),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}

--- a/test/src/session/session_rotation_integration_test.dart
+++ b/test/src/session/session_rotation_integration_test.dart
@@ -1,0 +1,409 @@
+import 'package:faro/src/configurations/batch_config.dart';
+import 'package:faro/src/configurations/faro_config.dart';
+import 'package:faro/src/core/current_time_provider.dart';
+import 'package:faro/src/core/pod.dart';
+import 'package:faro/src/data_collection_policy.dart';
+import 'package:faro/src/faro.dart';
+import 'package:faro/src/integrations/native_integration.dart';
+import 'package:faro/src/models/models.dart';
+import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
+import 'package:faro/src/session/app_lifecycle_service.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/transport/batch_transport.dart';
+import 'package:faro/src/transport/faro_transport.dart';
+import 'package:faro/src/user_actions/telemetry_router.dart';
+import 'package:faro/src/user_actions/user_action_types.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockFaroTransport extends Mock implements FaroTransport {}
+
+class MockBatchTransport extends Mock implements BatchTransport {}
+
+class MockFaroNativeMethods extends Mock implements FaroNativeMethods {}
+
+class MockDataCollectionPolicy extends Mock implements DataCollectionPolicy {}
+
+void main() {
+  group('Session rotation:', () {
+    const appName = 'TestApp';
+    const appVersion = '2.0.3';
+    const appEnv = 'Test';
+    const apiKey = 'TestAPIKey';
+
+    late MockFaroTransport mockFaroTransport;
+    late MockBatchTransport mockBatchTransport;
+    late MockFaroNativeMethods mockFaroNativeMethods;
+    late MockDataCollectionPolicy mockDataCollectionPolicy;
+    late DateTime now;
+
+    setUpAll(() {
+      registerFallbackValue(
+        FaroException('test', 'something', {
+          'frames': <Map<String, dynamic>>[],
+        }),
+      );
+      registerFallbackValue(Event('test'));
+      registerFallbackValue(FaroLog('This is a message'));
+      registerFallbackValue(Measurement({'test': 123}, 'test'));
+      registerFallbackValue(Payload(Meta()));
+      registerFallbackValue(BatchConfig());
+      registerFallbackValue(Meta());
+    });
+
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      await Faro.resetForTesting();
+      BatchTransportFactory().reset();
+
+      SharedPreferences.setMockInitialValues({});
+      mockDataCollectionPolicy = MockDataCollectionPolicy();
+      when(() => mockDataCollectionPolicy.isEnabled).thenReturn(true);
+      when(() => mockDataCollectionPolicy.enable()).thenAnswer((_) async {});
+      when(() => mockDataCollectionPolicy.disable()).thenAnswer((_) async {});
+
+      PackageInfo.setMockInitialValues(
+        appName: appName,
+        packageName: 'com.grafana.example',
+        version: appVersion,
+        buildNumber: '2',
+        buildSignature: 'buildSignature',
+      );
+
+      mockFaroTransport = MockFaroTransport();
+      mockBatchTransport = MockBatchTransport();
+      mockFaroNativeMethods = MockFaroNativeMethods();
+
+      BatchTransportFactory().setInstance(mockBatchTransport);
+
+      Faro().transports = [mockFaroTransport];
+      Faro().nativeChannel = mockFaroNativeMethods;
+      Faro().batchTransport = mockBatchTransport;
+
+      when(
+        () => mockFaroNativeMethods.enableCrashReporter(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockBatchTransport.addExceptions(any()),
+      ).thenAnswer((_) async {});
+      when(() => mockBatchTransport.addLog(any())).thenAnswer((_) async {});
+      when(() => mockBatchTransport.addEvent(any())).thenAnswer((_) async {});
+      when(
+        () => mockBatchTransport.addMeasurement(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockBatchTransport.updatePayloadMeta(any()),
+      ).thenAnswer((_) async {});
+      when(() => mockFaroTransport.send(any())).thenAnswer((_) async {});
+
+      now = DateTime(2026, 6, 10, 12);
+      pod.overrideProvider(
+        currentTimeProvider,
+        (_) =>
+            () => now,
+      );
+    });
+
+    tearDown(() async {
+      await Faro.resetForTesting();
+      BatchTransportFactory().reset();
+    });
+
+    Future<void> initFaro() async {
+      final config = FaroConfig(
+        appName: appName,
+        appVersion: appVersion,
+        appEnv: appEnv,
+        apiKey: apiKey,
+        collectorUrl: 'https://some-url.com',
+      );
+      await Faro().init(optionsConfiguration: config);
+    }
+
+    List<String> capturedEventNames() {
+      return verify(
+        () => mockBatchTransport.addEvent(captureAny()),
+      ).captured.map((dynamic event) => (event as Event).name).toList();
+    }
+
+    // Simulates the app moving to the background (screen locked or task
+    // switched), so passive vitals stop counting as session activity.
+    void setAppBackgrounded() {
+      pod
+          .resolve(appLifecycleServiceProvider)
+          .updateFromLifecycleState(AppLifecycleState.paused);
+    }
+
+    void ingestVitals() {
+      pod
+          .resolve(telemetryRouterProvider)
+          .ingest(
+            TelemetryItem.fromMeasurement(
+              Measurement({'mem_usage': 42}, 'app_memory'),
+            ),
+            activity: SessionActivityKind.foregroundOnly,
+          );
+    }
+
+    test('emits session_start (not session_extend) for the initial '
+        'session on init', () async {
+      await initFaro();
+
+      final eventNames = capturedEventNames();
+      expect(eventNames, contains('session_start'));
+      expect(eventNames, isNot(contains('session_extend')));
+    });
+
+    test('keeps the session when activity stays within thresholds', () async {
+      await initFaro();
+      final initialSessionId = Faro().meta.session?.id;
+      expect(initialSessionId, isNotNull);
+
+      now = now.add(const Duration(minutes: 14));
+      Faro().pushEvent('some_event');
+
+      expect(Faro().meta.session?.id, initialSessionId);
+      expect(
+        Faro().meta.session?.attributes?.containsKey('previousSession'),
+        isFalse,
+      );
+    });
+
+    test('rotates the session when inactivity reaches 15 minutes', () async {
+      await initFaro();
+      final initialSessionId = Faro().meta.session?.id;
+
+      now = now.add(const Duration(minutes: 15));
+      Faro().pushEvent('some_event');
+
+      final session = Faro().meta.session;
+      expect(session?.id, isNot(initialSessionId));
+      expect(session?.attributes?['previousSession'], initialSessionId);
+    });
+
+    test('rotates the session when lifetime reaches 4 hours', () async {
+      await initFaro();
+      final initialSessionId = Faro().meta.session?.id;
+
+      // Stay active every 10 minutes so inactivity never expires.
+      for (var i = 0; i < 23; i++) {
+        now = now.add(const Duration(minutes: 10));
+        Faro().pushEvent('keep_alive');
+      }
+      expect(Faro().meta.session?.id, initialSessionId);
+
+      now = now.add(const Duration(minutes: 10));
+      Faro().pushEvent('after_lifetime');
+
+      final session = Faro().meta.session;
+      expect(session?.id, isNot(initialSessionId));
+      expect(session?.attributes?['previousSession'], initialSessionId);
+    });
+
+    test('emits session_extend for the new session and attributes the '
+        'triggering telemetry to it', () async {
+      await initFaro();
+      clearInteractions(mockBatchTransport);
+
+      now = now.add(const Duration(minutes: 16));
+      Faro().pushEvent('trigger_event');
+
+      // Rotation updates the payload meta first, then emits
+      // session_extend, then the triggering event follows — so both
+      // events belong to the new session.
+      final rotatedSessionId = Faro().meta.session?.id;
+      verifyInOrder([
+        () => mockBatchTransport.updatePayloadMeta(
+          any(
+            that: isA<Meta>().having(
+              (m) => m.session?.id,
+              'session.id',
+              rotatedSessionId,
+            ),
+          ),
+        ),
+        () => mockBatchTransport.addEvent(
+          any(
+            that: isA<Event>().having((e) => e.name, 'name', 'session_extend'),
+          ),
+        ),
+        () => mockBatchTransport.addEvent(
+          any(
+            that: isA<Event>().having((e) => e.name, 'name', 'trigger_event'),
+          ),
+        ),
+      ]);
+    });
+
+    test('preserves session attributes across rotation', () async {
+      await initFaro();
+      final initialAttributes = Map<String, dynamic>.from(
+        Faro().meta.session?.attributes ?? {},
+      );
+      expect(initialAttributes, isNotEmpty);
+
+      now = now.add(const Duration(minutes: 20));
+      Faro().pushEvent('some_event');
+
+      final rotatedAttributes = Faro().meta.session?.attributes ?? {};
+      for (final entry in initialAttributes.entries) {
+        expect(rotatedAttributes[entry.key], entry.value);
+      }
+    });
+
+    test('overwrites previousSession on successive rotations', () async {
+      await initFaro();
+      final firstSessionId = Faro().meta.session?.id;
+
+      now = now.add(const Duration(minutes: 16));
+      Faro().pushEvent('first_rotation');
+      final secondSessionId = Faro().meta.session?.id;
+      expect(secondSessionId, isNot(firstSessionId));
+
+      now = now.add(const Duration(minutes: 16));
+      Faro().pushEvent('second_rotation');
+      final session = Faro().meta.session;
+      expect(session?.id, isNot(secondSessionId));
+      expect(session?.attributes?['previousSession'], secondSessionId);
+    });
+
+    test('logs also trigger rotation and belong to the new session', () async {
+      await initFaro();
+      final initialSessionId = Faro().meta.session?.id;
+      clearInteractions(mockBatchTransport);
+
+      now = now.add(const Duration(minutes: 16));
+      Faro().pushLog('a log message', level: LogLevel.info);
+
+      expect(Faro().meta.session?.id, isNot(initialSessionId));
+      verifyInOrder([
+        () => mockBatchTransport.updatePayloadMeta(any()),
+        () => mockBatchTransport.addEvent(
+          any(
+            that: isA<Event>().having((e) => e.name, 'name', 'session_extend'),
+          ),
+        ),
+        () => mockBatchTransport.addLog(any()),
+      ]);
+    });
+
+    test('background vitals do not extend the session and rotate it '
+        'once expired', () async {
+      await initFaro();
+      final initialSessionId = Faro().meta.session?.id;
+      // Backgrounded: vitals must not count as activity.
+      setAppBackgrounded();
+
+      // Vitals below the threshold neither rotate nor extend.
+      now = now.add(const Duration(minutes: 10));
+      ingestVitals();
+      now = now.add(const Duration(minutes: 4));
+      ingestVitals();
+      expect(Faro().meta.session?.id, initialSessionId);
+
+      // 16 minutes since the last ACTIVITY (init); the vitals ingest
+      // itself rotates the session even though it is passive.
+      now = now.add(const Duration(minutes: 2));
+      clearInteractions(mockBatchTransport);
+      ingestVitals();
+
+      final session = Faro().meta.session;
+      expect(session?.id, isNot(initialSessionId));
+      expect(session?.attributes?['previousSession'], initialSessionId);
+      verifyInOrder([
+        () => mockBatchTransport.updatePayloadMeta(any()),
+        () => mockBatchTransport.addEvent(
+          any(
+            that: isA<Event>().having((e) => e.name, 'name', 'session_extend'),
+          ),
+        ),
+        () => mockBatchTransport.addMeasurement(any()),
+      ]);
+    });
+
+    test('foreground vitals keep the session alive by extending the '
+        'window', () async {
+      await initFaro();
+      final initialSessionId = Faro().meta.session?.id;
+
+      // App stays in the foreground (default). Vitals every 10 minutes
+      // each extend the 15-minute window, so the session never expires
+      // even though there is no user interaction (e.g. a user reading
+      // a screen). Kept under the 4-hour max lifetime.
+      for (var i = 0; i < 6; i++) {
+        now = now.add(const Duration(minutes: 10));
+        ingestVitals();
+        expect(Faro().meta.session?.id, initialSessionId);
+      }
+      expect(
+        Faro().meta.session?.attributes?.containsKey('previousSession'),
+        isFalse,
+      );
+    });
+
+    test('foreground vitals stop extending once the app is '
+        'backgrounded', () async {
+      await initFaro();
+      final initialSessionId = Faro().meta.session?.id;
+
+      // Foreground vitals extend the window past the first threshold.
+      now = now.add(const Duration(minutes: 10));
+      ingestVitals();
+      now = now.add(const Duration(minutes: 10));
+      ingestVitals();
+      expect(Faro().meta.session?.id, initialSessionId);
+
+      // App goes to the background; from here vitals no longer extend.
+      setAppBackgrounded();
+      now = now.add(const Duration(minutes: 16));
+      ingestVitals();
+
+      final session = Faro().meta.session;
+      expect(session?.id, isNot(initialSessionId));
+      expect(session?.attributes?['previousSession'], initialSessionId);
+    });
+
+    test('vitals pushed by NativeIntegration do not extend the '
+        'session', () async {
+      when(
+        () => mockFaroNativeMethods.getAppStart(),
+      ).thenAnswer((_) async => {'appStartDuration': 100});
+      await initFaro();
+      final initialSessionId = Faro().meta.session?.id;
+      // Backgrounded: automatic vitals must not count as activity.
+      setAppBackgrounded();
+
+      // An automatic vitals measurement at 14 minutes flows through
+      // the passive path: no rotation, no activity recorded.
+      now = now.add(const Duration(minutes: 14));
+      await pod.resolve(nativeIntegrationProvider).getAppStart();
+      expect(Faro().meta.session?.id, initialSessionId);
+
+      // Two minutes later it is 16 minutes since the last real
+      // activity (init). If the vitals measurement had recorded
+      // activity, this event would NOT rotate.
+      now = now.add(const Duration(minutes: 2));
+      Faro().pushEvent('user_tap');
+
+      final session = Faro().meta.session;
+      expect(session?.id, isNot(initialSessionId));
+      expect(session?.attributes?['previousSession'], initialSessionId);
+    });
+
+    test('emits a single session_extend on rotation', () async {
+      await initFaro();
+      clearInteractions(mockBatchTransport);
+
+      now = now.add(const Duration(minutes: 16));
+      Faro().pushEvent('trigger_event');
+
+      final sessionExtends = capturedEventNames()
+          .where((name) => name == 'session_extend')
+          .length;
+      expect(sessionExtends, 1);
+    });
+  });
+}

--- a/test/src/tracing/faro_otel_bootstrap_test.dart
+++ b/test/src/tracing/faro_otel_bootstrap_test.dart
@@ -3,6 +3,7 @@
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/models/models.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
 import 'package:faro/src/tracing/faro_otel_bootstrap.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
 import 'package:faro/src/tracing/faro_user_action_span_processor.dart';
@@ -15,7 +16,11 @@ class _RecordingRouter implements TelemetryRouter {
   final List<TelemetryItem> ingested = [];
 
   @override
-  void ingest(TelemetryItem item, {bool skipBuffer = false}) {
+  void ingest(
+    TelemetryItem item, {
+    bool skipBuffer = false,
+    SessionActivityKind activity = SessionActivityKind.active,
+  }) {
     ingested.add(item);
   }
 }
@@ -57,7 +62,7 @@ void main() {
       // Second call must complete promptly without resetting OTel.
       await FaroOtelBootstrap.initialize().timeout(const Duration(seconds: 5));
 
-      final tracer = FaroTracerFactory().create();
+      final tracer = pod.resolve(faroTracerProvider);
       final span = tracer.startSpanManual('after-double-init');
       span.end();
       await Future<void>.delayed(Duration.zero);
@@ -87,7 +92,7 @@ void main() {
       pod.removeOverride(faroSpanProcessorProvider);
 
       await FaroOtelBootstrap.initialize();
-      final tracer = FaroTracerFactory().create();
+      final tracer = pod.resolve(faroTracerProvider);
       final span = tracer.startSpanManual('after-reset');
       span.end();
       await Future<void>.delayed(Duration.zero);

--- a/test/src/tracing/faro_tracer_test.dart
+++ b/test/src/tracing/faro_tracer_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
+import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/session/session_id_provider.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
 import 'package:faro/src/tracing/faro_zone_span_manager.dart';
@@ -525,11 +526,11 @@ void main() {
     });
   });
 
-  group('FaroTracerFactory:', () {
-    setUp(FaroTracerFactory.reset);
-    tearDown(FaroTracerFactory.reset);
+  group('faroTracerProvider:', () {
+    setUp(() => pod.clearScope(tracerScope));
+    tearDown(() => pod.clearScope(tracerScope));
 
-    test('create() returns a working tracer even when OTel has not been '
+    test('resolves a working tracer even when OTel has not been '
         'initialized (e.g. when Faro.init has not run)', () async {
       // Regression test: callers like FaroHttpTrackingClient call
       // Faro().startSpanManual without first calling Faro().init(),
@@ -545,9 +546,9 @@ void main() {
         await otel.OTel.reset();
         await _initializeOtelForTest();
       });
-      FaroTracerFactory.reset();
+      pod.clearScope(tracerScope);
 
-      final tracer = FaroTracerFactory().create();
+      final tracer = pod.resolve(faroTracerProvider);
       final span = tracer.startSpanManual('preinit-span');
       expect(span, isNotNull);
       expect(span.traceId, isNotEmpty);

--- a/test/src/tracing/faro_tracing_e2e_test.dart
+++ b/test/src/tracing/faro_tracing_e2e_test.dart
@@ -3,6 +3,8 @@
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/models/models.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/session/session_id_provider.dart';
 import 'package:faro/src/tracing/faro_otel_bootstrap.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
 import 'package:faro/src/tracing/faro_user_action_span_processor.dart';
@@ -17,7 +19,11 @@ class _RecordingRouter implements TelemetryRouter {
   final List<bool> skipBufferFlags = [];
 
   @override
-  void ingest(TelemetryItem item, {bool skipBuffer = false}) {
+  void ingest(
+    TelemetryItem item, {
+    bool skipBuffer = false,
+    SessionActivityKind activity = SessionActivityKind.active,
+  }) {
     ingested.add(item);
     skipBufferFlags.add(skipBuffer);
   }
@@ -62,7 +68,7 @@ void main() {
   test('Faro.startSpanManual flows through to the telemetry router as '
       'an Event with span attributes and a span TelemetryItem', () async {
     await FaroOtelBootstrap.initialize();
-    final tracer = FaroTracerFactory().create();
+    final tracer = pod.resolve(faroTracerProvider);
 
     final span = tracer.startSpanManual(
       'order.checkout',
@@ -99,7 +105,7 @@ void main() {
 
   test('HTTP-flavored spans surface as faro.tracing.fetch events', () async {
     await FaroOtelBootstrap.initialize();
-    final tracer = FaroTracerFactory().create();
+    final tracer = pod.resolve(faroTracerProvider);
 
     final span = tracer.startSpanManual(
       'GET https://example.com',
@@ -120,7 +126,7 @@ void main() {
 
   test('child span shares the parent trace_id', () async {
     await FaroOtelBootstrap.initialize();
-    final tracer = FaroTracerFactory().create();
+    final tracer = pod.resolve(faroTracerProvider);
 
     final parent = tracer.startSpanManual('parent');
     final child = tracer.startSpanManual('child', parentSpan: parent);
@@ -134,7 +140,7 @@ void main() {
     'Span.noParent starts a new trace even when an active span exists',
     () async {
       await FaroOtelBootstrap.initialize();
-      final tracer = FaroTracerFactory().create();
+      final tracer = pod.resolve(faroTracerProvider);
 
       final outer = tracer.startSpanManual('outer');
       final detached = tracer.startSpanManual(
@@ -146,4 +152,34 @@ void main() {
       outer.end();
     },
   );
+
+  test('spans pick up a rotated session id from the shared provider', () async {
+    await FaroOtelBootstrap.initialize();
+    final tracer = pod.resolve(faroTracerProvider);
+
+    final beforeSpan = tracer.startSpanManual('before_rotation');
+    beforeSpan.end();
+    await Future<void>.delayed(Duration.zero);
+
+    // Rotate the shared session id the same way SessionManager does on
+    // expiry. The tracer holds this same provider instance and reads the
+    // id live at span creation, so a later span must carry the new id.
+    final provider = pod.resolve(sessionIdProviderProvider);
+    final beforeId = provider.sessionId;
+    final afterId = provider.rotateSessionId();
+    expect(afterId, isNot(equals(beforeId)));
+
+    final afterSpan = tracer.startSpanManual('after_rotation');
+    afterSpan.end();
+    await Future<void>.delayed(Duration.zero);
+
+    Event spanEvent(String name) => router.ingested
+        .map((i) => i.asEvent)
+        .whereType<Event>()
+        .firstWhere((e) => e.name == 'span.$name');
+
+    expect(spanEvent('before_rotation').attributes?['session_id'], beforeId);
+    expect(spanEvent('after_rotation').attributes?['session_id'], afterId);
+    expect(spanEvent('after_rotation').attributes?['session.id'], afterId);
+  });
 }

--- a/test/src/transport/faro_transport_test.dart
+++ b/test/src/transport/faro_transport_test.dart
@@ -1,0 +1,112 @@
+import 'package:faro/src/data_collection_policy.dart';
+import 'package:faro/src/faro.dart';
+import 'package:faro/src/transport/faro_transport.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockDataCollectionPolicy extends Mock implements DataCollectionPolicy {}
+
+void main() {
+  group('FaroTransport:', () {
+    late List<http.Request> captured;
+    late MockClient client;
+
+    setUp(() {
+      captured = [];
+      client = MockClient((request) async {
+        captured.add(request);
+        return http.Response('', 200);
+      });
+    });
+
+    tearDown(() {
+      // The data-collection gate reads the global Faro singleton; reset it so
+      // tests stay isolated.
+      Faro().dataCollectionPolicy = null;
+    });
+
+    FaroTransport buildTransport({
+      SessionIdResolver? sessionIdResolver,
+      Map<String, String>? headers,
+    }) {
+      return FaroTransport(
+        collectorUrl: 'https://collector.example/collect',
+        apiKey: 'test-key',
+        sessionIdResolver: sessionIdResolver ?? () => 'session-id',
+        headers: headers,
+        httpClient: client,
+      );
+    }
+
+    Map<String, dynamic> payload() => {
+      'meta': {
+        'session': {'id': 'body-id'},
+      },
+      'events': <dynamic>[],
+    };
+
+    group('request:', () {
+      test('posts the encoded payload to the collector url', () async {
+        await buildTransport().send(payload());
+
+        final request = captured.single;
+        expect(request.method, 'POST');
+        expect(request.url.toString(), 'https://collector.example/collect');
+        expect(
+          request.body,
+          '{"meta":{"session":{"id":"body-id"}},"events":[]}',
+        );
+      });
+
+      test('sends content type, api key and merges custom headers', () async {
+        await buildTransport(
+          headers: {'x-custom': 'custom-value'},
+        ).send(payload());
+
+        final headers = captured.single.headers;
+        expect(headers['x-api-key'], 'test-key');
+        expect(headers['content-type'], contains('application/json'));
+        expect(headers['x-custom'], 'custom-value');
+      });
+    });
+
+    group('x-faro-session-id header:', () {
+      // The payload body always carries a fixed session id; the header should
+      // follow the live resolver instead, not this value.
+      test('uses the live resolver id, not the payload body', () async {
+        final transport = buildTransport(sessionIdResolver: () => 'live-id');
+        await transport.send(payload());
+
+        expect(captured.single.headers['x-faro-session-id'], 'live-id');
+      });
+
+      test('reflects a rotated session id on subsequent sends', () async {
+        var current = 'session-1';
+        final transport = buildTransport(sessionIdResolver: () => current);
+
+        await transport.send(payload());
+        current = 'session-2';
+        await transport.send(payload());
+
+        expect(captured.map((r) => r.headers['x-faro-session-id']).toList(), [
+          'session-1',
+          'session-2',
+        ]);
+      });
+    });
+
+    group('data collection:', () {
+      test('does not send when data collection is disabled', () async {
+        final policy = _MockDataCollectionPolicy();
+        when(() => policy.isEnabled).thenReturn(false);
+        Faro().dataCollectionPolicy = policy;
+
+        await buildTransport().send(payload());
+
+        expect(captured, isEmpty);
+      });
+    });
+  });
+}

--- a/test/src/user_actions/telemetry_router_test.dart
+++ b/test/src/user_actions/telemetry_router_test.dart
@@ -1,4 +1,6 @@
 import 'package:faro/src/models/models.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/session/session_manager.dart';
 import 'package:faro/src/transport/batch_transport.dart';
 import 'package:faro/src/user_actions/telemetry_router.dart';
 import 'package:faro/src/user_actions/user_action_types.dart';
@@ -10,23 +12,43 @@ class MockBatchTransport extends Mock implements BatchTransport {}
 
 class MockUserActionsService extends Mock implements UserActionsService {}
 
+class MockSessionManager extends Mock implements SessionManager {}
+
 void main() {
   late MockBatchTransport mockTransport;
   late MockUserActionsService mockUserActionsService;
+  late MockSessionManager mockSessionManager;
+
+  setUpAll(() {
+    registerFallbackValue(Event('fallback'));
+    registerFallbackValue(SessionActivityKind.active);
+  });
 
   setUp(() {
     mockTransport = MockBatchTransport();
     mockUserActionsService = MockUserActionsService();
+    mockSessionManager = MockSessionManager();
+    when(
+      () => mockSessionManager.checkSession(activity: any(named: 'activity')),
+    ).thenAnswer((_) {});
   });
+
+  TelemetryRouter buildRouter({
+    BatchTransportResolver? transportResolver,
+    SessionManager? sessionManager,
+  }) {
+    return TelemetryRouter(
+      userActionsService: mockUserActionsService,
+      sessionManager: sessionManager ?? mockSessionManager,
+      transportResolver: transportResolver ?? () => mockTransport,
+    );
+  }
 
   group('TelemetryRouter:', () {
     test('buffers events when active action accepts item', () {
       final item = TelemetryItem.fromEvent(Event('tap'));
       when(() => mockUserActionsService.tryBuffer(item)).thenReturn(true);
-      final router = TelemetryRouter(
-        transportResolver: () => mockTransport,
-        userActionsService: mockUserActionsService,
-      );
+      final router = buildRouter();
 
       router.ingest(item);
 
@@ -36,10 +58,7 @@ void main() {
 
     test('dispatches event immediately when skipBuffer is true', () {
       final item = TelemetryItem.fromEvent(Event('tap'));
-      final router = TelemetryRouter(
-        transportResolver: () => mockTransport,
-        userActionsService: mockUserActionsService,
-      );
+      final router = buildRouter();
 
       router.ingest(item, skipBuffer: true);
 
@@ -50,10 +69,7 @@ void main() {
     test('dispatches event when buffering is not possible', () {
       final item = TelemetryItem.fromEvent(Event('tap'));
       when(() => mockUserActionsService.tryBuffer(item)).thenReturn(false);
-      final router = TelemetryRouter(
-        transportResolver: () => mockTransport,
-        userActionsService: mockUserActionsService,
-      );
+      final router = buildRouter();
 
       router.ingest(item);
 
@@ -64,10 +80,7 @@ void main() {
     test('does not dispatch when no transport is available', () {
       final item = TelemetryItem.fromEvent(Event('tap'));
       when(() => mockUserActionsService.tryBuffer(item)).thenReturn(false);
-      final router = TelemetryRouter(
-        transportResolver: () => null,
-        userActionsService: mockUserActionsService,
-      );
+      final router = buildRouter(transportResolver: () => null);
 
       router.ingest(item);
 
@@ -75,11 +88,70 @@ void main() {
       verifyNever(() => mockTransport.addEvent(item.asEvent!));
     });
 
-    test('never buffers measurements', () {
-      final router = TelemetryRouter(
-        transportResolver: () => mockTransport,
-        userActionsService: mockUserActionsService,
+    test('checks the session before dispatching telemetry', () {
+      final dispatchOrder = <String>[];
+      when(
+        () => mockSessionManager.checkSession(activity: any(named: 'activity')),
+      ).thenAnswer((_) {
+        dispatchOrder.add('session-check');
+      });
+      when(() => mockTransport.addEvent(any())).thenAnswer((_) {
+        dispatchOrder.add('dispatch');
+      });
+      final item = TelemetryItem.fromEvent(Event('tap'));
+      final router = buildRouter();
+
+      router.ingest(item, skipBuffer: true);
+
+      expect(dispatchOrder, ['session-check', 'dispatch']);
+    });
+
+    test('forwards the activity kind to the session manager', () {
+      final item = TelemetryItem.fromMeasurement(
+        Measurement({'mem_usage': 1}, 'app_memory'),
       );
+      final router = buildRouter();
+
+      router.ingest(item, activity: SessionActivityKind.foregroundOnly);
+
+      // The router does not decide whether vitals count as activity; it
+      // just forwards the classification. The session policy interprets
+      // it (see session_activity_policy_test.dart).
+      verify(
+        () => mockSessionManager.checkSession(
+          activity: SessionActivityKind.foregroundOnly,
+        ),
+      ).called(1);
+      verify(() => mockTransport.addMeasurement(item.asMeasurement!)).called(1);
+    });
+
+    test('defaults to SessionActivityKind.active', () {
+      final item = TelemetryItem.fromEvent(Event('tap'));
+      final router = buildRouter();
+
+      router.ingest(item, skipBuffer: true);
+
+      verify(
+        () => mockSessionManager.checkSession(
+          activity: SessionActivityKind.active,
+        ),
+      ).called(1);
+    });
+
+    test('forwards SessionActivityKind.none', () {
+      final item = TelemetryItem.fromEvent(Event('session_extend'));
+      final router = buildRouter();
+
+      router.ingest(item, skipBuffer: true, activity: SessionActivityKind.none);
+
+      verify(
+        () =>
+            mockSessionManager.checkSession(activity: SessionActivityKind.none),
+      ).called(1);
+    });
+
+    test('never buffers measurements', () {
+      final router = buildRouter();
       final item = TelemetryItem.fromMeasurement(
         Measurement({'value': 1}, 'custom'),
       );


### PR DESCRIPTION
## Description

Implements automatic session rotation for the Faro Flutter SDK.

A session rotates when either window elapses:
- **15 minutes of inactivity**, or
- **4 hours of total lifetime**.

These windows are **fixed, not configurable** — the Grafana Cloud Faro
receiver enforces the same windows server-side and drops telemetry from
sessions that exceed them, so a longer client-side value would only cause
silent data loss.

**Session semantics:**
- The initial session emits `session_start`.
- A rotation emits `session_extend` and records the prior session id in the
  `previousSession` attribute, so consumers can stitch consecutive sessions
  together.
- A new session id is generated via the shared `SessionIdProvider`, so spans
  and other telemetry created after a rotation automatically carry the new id.

**What counts as "activity":**
- Telemetry from app or user behaviour extends the inactivity window: events,
  logs, exceptions, app-developer measurements, user interactions, view
  changes, app lifecycle events, and **spans** (each exported span emits a
  Faro event through the same path, so tracked HTTP requests and custom spans
  keep the session alive).
- Automatic vitals measurements pushed by the SDK itself (CPU, memory, refresh
  rate, frame stats, ANR count, app start) extend the window **only while the
  app is in the foreground**. This keeps a foregrounded-but-idle app (e.g. a
  user reading a screen) in a single session, while a backgrounded app's
  vitals cannot keep its session alive — the Dart isolate keeps running when
  backgrounded on Android, so counting background vitals would prevent expiry
  entirely.
- Expiry is always checked when any telemetry arrives, so the triggering item
  lands on a fresh session rather than an expired one.

Sampling is intentionally **not** re-evaluated on rotation in this PR (see
follow-ups below).

**Design / refactor:**
- `SessionManager` now owns session identity and lifecycle. It is inert until
  `start()` and notifies a `SessionChangedListener` on the initial session and
  each rotation; `Faro` reacts to those notifications to update payload meta
  and emit the lifecycle events. This follows the ownership model discussed in
  the OTel session-management proposal
  (open-telemetry/opentelemetry-specification#4198).
- `AppLifecycleService` tracks foreground/background state; `SessionActivityPolicy`
  is the single home for the "what counts as activity" rule (including the
  foreground gate).
- `SessionManager`, `AppLifecycleService`, `NativeIntegration`, the telemetry
  router and the tracer are now wired through dartyPod providers/scopes,
  replacing the previous static singletons and making them straightforward to
  override in tests.

## Related Issue(s)

Fixes #52
Related to #144 (Session and Identity Lifecycle epic)

## Type of Change

- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation
- [ ] 📈 Performance improvement
- [x] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Additional Notes

**Reference alignment.** Session event naming (`session_start` / `session_extend`)
and the `previousSession` attribute follow the Grafana Cloud Faro session
definition; the manager's ownership/observer design is inspired by the OTel
session-management proposal (#4198).

**On-device validation.** Verified end-to-end on an Android emulator against a
dev collector, including an A/B comparison against `main`:
- Initial launch emitted `session_start` with no `previousSession`.
- After 15 minutes backgrounded, the session rotated automatically ~6s past
  the threshold, emitting `session_extend` with a new session id and
  `previousSession` pointing at the prior session. Preserved session
  attributes carried across.
- Post-rotation telemetry carried the new session id.
- Foreground gate confirmed: backgrounded vitals did **not** extend the
  session (so it could expire) but still served as the check that triggered
  rotation.
- Telemetry shapes (event names, log levels, measurement types, spans) matched
  `main`; the only additive signals on this branch were `session_extend` /
  `previousSession`.

**Follow-ups (tracked):**
- #283 — cross-restart / multi-process session persistence.
- #284 — re-sample per rotated session (match the Faro sampling model).
- #144 — pause vitals collection while backgrounded, so a backgrounded app
  stops emitting vitals entirely (foreground gating already prevents them from
  extending the session).

Made with [Cursor](https://cursor.com)
