### PR TITLE
chore(tooling): add Grafana Cloud telemetry validation tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,19 @@ See `CONTRIBUTING.md` for the full contributor workflow.
 
 If `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` are set, the example APK can be tested on a real Android device using BrowserStack App Automate. Upload via the BrowserStack REST API with `custom_id=faro-flutter-example`, then use Appium REST calls to interact with the app. Flutter exposes UI elements through the Accessibility Bridge, so `accessibility id` element lookups work for buttons with text labels (e.g., `"Change Route"`, `"Simple Span"`). For card-style `ListTile` widgets, the accessibility label is the concatenated title and subtitle separated by `\n`.
 
+### Validating telemetry changes against Grafana Cloud
+
+When a change affects emitted telemetry (logs, events, exceptions, measurements,
+spans, trace/span context, or any `structuredMetadata` field), validate it
+end-to-end against the real data in Grafana Cloud (Loki + Tempo), not just unit
+tests. The `tool/telemetry/` directory has generic, dependency-free Dart helpers
+for this — verifying log↔trace correlation, diffing the emitted telemetry shape
+before/after a change (e.g. branch vs `main`), and listing a session's full
+signal timeline. They shell out to the `gcx` CLI.
+
+See `tool/telemetry/README.md` for the full workflow, inputs to gather, and the
+gcx/Loki/Tempo gotchas.
+
 ### Gotchas
 
 - `flutter pub get` in the root resolves both SDK and `example/` dependencies due to workspace configuration — no need to run it separately in `example/`.

--- a/tool/telemetry/README.md
+++ b/tool/telemetry/README.md
@@ -1,0 +1,221 @@
+# Telemetry validation tools
+
+Dev/debugging helpers for validating that an SDK change produces the intended
+telemetry — and nothing else — by inspecting the real data that reached Grafana
+Cloud (Loki + Tempo), not just unit tests.
+
+These are tool-agnostic Dart scripts (no editor/agent assumptions). They shell
+out to the [`gcx`](https://github.com/grafana/gcx) CLI and are kept separate
+from the release tooling in the parent `tool/` directory.
+
+## When this is useful
+
+- A change touches what/how telemetry is emitted (new fields, trace/span
+  correlation, HTTP tracking, measurements, events).
+- You want to answer "does the data look right in Grafana Cloud?" or "is only X
+  different vs `main`?".
+- Verifying that signals correlate to the correct Tempo trace/span.
+
+## Inputs you need
+
+1. **Grafana stack / gcx context**. The example app's collector URL is in
+   `example/api-config.json`; match its host to a context via
+   `gcx config list-contexts`.
+2. **App identity**: Loki `app_id` (preferred) or the app name
+   (`service_name`). The example app is `faro-flutter-sdk-example`.
+3. **Environment and time range**.
+4. **Isolation key**: a `qa_run_id` (or `session_id`) for the run to inspect.
+5. **Comparison scope**: which branch(es) to compare (branch vs `main`?).
+
+### Placeholders used in the examples below
+
+Substitute your own values — discover them via Preflight (below).
+
+| Placeholder | Meaning | How to find it |
+|---|---|---|
+| `<ctx>` | gcx context (Grafana stack) | `gcx config list-contexts` |
+| `<app-id>` | Loki `app_id` for your Faro app | `gcx frontend apps list` |
+| `<qa_run_id>` | your run's `session_attr_qa_run_id` | you set it (see step 2) |
+| Loki datasource | defaults to `grafanacloud-logs` | `gcx --context <ctx> datasources list` |
+| Tempo datasource | defaults to `grafanacloud-traces` | `gcx --context <ctx> datasources list` |
+
+The example app in this repo uses `service_name` `faro-flutter-sdk-example`.
+
+## The tools
+
+All three are generic (work for any Faro app), dependency-free Dart, share
+`common.dart`, and shell out to `gcx`. Run any with `--help` for full flags.
+
+### `verify_correlation.dart`
+
+Pulls a run's signals from Loki, extracts each signal's `trace_id`/`span_id`,
+fetches the referenced traces from Tempo, and confirms the span exists. Exits
+non-zero on any dangling correlation.
+
+```bash
+dart tool/telemetry/verify_correlation.dart \
+  --context <ctx> --app-id <app-id> \
+  --run-id <qa_run_id> --since 1h
+```
+
+### `snapshot.dart`
+
+Captures a normalized telemetry snapshot for a run (grouped by `kind::name`,
+comparing only shape + trace presence, not volatile values), and diffs two
+snapshots. Ideal for "only the trace context changed" checks.
+
+```bash
+# one run per branch, then diff
+dart tool/telemetry/snapshot.dart snapshot --context <ctx> --app-id <app-id> \
+  --run-id main-run --since 1h --out before.json
+dart tool/telemetry/snapshot.dart snapshot --context <ctx> --app-id <app-id> \
+  --run-id branch-run --since 1h --out after.json
+dart tool/telemetry/snapshot.dart diff before.json after.json
+```
+
+`snapshot` is **not trace-specific** — it validates *any* metadata-shape change.
+E.g. adding a new field like `battery_state` (or a whole new `app_battery`
+measurement) shows up in the diff as `+ keys: battery_state` on the affected
+`kind::name` groups (or `+ NEW GROUP`), proving the field appears where expected
+and nothing else moved. Know its limits before trusting a clean diff:
+
+- **Compares key *presence*, not values.** A same-key value change (e.g.
+  battery `0–100` vs `0.0–1.0`, or a units change) is invisible. Use
+  `list_signals.dart` (its EXTRA column / `--format json`) to check values.
+- **Only sees fields that reach Loki `structuredMetadata`.** If a new field
+  lands only in the log-line body or an unflattened nested payload, it won't
+  appear as a key. Sanity-check once with `list_signals --format json` that the
+  field actually surfaces.
+- **Ignores `count`.** Per-group counts are captured but not diffed (they drift
+  run to run), so "fires 5× instead of 1×" is not flagged — check the timeline.
+- **Requires identical scenarios on both runs.** Grouping is by `kind::name`, so
+  differing user actions produce spurious `NEW GROUP`/`REMOVED` noise. Keep the
+  two runs identical (same taps, similar duration), distinct `qa_run_id`s.
+
+### `list_signals.dart`
+
+Generic (not trace-specific) chronological timeline of every
+log/event/exception/measurement for a session or run. Use to eyeball what an app
+actually emitted, spot missing/duplicated signals, or export a normalized signal
+list (`--format json`). Filter with `--kind log,event,exception,measurement`.
+
+```bash
+dart tool/telemetry/list_signals.dart --context <ctx> --app-id <app-id> \
+  --run-id <qa_run_id> --since 2h
+dart tool/telemetry/list_signals.dart --context <ctx> --app-id <app-id> \
+  --session-id <session_id> --kind log,exception --format json
+```
+
+## Workflow
+
+```
+- [ ] 1. Preflight: resolve context, app_id, datasources; verify gcx auth
+- [ ] 2. Generate isolated data (example app + unique FARO_QA_RUN_ID)
+- [ ] 3. Inspect timeline + verify correlation (list_signals, verify_correlation)
+- [ ] 4. Before/after A/B if comparing branches (snapshot.dart)
+- [ ] 5. Report findings with evidence
+```
+
+### 1. Preflight
+
+```bash
+# keep gcx current — the JSON output shape these tools parse has changed
+# across versions (see gotchas). Update if it looks stale.
+gcx version
+gcx config check
+gcx config list-contexts
+# confirm datasources exist on the chosen context
+gcx --context <ctx> datasources list -o json | jq -r \
+  '.datasources[] | select(.name|test("logs|traces")) | "\(.uid)\t\(.name)"'
+```
+
+### 2. Generate isolated data
+
+Set a unique run id in `example/api-config.json` (gitignored) so the run is
+trivially filterable:
+
+```json
+{ "FARO_COLLECTOR_URL": "...", "FARO_QA_RUN_ID": "validate-<yyyymmdd-hhmm>" }
+```
+
+Run the app and trigger the relevant scenario(s), then wait ~30–45s for
+ingestion. To drive the example app on an Android emulator headlessly, see
+"Driving the example app" below.
+
+### 3. Inspect and verify
+
+First, get a chronological picture of what the run emitted:
+
+```bash
+dart tool/telemetry/list_signals.dart --context <ctx> --app-id <id> \
+  --run-id <qa_run_id> --since 2h
+```
+
+Then run `verify_correlation.dart` (above). Read the output:
+
+- **CORRELATED** signals should be exactly those emitted inside a span (plus the
+  span's own `span.<name>` event, which always carries its context).
+- **UNCORRELATED** should include background telemetry: `app_cpu_usage`,
+  `app_memory`, `app_frames_rate`, `app_refresh_rate`, `app_startup`,
+  `session_start`, `view_changed`, `user_interaction`, `app_lifecycle_changed`.
+- Any signal correlated to a span **not** found in Tempo is a bug (dangling
+  correlation) → tool exits non-zero.
+
+### 4. Before/after A/B (branch vs main)
+
+Only needed when confirming "nothing else changed". Do one isolated run per
+branch (distinct `qa_run_id`), snapshot each, then `diff`. A correct
+trace-correlation change shows **only** `has_trace: false -> true` (and/or added
+trace keys) on the affected `kind::name` groups; anything else is unexpected.
+
+### 5. Report
+
+State: what correlates, what does not, the trace/span ids verified in Tempo, and
+the exact A/B delta. Cite the `qa_run_id`, context, and commands used.
+
+## gcx / Loki / Tempo gotchas (learned the hard way)
+
+- **App name label is `service_name`**, not `app_name`. Filter Loki by the
+  indexed `app_id` label.
+- **Trace context is not a stream label.** It lives in the log line body and in
+  `structuredMetadata` as `trace_id`/`span_id` (and duplicated as
+  `traceID`/`spanID`).
+- **Event fields are prefixed `event_`** in `structuredMetadata` — the event
+  name is `event_name` (not `name`). Logs use `message`, exceptions/measurements
+  use `type`.
+- **gcx `logs query -o json` returns `values` as objects** with `.line` and
+  `.structuredMetadata` — not `[ts, line]` arrays. Extracting `.[1]` yields
+  nothing. The per-signal RFC3339 `timestamp` is inside `structuredMetadata`
+  (so lexicographic string sort is chronological).
+- **gcx metric queries (`sum by(...)`) drop labels** in the metric object in
+  some versions — prefer raw stream queries and parse `structuredMetadata`.
+- **Tempo `gcx traces get <id>` returns OTLP JSON** with `spanId` as **base64**
+  (`resourceSpans[].scopeSpans[].spans[].spanId`). Decode to hex to compare with
+  Loki's hex `span_id`. Query traces by the 32-char hex trace id.
+- **Ingestion delay ~30–45s.** If empty, widen `--since` before concluding data
+  is missing.
+- **`--limit` applies to the raw Loki stream, before client-side run/session
+  filtering.** On a busy app your run's signals can be truncated; the tools warn
+  when the limit is hit — raise `--limit` or narrow `--since`.
+- **FEO registry id ≠ Loki `app_id`** necessarily — resolve `app_id` from Loki.
+- Separate stderr from stdout: `gcx ... -o json 2>/dev/null` is clean JSON; a
+  merged stream has a non-JSON first line.
+
+## Driving the example app (Android emulator)
+
+Buttons expose their label as the accessibility `content-desc`, so taps can be
+scripted without hardcoded coordinates:
+
+```bash
+# dump the UI tree and find a button's bounds by its label
+adb -s emulator-5554 shell uiautomator dump /sdcard/ui.xml
+adb -s emulator-5554 shell cat /sdcard/ui.xml | tr '>' '>\n' \
+  | grep -oE 'content-desc="<label>"[^/]*bounds="\[[0-9,]+\]\[[0-9,]+\]"'
+# tap the center of the reported bounds
+adb -s emulator-5554 shell input tap <cx> <cy>
+```
+
+Navigation for telemetry demos: Home → "Change Route" → "Tracing / Spans"
+(or "Custom Telemetry" / "Network Requests"). The "Span + Telemetry" button runs
+a span and emits one log/event/exception/measurement inside it — the canonical
+correlation test.

--- a/tool/telemetry/common.dart
+++ b/tool/telemetry/common.dart
@@ -43,13 +43,17 @@ class Gcx {
     try {
       result = Process.runSync(bin, ['--context', context, ...args]);
     } on ProcessException catch (e) {
-      fail('Could not run "$bin" (${e.message}). '
-          'Is gcx installed and on your PATH? See https://github.com/grafana/gcx');
+      fail(
+        'Could not run "$bin" (${e.message}). '
+        'Is gcx installed and on your PATH? See https://github.com/grafana/gcx',
+      );
     }
     if (result.exitCode != 0) {
       if (allowFailure) return null;
-      fail('gcx ${args.join(' ')} failed (exit ${result.exitCode}):\n'
-          '${result.stderr}');
+      fail(
+        'gcx ${args.join(' ')} failed (exit ${result.exitCode}):\n'
+        '${result.stderr}',
+      );
     }
     final out = (result.stdout as String).trim();
     if (out.isEmpty) return allowFailure ? null : <String, dynamic>{};
@@ -62,14 +66,38 @@ class Gcx {
   }
 }
 
-/// Resolves a Loki `app_id` from a Faro app name (`service_name`).
-String? resolveAppId(Gcx runner, String appName) {
-  final json = runner.json(['frontend', 'apps', 'list', '-o', 'json']);
-  if (json is! List) return null;
-  for (final app in json) {
-    if (app is Map && app['spec'] is Map) {
-      final spec = app['spec'] as Map;
-      if (spec['name'] == appName) return spec['id']?.toString();
+/// Resolves a Loki `app_id` for a Faro app [appName] (`service_name`) by
+/// querying Loki and reading the `app_id` label off a matching stream.
+///
+/// The pipeline filters on `{app_id="..."}`, so the id must be Loki's — not the
+/// FEO registry id from `gcx frontend apps list`, which is not guaranteed to
+/// match. Returns null if no matching stream is found in the [since] window.
+String? resolveAppId(
+  Gcx runner,
+  String appName, {
+  required String lokiDs,
+  required String since,
+}) {
+  final json = runner.json([
+    'logs',
+    'query',
+    '-d',
+    lokiDs,
+    '{service_name="$appName"}',
+    '--since',
+    since,
+    '--limit',
+    '1',
+    '-o',
+    'json',
+  ], allowFailure: true);
+  final result = dig(json, ['data', 'result']);
+  if (result is! List) return null;
+  for (final stream in result) {
+    if (stream is! Map) continue;
+    final labels = stream['stream'];
+    if (labels is Map && labels['app_id'] != null) {
+      return labels['app_id'].toString();
     }
   }
   return null;
@@ -119,17 +147,17 @@ List<Signal> queryLokiSignals(
       // gcx returns each value as an object with a structuredMetadata map,
       // NOT a [timestamp, line] array.
       final rawMd = v is Map ? v['structuredMetadata'] : null;
-      final md =
-          rawMd is Map<String, dynamic> ? rawMd : const <String, dynamic>{};
+      final md = rawMd is Map<String, dynamic>
+          ? rawMd
+          : const <String, dynamic>{};
       if (runId != null && md['session_attr_qa_run_id'] != runId) continue;
       if (sessionId != null && md['session_id'] != sessionId) continue;
 
       final kind = (md['kind'] ?? labels['kind'] ?? 'unknown').toString();
       if (kinds != null && !kinds.contains(kind)) continue;
 
-      final ts =
-          (md['timestamp'] ?? (v is Map ? v['timestamp'] : null) ?? '')
-              .toString();
+      final ts = (md['timestamp'] ?? (v is Map ? v['timestamp'] : null) ?? '')
+          .toString();
       signals.add(
         Signal(
           kind: kind,
@@ -147,8 +175,10 @@ List<Signal> queryLokiSignals(
   // filtering. If we hit it, the run's signals may be silently truncated.
   final limitN = int.tryParse(limit);
   if (limitN != null && rawCount >= limitN) {
-    stderr.writeln('WARNING: hit --limit ($limit) raw Loki lines; results may '
-        'be truncated. Raise --limit or narrow --since.');
+    stderr.writeln(
+      'WARNING: hit --limit ($limit) raw Loki lines; results may '
+      'be truncated. Raise --limit or narrow --since.',
+    );
   }
   return signals;
 }
@@ -237,8 +267,10 @@ class Args {
     final allowed = {...known, 'help', 'h'};
     final unknown = _map.keys.where((k) => !allowed.contains(k)).toList();
     if (unknown.isNotEmpty) {
-      fail('Unknown flag(s): ${unknown.map((k) => '--$k').join(', ')}. '
-          'See --help.');
+      fail(
+        'Unknown flag(s): ${unknown.map((k) => '--$k').join(', ')}. '
+        'See --help.',
+      );
     }
   }
 }

--- a/tool/telemetry/common.dart
+++ b/tool/telemetry/common.dart
@@ -1,0 +1,244 @@
+// Shared helpers for the Faro telemetry debugging tools in this folder.
+//
+// These scripts inspect the telemetry a Faro app actually exported to Grafana
+// Cloud (Loki + Tempo) via the `gcx` CLI. They are development/debugging aids,
+// kept separate from the release tooling in the parent `tool/` directory.
+//
+// This file is a library (no `main`); the sibling scripts import it.
+
+import 'dart:convert';
+import 'dart:io';
+
+/// A single telemetry signal (log, event, exception, or measurement) pulled
+/// from Loki, with the fields the tools commonly need plus the raw metadata.
+class Signal {
+  Signal({
+    required this.kind,
+    required this.name,
+    required this.timestamp,
+    required this.metadata,
+    this.level,
+    this.traceId,
+    this.spanId,
+  });
+  final String kind;
+  final String name;
+  final String timestamp;
+  final Map<String, dynamic> metadata;
+  final String? level;
+  final String? traceId;
+  final String? spanId;
+
+  bool get hasTrace => traceId != null || spanId != null;
+}
+
+/// Thin wrapper around the `gcx` CLI that returns parsed JSON.
+class Gcx {
+  Gcx(this.bin, this.context);
+  final String bin;
+  final String context;
+
+  dynamic json(List<String> args, {bool allowFailure = false}) {
+    final ProcessResult result;
+    try {
+      result = Process.runSync(bin, ['--context', context, ...args]);
+    } on ProcessException catch (e) {
+      fail('Could not run "$bin" (${e.message}). '
+          'Is gcx installed and on your PATH? See https://github.com/grafana/gcx');
+    }
+    if (result.exitCode != 0) {
+      if (allowFailure) return null;
+      fail('gcx ${args.join(' ')} failed (exit ${result.exitCode}):\n'
+          '${result.stderr}');
+    }
+    final out = (result.stdout as String).trim();
+    if (out.isEmpty) return allowFailure ? null : <String, dynamic>{};
+    try {
+      return jsonDecode(out);
+    } catch (e) {
+      if (allowFailure) return null;
+      fail('Could not parse gcx JSON for "${args.join(' ')}": $e');
+    }
+  }
+}
+
+/// Resolves a Loki `app_id` from a Faro app name (`service_name`).
+String? resolveAppId(Gcx runner, String appName) {
+  final json = runner.json(['frontend', 'apps', 'list', '-o', 'json']);
+  if (json is! List) return null;
+  for (final app in json) {
+    if (app is Map && app['spec'] is Map) {
+      final spec = app['spec'] as Map;
+      if (spec['name'] == appName) return spec['id']?.toString();
+    }
+  }
+  return null;
+}
+
+/// Pulls telemetry signals for an app from Loki, filtered client-side by run
+/// id / session id / kind. Those are stored in `structuredMetadata`, not as
+/// indexed Loki labels, so filtering happens here rather than in the query.
+List<Signal> queryLokiSignals(
+  Gcx runner, {
+  required String lokiDs,
+  required String appId,
+  required String since,
+  required String limit,
+  String? runId,
+  String? sessionId,
+  Set<String>? kinds,
+}) {
+  final json = runner.json([
+    'logs',
+    'query',
+    '-d',
+    lokiDs,
+    '{app_id="$appId"}',
+    '--since',
+    since,
+    '--limit',
+    limit,
+    '-o',
+    'json',
+  ]);
+  final result = dig(json, ['data', 'result']);
+  if (result is! List) return [];
+
+  final signals = <Signal>[];
+  var rawCount = 0;
+  for (final stream in result) {
+    if (stream is! Map) continue;
+    final rawLabels = stream['stream'];
+    final labels = rawLabels is Map<String, dynamic>
+        ? rawLabels
+        : const <String, dynamic>{};
+    final values = stream['values'];
+    if (values is! List) continue;
+    for (final v in values) {
+      rawCount++;
+      // gcx returns each value as an object with a structuredMetadata map,
+      // NOT a [timestamp, line] array.
+      final rawMd = v is Map ? v['structuredMetadata'] : null;
+      final md =
+          rawMd is Map<String, dynamic> ? rawMd : const <String, dynamic>{};
+      if (runId != null && md['session_attr_qa_run_id'] != runId) continue;
+      if (sessionId != null && md['session_id'] != sessionId) continue;
+
+      final kind = (md['kind'] ?? labels['kind'] ?? 'unknown').toString();
+      if (kinds != null && !kinds.contains(kind)) continue;
+
+      final ts =
+          (md['timestamp'] ?? (v is Map ? v['timestamp'] : null) ?? '')
+              .toString();
+      signals.add(
+        Signal(
+          kind: kind,
+          name: signalName(kind, md),
+          timestamp: ts,
+          metadata: md,
+          level: md['level']?.toString(),
+          traceId: (md['trace_id'] ?? md['traceID'])?.toString(),
+          spanId: (md['span_id'] ?? md['spanID'])?.toString(),
+        ),
+      );
+    }
+  }
+  // The --limit applies to the raw Loki stream, BEFORE client-side run/session
+  // filtering. If we hit it, the run's signals may be silently truncated.
+  final limitN = int.tryParse(limit);
+  if (limitN != null && rawCount >= limitN) {
+    stderr.writeln('WARNING: hit --limit ($limit) raw Loki lines; results may '
+        'be truncated. Raise --limit or narrow --since.');
+  }
+  return signals;
+}
+
+/// Human-readable name for a signal. Note the per-kind field names: events use
+/// `event_name`, logs use `message`, exceptions/measurements use `type`.
+String signalName(String kind, Map<String, dynamic> md) {
+  switch (kind) {
+    case 'event':
+      return (md['event_name'] ?? md['name'] ?? '(event)').toString();
+    case 'measurement':
+      return (md['type'] ?? '(measurement)').toString();
+    case 'exception':
+      return (md['type'] ?? md['value'] ?? '(exception)').toString();
+    case 'log':
+      return (md['message'] ?? '(log)').toString();
+    default:
+      return (md['name'] ?? md['message'] ?? md['type'] ?? '(unknown)')
+          .toString();
+  }
+}
+
+/// Safely walks nested maps by [path], returning null if any hop is missing.
+dynamic dig(dynamic node, List<String> path) {
+  var current = node;
+  for (final key in path) {
+    if (current is Map && current.containsKey(key)) {
+      current = current[key];
+    } else {
+      return null;
+    }
+  }
+  return current;
+}
+
+/// Shortens an id for display to [len] chars plus a trailing `...` when cut;
+/// returns '-' for null.
+String short(String? id, {int len = 12}) {
+  if (id == null) return '-';
+  return id.length <= len ? id : '${id.substring(0, len)}...';
+}
+
+/// Truncates [s] to [max] chars plus a trailing `...` when cut.
+String truncate(String s, int max) =>
+    s.length <= max ? s : '${s.substring(0, max)}...';
+
+/// Pads/truncates [s] to a fixed column [width]. Truncation is marked with an
+/// ellipsis (so a cut value is never mistaken for a complete one) and keeps a
+/// trailing space so columns stay visually separated. Assumes width >= 4.
+String pad(String s, int width) {
+  if (s.length < width) return s.padRight(width);
+  if (s.length == width) return s;
+  return '${s.substring(0, width - 4)}... ';
+}
+
+/// Prints an error and exits non-zero.
+Never fail(String message) {
+  stderr.writeln('ERROR: $message');
+  exit(1);
+}
+
+/// Minimal `--key value` / `--key=value` / `--flag` argument parser.
+class Args {
+  Args(List<String> argv) {
+    for (var i = 0; i < argv.length; i++) {
+      var a = argv[i];
+      if (!a.startsWith('-')) continue;
+      a = a.replaceFirst(RegExp('^--?'), '');
+      if (a.contains('=')) {
+        final idx = a.indexOf('=');
+        _map[a.substring(0, idx)] = a.substring(idx + 1);
+      } else if (i + 1 < argv.length && !argv[i + 1].startsWith('-')) {
+        _map[a] = argv[++i];
+      } else {
+        _map[a] = 'true';
+      }
+    }
+  }
+  final _map = <String, String>{};
+  String? value(String key) => _map[key];
+  bool has(String key) => _map.containsKey(key);
+
+  /// Fails if any parsed flag is not in [known] (plus `help`/`h`). Guards
+  /// against silent typos like `--runid` widening a query to the wrong data.
+  void ensureKnown(Set<String> known) {
+    final allowed = {...known, 'help', 'h'};
+    final unknown = _map.keys.where((k) => !allowed.contains(k)).toList();
+    if (unknown.isNotEmpty) {
+      fail('Unknown flag(s): ${unknown.map((k) => '--$k').join(', ')}. '
+          'See --help.');
+    }
+  }
+}

--- a/tool/telemetry/list_signals.dart
+++ b/tool/telemetry/list_signals.dart
@@ -1,0 +1,179 @@
+// Lists every Faro telemetry signal (log, event, exception, measurement) for a
+// single session or run, as a chronological timeline. This is the generic
+// "reconstruct what the app emitted" primitive — not trace-specific — useful
+// for eyeballing a session, debugging missing/duplicated signals, or feeding a
+// normalized signal list into other tooling via --format json.
+//
+// Generic: works for any Faro app, via the `gcx` CLI.
+//
+// Usage:
+//   dart tool/telemetry/list_signals.dart \
+//     --context <ctx> (--app-id <id> | --app-name <service_name>) \
+//     (--session-id <id> | --run-id <qa_run_id>) \
+//     [--kind log,event,exception,measurement] \
+//     [--since 1h] [--limit 2000] [--format timeline|json] \
+//     [--loki-ds grafanacloud-logs] [--gcx gcx]
+//
+// Exit codes: 0 = signals listed (or none found); 1 = query/arg error.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'common.dart';
+
+void main(List<String> argv) {
+  final args = Args(argv);
+  if (args.has('help') || args.has('h')) {
+    _printUsage();
+    return;
+  }
+  args.ensureKnown({
+    'context', 'gcx', 'loki-ds', 'since', 'limit', 'format', //
+    'run-id', 'session-id', 'app-id', 'app-name', 'kind',
+  });
+
+  final context = args.value('context');
+  final gcx = args.value('gcx') ?? 'gcx';
+  final lokiDs = args.value('loki-ds') ?? 'grafanacloud-logs';
+  final since = args.value('since') ?? '1h';
+  final limit = args.value('limit') ?? '2000';
+  final format = args.value('format') ?? 'timeline';
+  final runId = args.value('run-id');
+  final sessionId = args.value('session-id');
+  var appId = args.value('app-id');
+  final appName = args.value('app-name');
+  final kindFilter = args
+      .value('kind')
+      ?.split(',')
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toSet();
+
+  if (context == null) fail('Missing required --context. See --help.');
+  if (appId == null && appName == null) {
+    fail('Provide either --app-id or --app-name. See --help.');
+  }
+  if (runId == null && sessionId == null) {
+    fail('Provide either --session-id or --run-id. See --help.');
+  }
+
+  final runner = Gcx(gcx, context);
+
+  if (appId == null) {
+    appId = resolveAppId(runner, appName!);
+    if (appId == null) fail('Could not resolve app-id for "$appName".');
+  }
+
+  final signals = queryLokiSignals(
+    runner,
+    lokiDs: lokiDs,
+    appId: appId,
+    since: since,
+    limit: limit,
+    runId: runId,
+    sessionId: sessionId,
+    kinds: kindFilter,
+  )..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+  if (format == 'json') {
+    stdout.writeln(
+      const JsonEncoder.withIndent('  ').convert(
+        signals.map(_toJson).toList(),
+      ),
+    );
+    return;
+  }
+
+  final target = runId != null ? 'qa_run_id=$runId' : 'session_id=$sessionId';
+  stdout
+    ..writeln('Context : $context   App: id=$appId')
+    ..writeln('Target  : $target   Window: last $since')
+    ..writeln();
+
+  if (signals.isEmpty) {
+    stdout.writeln('No signals found. Data can take ~30-45s to appear; try a '
+        'wider --since.');
+    return;
+  }
+
+  stdout.writeln(
+    '${pad('TIME (UTC)', 26)}${pad('KIND', 13)}'
+    '${pad('SIGNAL', 34)}EXTRA',
+  );
+  stdout.writeln('-' * 100);
+  for (final s in signals) {
+    final kindCol =
+        (s.kind == 'log' && s.level != null) ? '${s.kind}/${s.level}' : s.kind;
+    stdout.writeln(
+      '${pad(s.timestamp, 26)}${pad(kindCol, 13)}'
+      '${pad(s.name, 34)}${_extra(s)}',
+    );
+  }
+
+  final byKind = <String, int>{};
+  for (final s in signals) {
+    byKind[s.kind] = (byKind[s.kind] ?? 0) + 1;
+  }
+  final summary =
+      (byKind.entries.toList()..sort((a, b) => a.key.compareTo(b.key)))
+          .map((e) => '${e.key}=${e.value}')
+          .join('  ');
+  stdout
+    ..writeln('-' * 100)
+    ..writeln('Total: ${signals.length}   ($summary)');
+}
+
+Map<String, dynamic> _toJson(Signal s) => {
+      'timestamp': s.timestamp,
+      'kind': s.kind,
+      'name': s.name,
+      if (s.kind == 'log' && s.level != null) 'level': s.level,
+      if (s.traceId != null) 'trace_id': s.traceId,
+      if (s.spanId != null) 'span_id': s.spanId,
+      // Full structuredMetadata so `--format json` can be used to inspect
+      // actual field names/values (e.g. confirm a new field surfaces).
+      'metadata': s.metadata,
+    };
+
+/// Trailing EXTRA column: trace context plus a couple of kind-specific hints
+/// (exception value, measurement value keys).
+String _extra(Signal s) {
+  final parts = <String>[];
+  if (s.traceId != null) {
+    parts.add('trace=${short(s.traceId, len: 10)}:${s.spanId ?? '-'}');
+  }
+  if (s.kind == 'exception' && s.metadata['value'] != null) {
+    parts.add('value="${truncate(s.metadata['value'].toString(), 40)}"');
+  }
+  if (s.kind == 'measurement') {
+    final values = s.metadata.entries
+        .where((e) => e.key.startsWith('value'))
+        .map((e) => '${e.key}=${e.value}')
+        .toList();
+    if (values.isNotEmpty) parts.add(values.join(','));
+  }
+  return parts.join('  ');
+}
+
+void _printUsage() {
+  stdout.writeln(r'''
+list_signals.dart — chronological timeline of a session's telemetry.
+
+Required:
+  --context <name>        gcx context (Grafana stack)
+  --app-id <id> | --app-name <service_name>
+  --session-id <id> | --run-id <qa_run_id>
+
+Optional:
+  --kind <list>           comma list: log,event,exception,measurement
+  --since <dur>           default: 1h
+  --limit <n>             default: 2000
+  --format <fmt>          timeline (default) | json
+  --loki-ds <uid>         default: grafanacloud-logs
+  --gcx <path>            default: gcx
+
+Example:
+  dart tool/telemetry/list_signals.dart \
+    --context <ctx> --app-id <app-id> --run-id validate-run --since 2h
+''');
+}

--- a/tool/telemetry/list_signals.dart
+++ b/tool/telemetry/list_signals.dart
@@ -60,7 +60,7 @@ void main(List<String> argv) {
   final runner = Gcx(gcx, context);
 
   if (appId == null) {
-    appId = resolveAppId(runner, appName!);
+    appId = resolveAppId(runner, appName!, lokiDs: lokiDs, since: since);
     if (appId == null) fail('Could not resolve app-id for "$appName".');
   }
 
@@ -77,9 +77,7 @@ void main(List<String> argv) {
 
   if (format == 'json') {
     stdout.writeln(
-      const JsonEncoder.withIndent('  ').convert(
-        signals.map(_toJson).toList(),
-      ),
+      const JsonEncoder.withIndent('  ').convert(signals.map(_toJson).toList()),
     );
     return;
   }
@@ -91,8 +89,10 @@ void main(List<String> argv) {
     ..writeln();
 
   if (signals.isEmpty) {
-    stdout.writeln('No signals found. Data can take ~30-45s to appear; try a '
-        'wider --since.');
+    stdout.writeln(
+      'No signals found. Data can take ~30-45s to appear; try a '
+      'wider --since.',
+    );
     return;
   }
 
@@ -102,8 +102,9 @@ void main(List<String> argv) {
   );
   stdout.writeln('-' * 100);
   for (final s in signals) {
-    final kindCol =
-        (s.kind == 'log' && s.level != null) ? '${s.kind}/${s.level}' : s.kind;
+    final kindCol = (s.kind == 'log' && s.level != null)
+        ? '${s.kind}/${s.level}'
+        : s.kind;
     stdout.writeln(
       '${pad(s.timestamp, 26)}${pad(kindCol, 13)}'
       '${pad(s.name, 34)}${_extra(s)}',
@@ -124,16 +125,16 @@ void main(List<String> argv) {
 }
 
 Map<String, dynamic> _toJson(Signal s) => {
-      'timestamp': s.timestamp,
-      'kind': s.kind,
-      'name': s.name,
-      if (s.kind == 'log' && s.level != null) 'level': s.level,
-      if (s.traceId != null) 'trace_id': s.traceId,
-      if (s.spanId != null) 'span_id': s.spanId,
-      // Full structuredMetadata so `--format json` can be used to inspect
-      // actual field names/values (e.g. confirm a new field surfaces).
-      'metadata': s.metadata,
-    };
+  'timestamp': s.timestamp,
+  'kind': s.kind,
+  'name': s.name,
+  if (s.kind == 'log' && s.level != null) 'level': s.level,
+  if (s.traceId != null) 'trace_id': s.traceId,
+  if (s.spanId != null) 'span_id': s.spanId,
+  // Full structuredMetadata so `--format json` can be used to inspect
+  // actual field names/values (e.g. confirm a new field surfaces).
+  'metadata': s.metadata,
+};
 
 /// Trailing EXTRA column: trace context plus a couple of kind-specific hints
 /// (exception value, measurement value keys).

--- a/tool/telemetry/list_signals.dart
+++ b/tool/telemetry/list_signals.dart
@@ -140,7 +140,10 @@ Map<String, dynamic> _toJson(Signal s) => {
 /// (exception value, measurement value keys).
 String _extra(Signal s) {
   final parts = <String>[];
-  if (s.traceId != null) {
+  // Show trace context whenever EITHER id is present. Gating on traceId alone
+  // would hide span-only (partial context) signals — the exact case
+  // verify_correlation.dart flags — so use hasTrace. short(null) renders '-'.
+  if (s.hasTrace) {
     parts.add('trace=${short(s.traceId, len: 10)}:${s.spanId ?? '-'}');
   }
   if (s.kind == 'exception' && s.metadata['value'] != null) {

--- a/tool/telemetry/snapshot.dart
+++ b/tool/telemetry/snapshot.dart
@@ -81,7 +81,7 @@ void _snapshot(Args args) {
 
   final runner = Gcx(gcx, context);
   if (appId == null) {
-    appId = resolveAppId(runner, appName!);
+    appId = resolveAppId(runner, appName!, lokiDs: lokiDs, since: since);
     if (appId == null) fail('Could not resolve app-id for "$appName".');
   }
 
@@ -107,8 +107,10 @@ void _snapshot(Args args) {
 
   final groups = <String, _Group>{};
   for (final s in signals) {
-    final group = groups.putIfAbsent('${s.kind}::${s.name}',
-        () => _Group(s.kind, s.name));
+    final group = groups.putIfAbsent(
+      '${s.kind}::${s.name}',
+      () => _Group(s.kind, s.name),
+    );
     group.count++;
     if (s.hasTrace) group.hasTrace = true;
     for (final key in s.metadata.keys) {
@@ -117,8 +119,7 @@ void _snapshot(Args args) {
     }
   }
 
-  final sorted = groups.values.toList()
-    ..sort((a, b) => a.key.compareTo(b.key));
+  final sorted = groups.values.toList()..sort((a, b) => a.key.compareTo(b.key));
   final snapshot = {
     'app_id': appId,
     'context': context,
@@ -202,8 +203,10 @@ void _diff(String beforePath, String afterPath) {
     stdout.writeln('No structural differences. Telemetry shape is identical.');
     exit(0);
   }
-  stdout.writeln('$changes group(s) differ. Review above — for a '
-      'trace-correlation change, expect only has_trace / trace-key deltas.');
+  stdout.writeln(
+    '$changes group(s) differ. Review above — for a '
+    'trace-correlation change, expect only has_trace / trace-key deltas.',
+  );
   exit(2);
 }
 
@@ -227,8 +230,10 @@ Map<String, dynamic> _readSnapshot(String path) {
     fail('Could not parse snapshot "$path": $e');
   }
   if (decoded is! Map<String, dynamic> || decoded['groups'] is! Map) {
-    fail('"$path" is not a telemetry snapshot (missing "groups"). '
-        'Generate one with: snapshot.dart snapshot ... --out $path');
+    fail(
+      '"$path" is not a telemetry snapshot (missing "groups"). '
+      'Generate one with: snapshot.dart snapshot ... --out $path',
+    );
   }
   return decoded;
 }

--- a/tool/telemetry/snapshot.dart
+++ b/tool/telemetry/snapshot.dart
@@ -35,10 +35,14 @@ import 'common.dart';
 const _traceKeys = <String>{'trace_id', 'span_id', 'traceID', 'spanID'};
 
 void main(List<String> argv) {
+  // Only the bare `help` keyword counts as help when it's the first token;
+  // matching it anywhere would treat flag values/paths (e.g. `--run-id help`
+  // or `diff help after.json`) as a help request. The `--help`/`-h` flags may
+  // appear anywhere.
   if (argv.isEmpty ||
+      argv.first == 'help' ||
       argv.contains('--help') ||
-      argv.contains('-h') ||
-      argv.contains('help')) {
+      argv.contains('-h')) {
     _printUsage();
     return;
   }

--- a/tool/telemetry/snapshot.dart
+++ b/tool/telemetry/snapshot.dart
@@ -1,0 +1,261 @@
+// Captures a normalized snapshot of the telemetry a Faro app emitted for a
+// single run, and diffs two snapshots. Built for before/after validation of
+// SDK changes: run the app on `main`, snapshot; run on the branch, snapshot;
+// diff. The diff highlights structural changes (which signal types gained or
+// lost fields, and whether they carry trace context) while ignoring volatile
+// noise like timestamps, session ids, and the concrete trace/span id values.
+//
+// Normalization strategy: signals are grouped by "kind::name". For each group
+// we record the count, the union of structuredMetadata keys, and whether the
+// group carries trace context. Volatile values are never compared — only the
+// SHAPE (key set) and trace presence, so two runs of the same code match.
+//
+// Generic: works for any Faro app, via the `gcx` CLI.
+//
+// Usage:
+//   # snapshot a run to a file
+//   dart tool/telemetry/snapshot.dart snapshot \
+//     --context <ctx> (--app-id <id> | --app-name <name>) \
+//     [--run-id <id> | --session-id <id>] [--since 30m] [--out run.json]
+//
+//   # diff two snapshots (before = main, after = branch)
+//   dart tool/telemetry/snapshot.dart diff before.json after.json
+//
+// Exit codes for `diff`: 0 = identical shape; 2 = differences found (not an
+// error, just a signal for scripting).
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'common.dart';
+
+// Trace-context keys. Their VALUES are volatile across runs, but their
+// PRESENCE is exactly what a correlation change adds, so they are surfaced via
+// the `has_trace` flag rather than the compared metadata-key set.
+const _traceKeys = <String>{'trace_id', 'span_id', 'traceID', 'spanID'};
+
+void main(List<String> argv) {
+  if (argv.isEmpty ||
+      argv.contains('--help') ||
+      argv.contains('-h') ||
+      argv.contains('help')) {
+    _printUsage();
+    return;
+  }
+  final mode = argv.first;
+  final rest = argv.sublist(1);
+  switch (mode) {
+    case 'snapshot':
+      _snapshot(Args(rest));
+    case 'diff':
+      final positional = rest.where((a) => !a.startsWith('-')).toList();
+      if (positional.length != 2) {
+        fail('diff needs exactly two snapshot files: <before> <after>');
+      }
+      _diff(positional[0], positional[1]);
+    default:
+      fail('Unknown mode "$mode". Use "snapshot" or "diff". See --help.');
+  }
+}
+
+void _snapshot(Args args) {
+  args.ensureKnown({
+    'context', 'gcx', 'loki-ds', 'since', 'limit', //
+    'run-id', 'session-id', 'app-id', 'app-name', 'out',
+  });
+  final context = args.value('context');
+  final gcx = args.value('gcx') ?? 'gcx';
+  final lokiDs = args.value('loki-ds') ?? 'grafanacloud-logs';
+  final since = args.value('since') ?? '30m';
+  final limit = args.value('limit') ?? '2000';
+  final runId = args.value('run-id');
+  final sessionId = args.value('session-id');
+  var appId = args.value('app-id');
+  final appName = args.value('app-name');
+  final out = args.value('out');
+
+  if (context == null) fail('Missing required --context.');
+  if (appId == null && appName == null) {
+    fail('Provide either --app-id or --app-name.');
+  }
+
+  final runner = Gcx(gcx, context);
+  if (appId == null) {
+    appId = resolveAppId(runner, appName!);
+    if (appId == null) fail('Could not resolve app-id for "$appName".');
+  }
+
+  final signals = queryLokiSignals(
+    runner,
+    lokiDs: lokiDs,
+    appId: appId,
+    since: since,
+    limit: limit,
+    runId: runId,
+    sessionId: sessionId,
+  );
+
+  if (signals.isEmpty) {
+    final filtered = runId != null || sessionId != null;
+    fail(
+      'No signals found for app_id=$appId in the last $since'
+      '${filtered ? ' matching the given filter' : ''}. '
+      'Refusing to write an empty snapshot (an empty-vs-empty diff would look '
+      '"identical"). Data can take ~30-45s to appear; try a wider --since.',
+    );
+  }
+
+  final groups = <String, _Group>{};
+  for (final s in signals) {
+    final group = groups.putIfAbsent('${s.kind}::${s.name}',
+        () => _Group(s.kind, s.name));
+    group.count++;
+    if (s.hasTrace) group.hasTrace = true;
+    for (final key in s.metadata.keys) {
+      // Trace keys are surfaced via has_trace, not the compared key set.
+      if (!_traceKeys.contains(key)) group.keys.add(key);
+    }
+  }
+
+  final sorted = groups.values.toList()
+    ..sort((a, b) => a.key.compareTo(b.key));
+  final snapshot = {
+    'app_id': appId,
+    'context': context,
+    'run_id': runId,
+    'session_id': sessionId,
+    'since': since,
+    'total_signals': signals.length,
+    'groups': {
+      for (final g in sorted)
+        g.key: {
+          'kind': g.kind,
+          'name': g.name,
+          'count': g.count,
+          'has_trace': g.hasTrace,
+          'metadata_keys': g.keys.toList()..sort(),
+        },
+    },
+  };
+
+  final encoded = const JsonEncoder.withIndent('  ').convert(snapshot);
+  if (out != null) {
+    File(out).writeAsStringSync('$encoded\n');
+    stdout.writeln(
+      'Wrote snapshot: $out  (${groups.length} groups, '
+      '${signals.length} signals)',
+    );
+  } else {
+    stdout.writeln(encoded);
+  }
+}
+
+void _diff(String beforePath, String afterPath) {
+  final before = _readSnapshot(beforePath);
+  final after = _readSnapshot(afterPath);
+  final bGroups = (before['groups'] as Map).cast<String, dynamic>();
+  final aGroups = (after['groups'] as Map).cast<String, dynamic>();
+
+  final allKeys = {...bGroups.keys, ...aGroups.keys}.toList()..sort();
+  var changes = 0;
+
+  stdout.writeln('TELEMETRY SHAPE DIFF');
+  stdout.writeln('  before: $beforePath');
+  stdout.writeln('  after : $afterPath');
+  stdout.writeln('-' * 78);
+
+  for (final key in allKeys) {
+    final b = bGroups[key] as Map<String, dynamic>?;
+    final a = aGroups[key] as Map<String, dynamic>?;
+    if (b == null) {
+      stdout.writeln('  + NEW GROUP   $key  (has_trace=${a!['has_trace']})');
+      changes++;
+      continue;
+    }
+    if (a == null) {
+      stdout.writeln('  - REMOVED     $key');
+      changes++;
+      continue;
+    }
+    final bTrace = b['has_trace'] == true;
+    final aTrace = a['has_trace'] == true;
+    final bKeys = (b['metadata_keys'] as List).map((e) => e.toString()).toSet();
+    final aKeys = (a['metadata_keys'] as List).map((e) => e.toString()).toSet();
+    final added = aKeys.difference(bKeys).toList()..sort();
+    final removed = bKeys.difference(aKeys).toList()..sort();
+
+    if (bTrace != aTrace || added.isNotEmpty || removed.isNotEmpty) {
+      stdout.writeln('  ~ CHANGED     $key');
+      if (bTrace != aTrace) {
+        stdout.writeln('      has_trace: $bTrace -> $aTrace');
+      }
+      if (added.isNotEmpty) stdout.writeln('      + keys: ${added.join(', ')}');
+      if (removed.isNotEmpty) {
+        stdout.writeln('      - keys: ${removed.join(', ')}');
+      }
+      changes++;
+    }
+  }
+
+  stdout.writeln('-' * 78);
+  if (changes == 0) {
+    stdout.writeln('No structural differences. Telemetry shape is identical.');
+    exit(0);
+  }
+  stdout.writeln('$changes group(s) differ. Review above — for a '
+      'trace-correlation change, expect only has_trace / trace-key deltas.');
+  exit(2);
+}
+
+class _Group {
+  _Group(this.kind, this.name);
+  final String kind;
+  final String name;
+  int count = 0;
+  bool hasTrace = false;
+  final Set<String> keys = {};
+  String get key => '$kind::$name';
+}
+
+Map<String, dynamic> _readSnapshot(String path) {
+  final file = File(path);
+  if (!file.existsSync()) fail('Snapshot file not found: $path');
+  final dynamic decoded;
+  try {
+    decoded = jsonDecode(file.readAsStringSync());
+  } catch (e) {
+    fail('Could not parse snapshot "$path": $e');
+  }
+  if (decoded is! Map<String, dynamic> || decoded['groups'] is! Map) {
+    fail('"$path" is not a telemetry snapshot (missing "groups"). '
+        'Generate one with: snapshot.dart snapshot ... --out $path');
+  }
+  return decoded;
+}
+
+void _printUsage() {
+  stdout.writeln(r'''
+snapshot.dart — normalized before/after telemetry comparison.
+
+MODES:
+  snapshot   capture a run's telemetry shape to JSON
+  diff       compare two snapshot files
+
+snapshot flags:
+  --context <name>        gcx context (required)
+  --app-id <id> | --app-name <service_name>
+  --run-id <id>           filter by session_attr_qa_run_id
+  --session-id <id>       filter by session_id
+  --loki-ds <uid>         default: grafanacloud-logs
+  --since <dur>           default: 30m
+  --limit <n>             default: 2000
+  --out <file>            write JSON here (default: stdout)
+
+Examples:
+  dart tool/telemetry/snapshot.dart snapshot --context <ctx> \
+    --app-id <app-id> --run-id main-run   --since 1h --out before.json
+  dart tool/telemetry/snapshot.dart snapshot --context <ctx> \
+    --app-id <app-id> --run-id branch-run --since 1h --out after.json
+  dart tool/telemetry/snapshot.dart diff before.json after.json
+''');
+}

--- a/tool/telemetry/verify_correlation.dart
+++ b/tool/telemetry/verify_correlation.dart
@@ -1,0 +1,244 @@
+// Verifies Faro log/trace correlation for a single run by cross-referencing
+// Loki signals against Tempo traces via the `gcx` CLI.
+//
+// For a given app + run (or session), it pulls every log/event/exception/
+// measurement from Loki, extracts the trace_id/span_id each one carries, then
+// fetches the referenced traces from Tempo and confirms the span actually
+// exists. Signals that reference a trace/span not found in Tempo are reported
+// as dangling correlations and cause a non-zero exit.
+//
+// Generic: works for any Faro app, not just the example app in this repo.
+//
+// Usage:
+//   dart tool/telemetry/verify_correlation.dart \
+//     --context <gcx-context> \
+//     (--app-id <id> | --app-name <service_name>) \
+//     [--run-id <qa_run_id> | --session-id <id>] \
+//     [--loki-ds grafanacloud-logs] [--tempo-ds grafanacloud-traces] \
+//     [--since 30m] [--limit 2000] [--gcx gcx]
+//
+// Exit codes: 0 = all referenced spans found in Tempo (or no correlation to
+// check); 1 = at least one dangling correlation or a query error.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'common.dart';
+
+void main(List<String> argv) {
+  final args = Args(argv);
+  if (args.has('help') || args.has('h')) {
+    _printUsage();
+    return;
+  }
+  args.ensureKnown({
+    'context', 'gcx', 'loki-ds', 'tempo-ds', 'since', 'limit', //
+    'run-id', 'session-id', 'app-id', 'app-name',
+  });
+
+  final context = args.value('context');
+  final gcx = args.value('gcx') ?? 'gcx';
+  final lokiDs = args.value('loki-ds') ?? 'grafanacloud-logs';
+  final tempoDs = args.value('tempo-ds') ?? 'grafanacloud-traces';
+  final since = args.value('since') ?? '30m';
+  final limit = args.value('limit') ?? '2000';
+  final runId = args.value('run-id');
+  final sessionId = args.value('session-id');
+  var appId = args.value('app-id');
+  final appName = args.value('app-name');
+
+  if (context == null) fail('Missing required --context. See --help.');
+  if (appId == null && appName == null) {
+    fail('Provide either --app-id or --app-name. See --help.');
+  }
+
+  final runner = Gcx(gcx, context);
+
+  if (appId == null) {
+    stdout.writeln('Resolving app-id for "$appName" ...');
+    appId = resolveAppId(runner, appName!);
+    if (appId == null) {
+      fail('Could not resolve an app-id for --app-name "$appName".');
+    }
+    stdout.writeln('  -> app_id=$appId');
+  }
+
+  final filter = runId != null
+      ? 'qa_run_id=$runId'
+      : sessionId != null
+          ? 'session_id=$sessionId'
+          : '(none)';
+  stdout
+    ..writeln('Context : $context')
+    ..writeln('App     : id=$appId')
+    ..writeln('Loki    : $lokiDs   Tempo: $tempoDs')
+    ..writeln('Window  : last $since')
+    ..writeln('Filter  : $filter')
+    ..writeln();
+
+  final signals = queryLokiSignals(
+    runner,
+    lokiDs: lokiDs,
+    appId: appId,
+    since: since,
+    limit: limit,
+    runId: runId,
+    sessionId: sessionId,
+  );
+
+  if (signals.isEmpty) {
+    final filtered = runId != null || sessionId != null;
+    fail(
+      'No signals found for app_id=$appId in the last $since'
+      '${filtered ? ' matching the given filter' : ''}. '
+      'Data can take ~30-45s to appear; try a wider --since.',
+    );
+  }
+
+  // "Correlated" = carries ANY trace context (trace_id and/or span_id). A
+  // signal with only one of the two is partial context and must be flagged,
+  // not silently passed as uncorrelated.
+  final correlated = signals.where((s) => s.hasTrace).toList();
+  final uncorrelated = signals.where((s) => !s.hasTrace).toList();
+
+  // Fetch each referenced trace once and collect its span-id set (hex).
+  final traceSpanIds = <String, Set<String>?>{};
+  for (final traceId
+      in correlated.map((s) => s.traceId).whereType<String>().toSet()) {
+    traceSpanIds[traceId] = _fetchTraceSpanIds(runner, tempoDs, traceId);
+  }
+
+  stdout.writeln('CORRELATED SIGNALS (carry trace context)');
+  stdout.writeln('-' * 78);
+  var dangling = 0;
+  if (correlated.isEmpty) {
+    stdout.writeln('  (none)');
+  }
+  for (final s in correlated) {
+    final spans = s.traceId == null ? null : traceSpanIds[s.traceId];
+    final String status;
+    if (s.traceId == null) {
+      status = 'NO TRACE ID (partial context)';
+      dangling++;
+    } else if (s.spanId == null) {
+      status = 'NO SPAN ID (partial context)';
+      dangling++;
+    } else if (spans == null) {
+      status = 'TRACE NOT FOUND IN TEMPO';
+      dangling++;
+    } else if (!spans.contains(s.spanId!.toLowerCase())) {
+      status = 'SPAN NOT IN TRACE';
+      dangling++;
+    } else {
+      status = 'OK';
+    }
+    stdout.writeln(
+      '  [${pad(s.kind, 11)}] ${pad(s.name, 30)} '
+      'trace=${short(s.traceId)} span=${s.spanId ?? '-'}  $status',
+    );
+  }
+
+  stdout.writeln();
+  stdout.writeln('UNCORRELATED SIGNALS (no trace context) — grouped');
+  stdout.writeln('-' * 78);
+  final grouped = <String, int>{};
+  for (final s in uncorrelated) {
+    final key = '${s.kind}::${s.name}';
+    grouped[key] = (grouped[key] ?? 0) + 1;
+  }
+  if (grouped.isEmpty) {
+    stdout.writeln('  (none)');
+  }
+  final keys = grouped.keys.toList()..sort();
+  for (final k in keys) {
+    stdout.writeln('  ${pad(k, 44)} x${grouped[k]}');
+  }
+
+  stdout.writeln();
+  stdout.writeln('SUMMARY');
+  stdout.writeln('-' * 78);
+  final tracesFound = traceSpanIds.values.where((s) => s != null).length;
+  stdout
+    ..writeln('  signals total     : ${signals.length}')
+    ..writeln('  correlated        : ${correlated.length}')
+    ..writeln('  uncorrelated      : ${uncorrelated.length}')
+    ..writeln('  distinct traces   : ${traceSpanIds.length} '
+        '(found in Tempo: $tracesFound)')
+    ..writeln('  dangling refs     : $dangling');
+
+  if (dangling > 0) {
+    stdout.writeln('\nFAIL: $dangling signal(s) have partial context or '
+        'reference a trace/span not found in Tempo.');
+    exit(1);
+  }
+  stdout.writeln('\nPASS: every correlated signal resolves to a real Tempo '
+      'span.');
+}
+
+/// Returns the set of span-ids (lowercase hex) in a Tempo trace, or null if
+/// the trace could not be fetched.
+Set<String>? _fetchTraceSpanIds(Gcx runner, String tempoDs, String traceId) {
+  final json = runner.json(
+    ['traces', 'get', traceId, '-d', tempoDs, '-o', 'json'],
+    allowFailure: true,
+  );
+  if (json == null) return null;
+  final ids = <String>{};
+  _collectSpanIds(json, ids);
+  return ids.isEmpty ? null : ids;
+}
+
+/// Recursively walks OTLP-shaped JSON collecting base64 `spanId` values,
+/// decoded to lowercase hex.
+void _collectSpanIds(dynamic node, Set<String> out) {
+  if (node is Map) {
+    for (final entry in node.entries) {
+      if (entry.key == 'spanId' && entry.value is String) {
+        final hex = _base64ToHex(entry.value as String);
+        if (hex != null) out.add(hex);
+      } else {
+        _collectSpanIds(entry.value, out);
+      }
+    }
+  } else if (node is List) {
+    for (final item in node) {
+      _collectSpanIds(item, out);
+    }
+  }
+}
+
+String? _base64ToHex(String b64) {
+  try {
+    final bytes = base64.decode(base64.normalize(b64));
+    return bytes
+        .map((b) => b.toRadixString(16).padLeft(2, '0'))
+        .join()
+        .toLowerCase();
+  } catch (_) {
+    return null;
+  }
+}
+
+void _printUsage() {
+  stdout.writeln(r'''
+verify_correlation.dart — cross-check Faro Loki signals vs Tempo.
+
+Required:
+  --context <name>        gcx context (Grafana stack)
+  --app-id <id> | --app-name <service_name>
+
+Optional:
+  --run-id <id>           filter by session_attr_qa_run_id
+  --session-id <id>       filter by session_id
+  --loki-ds <uid>         default: grafanacloud-logs
+  --tempo-ds <uid>        default: grafanacloud-traces
+  --since <dur>           default: 30m
+  --limit <n>             default: 2000
+  --gcx <path>            default: gcx
+
+Example:
+  dart tool/telemetry/verify_correlation.dart \
+    --context <ctx> --app-id <app-id> \
+    --run-id <qa_run_id> --since 1h
+''');
+}

--- a/tool/telemetry/verify_correlation.dart
+++ b/tool/telemetry/verify_correlation.dart
@@ -56,7 +56,7 @@ void main(List<String> argv) {
 
   if (appId == null) {
     stdout.writeln('Resolving app-id for "$appName" ...');
-    appId = resolveAppId(runner, appName!);
+    appId = resolveAppId(runner, appName!, lokiDs: lokiDs, since: since);
     if (appId == null) {
       fail('Could not resolve an app-id for --app-name "$appName".');
     }
@@ -66,8 +66,8 @@ void main(List<String> argv) {
   final filter = runId != null
       ? 'qa_run_id=$runId'
       : sessionId != null
-          ? 'session_id=$sessionId'
-          : '(none)';
+      ? 'session_id=$sessionId'
+      : '(none)';
   stdout
     ..writeln('Context : $context')
     ..writeln('App     : id=$appId')
@@ -126,6 +126,9 @@ void main(List<String> argv) {
     } else if (spans == null) {
       status = 'TRACE NOT FOUND IN TEMPO';
       dangling++;
+    } else if (spans.isEmpty) {
+      status = 'TRACE HAS NO DECODABLE SPANS';
+      dangling++;
     } else if (!spans.contains(s.spanId!.toLowerCase())) {
       status = 'SPAN NOT IN TRACE';
       dangling++;
@@ -162,37 +165,53 @@ void main(List<String> argv) {
     ..writeln('  signals total     : ${signals.length}')
     ..writeln('  correlated        : ${correlated.length}')
     ..writeln('  uncorrelated      : ${uncorrelated.length}')
-    ..writeln('  distinct traces   : ${traceSpanIds.length} '
-        '(found in Tempo: $tracesFound)')
+    ..writeln(
+      '  distinct traces   : ${traceSpanIds.length} '
+      '(found in Tempo: $tracesFound)',
+    )
     ..writeln('  dangling refs     : $dangling');
 
   if (dangling > 0) {
-    stdout.writeln('\nFAIL: $dangling signal(s) have partial context or '
-        'reference a trace/span not found in Tempo.');
+    stdout.writeln(
+      '\nFAIL: $dangling signal(s) have partial context or '
+      'reference a trace/span not found in Tempo.',
+    );
     exit(1);
   }
-  stdout.writeln('\nPASS: every correlated signal resolves to a real Tempo '
-      'span.');
+  stdout.writeln(
+    '\nPASS: every correlated signal resolves to a real Tempo '
+    'span.',
+  );
 }
 
-/// Returns the set of span-ids (lowercase hex) in a Tempo trace, or null if
-/// the trace could not be fetched.
+/// Returns the set of span-ids (lowercase hex) in a Tempo trace. Returns null
+/// only when the trace could not be fetched (missing/absent); an empty set
+/// means the trace was fetched but no `spanId`s decoded, which is distinct and
+/// reported separately so a decode/schema regression isn't mistaken for a
+/// missing trace.
 Set<String>? _fetchTraceSpanIds(Gcx runner, String tempoDs, String traceId) {
-  final json = runner.json(
-    ['traces', 'get', traceId, '-d', tempoDs, '-o', 'json'],
-    allowFailure: true,
-  );
+  final json = runner.json([
+    'traces',
+    'get',
+    traceId,
+    '-d',
+    tempoDs,
+    '-o',
+    'json',
+  ], allowFailure: true);
   if (json == null) return null;
   final ids = <String>{};
   _collectSpanIds(json, ids);
-  return ids.isEmpty ? null : ids;
+  return ids;
 }
 
 /// Recursively walks OTLP-shaped JSON collecting base64 `spanId` values,
-/// decoded to lowercase hex.
+/// decoded to lowercase hex. Skips `links`/`references`, whose `spanId`s point
+/// at other spans (often in other traces) and would cause false matches.
 void _collectSpanIds(dynamic node, Set<String> out) {
   if (node is Map) {
     for (final entry in node.entries) {
+      if (entry.key == 'links' || entry.key == 'references') continue;
       if (entry.key == 'spanId' && entry.value is String) {
         final hex = _base64ToHex(entry.value as String);
         if (hex != null) out.add(hex);


### PR DESCRIPTION
## Description

Adds a small suite of dependency-free Dart tools under `tool/telemetry/` to
validate Faro telemetry against Grafana Cloud (Loki + Tempo) using the `gcx`
CLI. They make it repeatable to answer "does the data look right?" and "is only
X different vs `main`?" when reviewing telemetry-affecting changes.

- `verify_correlation.dart` — pulls a run's signals from Loki, extracts each
  `trace_id`/`span_id`, fetches the referenced traces from Tempo, and confirms
  the span exists. Exits non-zero on any dangling/partial correlation.
- `snapshot.dart` — captures a normalized telemetry "shape" for a run and diffs
  two snapshots (branch vs `main`) so only intended changes stand out. Generic:
  reusable for any future metadata change (e.g. adding a battery-state field).
- `list_signals.dart` — lists all signals for a run/session chronologically,
  as a table or JSON (with full `structuredMetadata`).

Shared helpers live in `common.dart`. `tool/telemetry/README.md` documents the
inputs, preflight checks, usage, and gotchas; `AGENTS.md` links to it.

## Related Issue(s)

N/A

## Type of Change

- [x] Chore (developer tooling / docs; no runtime library changes)

## Checklist

- [x] Docs updated (`tool/telemetry/README.md`, `AGENTS.md`)
- [x] `flutter analyze` passes for `tool/`
- [x] No changes to `lib/` runtime code
- [ ] CHANGELOG — N/A (dev tooling, not shipped in the package)

## Additional Notes

- Tooling only; nothing under `tool/` ships in the published package.
- Requires the `gcx` CLI on PATH. Examples use `<ctx>` / `<app-id>` /
  `<qa_run_id>` placeholders — no internal stacks, app ids, or credentials.

Made with [Cursor](https://cursor.com)