### PR TITLE
fix: forward Android native crash traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Forward Android native crash and ANR traces from `ApplicationExitInfo` into
+  the Faro exception context instead of always reporting `No stacktrace`.
+
 ## [0.17.0-beta.2] - 2026-07-16
 
 ### Added

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -855,51 +855,56 @@ class Faro {
       if (Platform.isAndroid) {
         final crashReports = await _nativeChannel?.getCrashReport();
         if (crashReports != null) {
-          for (final crashInfo in crashReports) {
-            final crashInfoJson = json.decode(crashInfo);
-            final String reason = crashInfoJson['reason'];
-            final int status = crashInfoJson['status'];
-            // String description = crashInfoJson["description"];
-            // description/stacktrace fails to send format and sanitize before push
-
-            // Convert crashInfoJson from Map<String, dynamic> to Map<String, String>
-            final stringifiedContext = <String, String>{};
-            crashInfoJson.forEach((String key, dynamic value) {
-              stringifiedContext[key] = value?.toString() ?? '';
-            });
-
-            final description =
-                stringifiedContext['description'] ?? 'No description';
-            final stacktrace =
-                stringifiedContext['stacktrace'] ?? 'No stacktrace';
-            final timestamp = stringifiedContext['timestamp'] ?? 'No timestamp';
-            final humanReadableTimestamp = timestamp.toHumanReadableTimestamp();
-
-            final importance =
-                stringifiedContext['importance'] ?? 'No importance';
-            final processName =
-                stringifiedContext['processName'] ?? 'No processName';
-
-            _instance.pushError(
-              type: 'crash',
-              value: '$reason , status: $status',
-              fatal: true,
-              context: {
-                'description': description,
-                'stacktrace': stacktrace,
-                'timestamp': timestamp,
-                'timestamp_readable_utc': humanReadableTimestamp,
-                'importance': importance,
-                'processName': processName,
-              },
-            );
-          }
+          _reportAndroidCrashReports(crashReports);
         }
       }
     } catch (error, stacktrace) {
       log(
         'Faro: enableCrashReporter failed with error: $error',
         stackTrace: stacktrace,
+      );
+    }
+  }
+
+  @visibleForTesting
+  void reportAndroidCrashesForTesting(List<String> crashReports) {
+    _reportAndroidCrashReports(crashReports);
+  }
+
+  void _reportAndroidCrashReports(List<String> crashReports) {
+    for (final crashInfo in crashReports) {
+      final crashInfoJson = json.decode(crashInfo);
+      final String reason = crashInfoJson['reason'];
+      final int status = crashInfoJson['status'];
+
+      final stringifiedContext = <String, String>{};
+      crashInfoJson.forEach((String key, dynamic value) {
+        stringifiedContext[key] = value?.toString() ?? '';
+      });
+
+      final description = stringifiedContext['description'] ?? 'No description';
+      final stacktrace =
+          stringifiedContext['trace'] ??
+          stringifiedContext['stacktrace'] ??
+          'No stacktrace';
+      final timestamp = stringifiedContext['timestamp'] ?? 'No timestamp';
+      final humanReadableTimestamp = timestamp.toHumanReadableTimestamp();
+
+      final importance = stringifiedContext['importance'] ?? 'No importance';
+      final processName = stringifiedContext['processName'] ?? 'No processName';
+
+      _instance.pushError(
+        type: 'crash',
+        value: '$reason , status: $status',
+        fatal: true,
+        context: {
+          'description': description,
+          'stacktrace': stacktrace,
+          'timestamp': timestamp,
+          'timestamp_readable_utc': humanReadableTimestamp,
+          'importance': importance,
+          'processName': processName,
+        },
       );
     }
   }

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/configurations/batch_config.dart';
 import 'package:faro/src/configurations/faro_config.dart';
@@ -354,6 +356,74 @@ void main() {
               ).captured.single
               as FaroException;
       expect(capturedException.fatal, isTrue);
+    });
+
+    test('native Android crash forwards the captured trace', () {
+      const nativeTrace = '''
+java.lang.NullPointerException: test crash
+    at com.example.MainActivity.crash(MainActivity.kt:42)
+''';
+      final crashReport = json.encode({
+        'reason': 'CRASH',
+        'status': 0,
+        'description': 'Native crash',
+        'trace': nativeTrace,
+        'timestamp': '1749080960296',
+        'importance': 100,
+        'processName': 'com.example.app',
+      });
+
+      Faro().reportAndroidCrashesForTesting([crashReport]);
+
+      final capturedException =
+          verify(
+                () => mockBatchTransport.addExceptions(captureAny()),
+              ).captured.single
+              as FaroException;
+      expect(capturedException.fatal, isTrue);
+      expect(capturedException.context?['stacktrace'], nativeTrace);
+    });
+
+    test('native Android crash accepts the legacy stacktrace key', () {
+      const nativeTrace = 'legacy native trace';
+      final crashReport = json.encode({
+        'reason': 'CRASH',
+        'status': 0,
+        'description': 'Native crash',
+        'stacktrace': nativeTrace,
+        'timestamp': '1749080960296',
+        'importance': 100,
+        'processName': 'com.example.app',
+      });
+
+      Faro().reportAndroidCrashesForTesting([crashReport]);
+
+      final capturedException =
+          verify(
+                () => mockBatchTransport.addExceptions(captureAny()),
+              ).captured.single
+              as FaroException;
+      expect(capturedException.context?['stacktrace'], nativeTrace);
+    });
+
+    test('native Android crash keeps the missing trace fallback', () {
+      final crashReport = json.encode({
+        'reason': 'CRASH',
+        'status': 0,
+        'description': 'Native crash',
+        'timestamp': '1749080960296',
+        'importance': 100,
+        'processName': 'com.example.app',
+      });
+
+      Faro().reportAndroidCrashesForTesting([crashReport]);
+
+      final capturedException =
+          verify(
+                () => mockBatchTransport.addExceptions(captureAny()),
+              ).captured.single
+              as FaroException;
+      expect(capturedException.context?['stacktrace'], 'No stacktrace');
     });
 
     test('send custom measurement', () {


### PR DESCRIPTION
Android sends native crash traces as `trace`, but the Dart side was looking for
`stacktrace`, so the report always fell back to `No stacktrace`.

This forwards the captured trace into the Faro exception context while keeping
compatibility with the older `stacktrace` key and the existing fallback.

Fixes #219.
