### PR TITLE
feat(session): react to receiver session invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Rotate the active session when the Grafana Cloud receiver accepts a payload
+  with `X-Faro-Session-Status: invalid`, matching the Faro Web SDK. Duplicate
+  or delayed invalidation responses for an older session are ignored.
+  ([#286](https://github.com/grafana/faro-flutter-sdk/issues/286))
 - **Automatic log-trace correlation**: Logs, events, exceptions, and
   measurements pushed via `pushLog`, `pushEvent`, `pushError`, and
   `pushMeasurement` while a span is active are now automatically stamped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Rotate the active session when the Grafana Cloud receiver accepts a payload
-  with `X-Faro-Session-Status: invalid`, matching the Faro Web SDK. Duplicate
-  or delayed invalidation responses for an older session are ignored.
+  with `X-Faro-Session-Status: invalid`, following the Faro Web SDK response
+  handling. Duplicate or delayed responses for an older session are ignored.
   ([#286](https://github.com/grafana/faro-flutter-sdk/issues/286))
 - **Automatic log-trace correlation**: Logs, events, exceptions, and
   measurements pushed via `pushLog`, `pushEvent`, `pushError`, and

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -306,8 +306,10 @@ Faro tracks a session id that groups all telemetry from a single period of use. 
 - **Inactivity**: no app/user activity for 15 minutes, or
 - **Max lifetime**: the session has been alive for 4 hours.
 
-These thresholds are fixed and not configurable so they stay aligned with the
-same windows enforced by the Grafana Cloud Faro receiver.
+These thresholds are fixed and not configurable: the Grafana Cloud Faro
+receiver enforces the same windows server-side and drops telemetry from
+sessions that exceed them, so a longer client-side value would cause silent
+data loss.
 
 **Lifecycle events.** Faro emits an event whenever the session id changes, so you can follow the user journey in Grafana:
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -306,14 +306,15 @@ Faro tracks a session id that groups all telemetry from a single period of use. 
 - **Inactivity**: no app/user activity for 15 minutes, or
 - **Max lifetime**: the session has been alive for 4 hours.
 
-These thresholds are fixed and not configurable: the Grafana Cloud Faro receiver enforces the same windows server-side and drops telemetry from sessions that exceed them, so a longer client-side value would cause silent data loss.
+These thresholds are fixed and not configurable so they stay aligned with the
+same windows enforced by the Grafana Cloud Faro receiver.
 
 **Lifecycle events.** Faro emits an event whenever the session id changes, so you can follow the user journey in Grafana:
 
 | Event           | When                                                                                 |
 | --------------- | ------------------------------------------------------------------------------------ |
 | `session_start` | The initial session, emitted once when the SDK initializes                           |
-| `session_extend` | A rotation: a new session was auto-created because the inactivity or lifetime timeout was reached |
+| `session_extend` | A rotation: a new session was auto-created after local expiry or receiver invalidation |
 
 **Linking rotated sessions.** On rotation, the previous session id is recorded in the `previousSession` session attribute, so backends can link a rotated session back to its predecessor. Existing custom session attributes are preserved across rotation. All telemetry created after a rotation — events, logs, exceptions, and spans — automatically carries the new session id.
 
@@ -322,6 +323,12 @@ These thresholds are fixed and not configurable: the Grafana Cloud Faro receiver
 Automatic vitals measurements pushed by the SDK itself (CPU, memory, refresh rate, frame stats, ANR count, app start) count as activity **only while the app is in the foreground**. This keeps a single session for a foregrounded but idle app (e.g. a user reading a screen without tapping), while ensuring a backgrounded app's session still expires — the Dart isolate keeps running while backgrounded on Android, so if background vitals counted they would keep the session alive indefinitely.
 
 Session expiry is evaluated lazily on the next ingested telemetry item (there is no periodic rotation timer). The triggering telemetry is attributed to the new session.
+
+The Grafana Cloud receiver can also report that a submitted session has
+expired by returning `X-Faro-Session-Status: invalid` with its accepted
+response. Faro rotates that session immediately. Delayed or duplicate
+responses for an older session are ignored, so they cannot rotate the current
+session again.
 
 > **Sampling note:** the session sampling decision is made once at initialization and is **not** re-evaluated on rotation (see [Session Sampling](#session-sampling)).
 

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -232,6 +232,9 @@ class Faro {
     } else {
       Faro()._transports.addAll(config?.transports ?? []);
     }
+    for (final transport in _transports.whereType<FaroTransport>()) {
+      transport.sessionInvalidatedHandler = sessionManager.invalidateSession;
+    }
     _httpTrackingFilter.configure(
       collectorUrl: optionsConfiguration.collectorUrl,
       ignoreUrls: optionsConfiguration.ignoreUrls,

--- a/lib/src/session/session_manager.dart
+++ b/lib/src/session/session_manager.dart
@@ -10,7 +10,7 @@ enum SessionStartTrigger {
   /// The first session after the SDK started (via [SessionManager.start]).
   initial,
 
-  /// A rotation triggered by inactivity or maximum lifetime.
+  /// A rotation triggered by expiry or receiver invalidation.
   rotation,
 }
 
@@ -24,7 +24,8 @@ typedef SessionChangedListener =
       required SessionStartTrigger trigger,
     });
 
-/// Tracks session validity and rotates the session when it expires.
+/// Tracks session validity and rotates the session when it expires locally or
+/// the receiver reports it as invalid.
 ///
 /// A session expires when either:
 /// - no activity has been recorded for [inactivityTimeout]
@@ -126,6 +127,18 @@ class SessionManager {
     } else if (_activityPolicy.recordsActivity(activity)) {
       _lastActivityAt = now;
     }
+  }
+
+  /// Rotates a session that the receiver reported as invalid.
+  ///
+  /// [invalidSessionId] must still be the active session. This prevents
+  /// duplicate or delayed responses for an older session from rotating a
+  /// newer session again.
+  void invalidateSession(String invalidSessionId) {
+    if (!_isActive || _isRotating || invalidSessionId != currentSessionId) {
+      return;
+    }
+    _rotate(_currentTimeProvider());
   }
 
   /// Rotates the session and notifies listeners.

--- a/lib/src/transport/faro_transport.dart
+++ b/lib/src/transport/faro_transport.dart
@@ -27,6 +27,7 @@ class FaroTransport extends BaseTransport {
   }
 
   static const _accepted = 202;
+  static const _sessionIdHeader = 'x-faro-session-id';
   static const _sessionStatusHeader = 'x-faro-session-status';
   static const _invalidSessionStatus = 'invalid';
 
@@ -68,12 +69,10 @@ class FaroTransport extends BaseTransport {
       final headers = {
         'Content-Type': 'application/json',
         'x-api-key': apiKey,
-        'x-faro-session-id': _sessionIdResolver(),
+        _sessionIdHeader: _sessionIdResolver(),
         ...?this.headers,
       };
-      final sentSessionId = headers.entries
-          .lastWhere((entry) => entry.key.toLowerCase() == 'x-faro-session-id')
-          .value;
+      final sentSessionId = _headerValue(headers, _sessionIdHeader);
 
       final post = _httpClient?.post ?? http.post;
       final response = await _taskBuffer?.add(() {
@@ -92,22 +91,24 @@ class FaroTransport extends BaseTransport {
       }
 
       if (response != null &&
+          sentSessionId != null &&
           response.statusCode == _accepted &&
-          _responseHeader(response.headers, _sessionStatusHeader) ==
+          _headerValue(response.headers, _sessionStatusHeader) ==
               _invalidSessionStatus) {
         _onSessionInvalidated?.call(sentSessionId);
       }
     } catch (error) {
-      log('Error encoding payload: $error');
+      log('Error sending payload: $error');
     }
   }
 
-  static String? _responseHeader(Map<String, String> headers, String name) {
+  static String? _headerValue(Map<String, String> headers, String name) {
+    String? value;
     for (final entry in headers.entries) {
       if (entry.key.toLowerCase() == name) {
-        return entry.value;
+        value = entry.value;
       }
     }
-    return null;
+    return value;
   }
 }

--- a/lib/src/transport/faro_transport.dart
+++ b/lib/src/transport/faro_transport.dart
@@ -72,6 +72,8 @@ class FaroTransport extends BaseTransport {
         _sessionIdHeader: _sessionIdResolver(),
         ...?this.headers,
       };
+      // Capture the effective request value before awaiting the response.
+      // Custom headers may override the resolver value using different casing.
       final sentSessionId = _headerValue(headers, _sessionIdHeader);
 
       final post = _httpClient?.post ?? http.post;
@@ -95,6 +97,7 @@ class FaroTransport extends BaseTransport {
           response.statusCode == _accepted &&
           _headerValue(response.headers, _sessionStatusHeader) ==
               _invalidSessionStatus) {
+        log('Faro: Receiver reported the submitted session as invalid.');
         _onSessionInvalidated?.call(sentSessionId);
       }
     } catch (error) {
@@ -104,6 +107,8 @@ class FaroTransport extends BaseTransport {
 
   static String? _headerValue(Map<String, String> headers, String name) {
     String? value;
+    // Custom headers are merged last, so the last case-insensitive match is
+    // the effective value sent by the HTTP client.
     for (final entry in headers.entries) {
       if (entry.key.toLowerCase() == name) {
         value = entry.value;

--- a/lib/src/transport/faro_transport.dart
+++ b/lib/src/transport/faro_transport.dart
@@ -10,6 +10,9 @@ import 'package:http/http.dart' as http;
 /// Resolves the current session id to send in the `x-faro-session-id` header.
 typedef SessionIdResolver = String Function();
 
+/// Called when the receiver reports that a submitted session is invalid.
+typedef SessionInvalidatedHandler = void Function(String sessionId);
+
 class FaroTransport extends BaseTransport {
   FaroTransport({
     required this.collectorUrl,
@@ -22,6 +25,11 @@ class FaroTransport extends BaseTransport {
        _httpClient = httpClient {
     _taskBuffer = TaskBuffer(maxBufferLimit ?? 30);
   }
+
+  static const _accepted = 202;
+  static const _sessionStatusHeader = 'x-faro-session-status';
+  static const _invalidSessionStatus = 'invalid';
+
   final String collectorUrl;
   final String apiKey;
 
@@ -34,12 +42,18 @@ class FaroTransport extends BaseTransport {
   /// active session even when a rotation happened after this transport was
   /// created, or when an older cached payload is replayed offline.
   final SessionIdResolver _sessionIdResolver;
+  SessionInvalidatedHandler? _onSessionInvalidated;
   TaskBuffer<dynamic>? _taskBuffer;
   final Map<String, String>? headers;
 
   /// Optional HTTP client seam for tests. When null, the top-level
   /// [http.post] is used so production behavior is unchanged.
   final http.Client? _httpClient;
+
+  /// Connects receiver invalidation responses to the SDK session manager.
+  set sessionInvalidatedHandler(SessionInvalidatedHandler handler) {
+    _onSessionInvalidated = handler;
+  }
 
   @override
   Future<void> send(Map<String, dynamic> payloadJson) async {
@@ -57,6 +71,9 @@ class FaroTransport extends BaseTransport {
         'x-faro-session-id': _sessionIdResolver(),
         ...?this.headers,
       };
+      final sentSessionId = headers.entries
+          .lastWhere((entry) => entry.key.toLowerCase() == 'x-faro-session-id')
+          .value;
 
       final post = _httpClient?.post ?? http.post;
       final response = await _taskBuffer?.add(() {
@@ -73,8 +90,24 @@ class FaroTransport extends BaseTransport {
           'body: ${response.body} payload:$encodedPayload',
         );
       }
+
+      if (response != null &&
+          response.statusCode == _accepted &&
+          _responseHeader(response.headers, _sessionStatusHeader) ==
+              _invalidSessionStatus) {
+        _onSessionInvalidated?.call(sentSessionId);
+      }
     } catch (error) {
       log('Error encoding payload: $error');
     }
+  }
+
+  static String? _responseHeader(Map<String, String> headers, String name) {
+    for (final entry in headers.entries) {
+      if (entry.key.toLowerCase() == name) {
+        return entry.value;
+      }
+    }
+    return null;
   }
 }

--- a/test/src/session/session_manager_test.dart
+++ b/test/src/session/session_manager_test.dart
@@ -179,6 +179,45 @@ void main() {
       expect(observer.startedCount, 0);
     });
 
+    test('rotates when the receiver invalidates the active session', () {
+      final manager = createManager();
+      final initialId = manager.currentSessionId;
+      now = now.add(const Duration(minutes: 1));
+
+      manager.invalidateSession(initialId);
+
+      expect(manager.currentSessionId, isNot(initialId));
+      expect(manager.previousSessionId, initialId);
+      expect(manager.startedAt, now);
+      expect(manager.lastActivityAt, now);
+      expect(observer.startedCount, 1);
+      expect(observer.lastTrigger, SessionStartTrigger.rotation);
+    });
+
+    test('ignores duplicate invalidation for a previous session', () {
+      final manager = createManager();
+      final initialId = manager.currentSessionId;
+
+      manager.invalidateSession(initialId);
+      final rotatedId = manager.currentSessionId;
+      observer.reset();
+
+      manager.invalidateSession(initialId);
+
+      expect(manager.currentSessionId, rotatedId);
+      expect(observer.startedCount, 0);
+    });
+
+    test('ignores invalidation before session tracking starts', () {
+      final manager = buildManager();
+      final initialId = manager.currentSessionId;
+
+      manager.invalidateSession(initialId);
+
+      expect(manager.currentSessionId, initialId);
+      expect(observer.startedCount, 0);
+    });
+
     test('records activity to keep the session alive', () {
       final manager = createManager();
 

--- a/test/src/session/session_rotation_integration_test.dart
+++ b/test/src/session/session_rotation_integration_test.dart
@@ -15,6 +15,8 @@ import 'package:faro/src/user_actions/telemetry_router.dart';
 import 'package:faro/src/user_actions/user_action_types.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -237,6 +239,66 @@ void main() {
         ),
       ]);
     });
+
+    test(
+      'rotates the session when a configured transport reports it invalid',
+      () async {
+        final client = MockClient((request) async {
+          return http.Response(
+            '',
+            202,
+            headers: {'X-Faro-Session-Status': 'invalid'},
+          );
+        });
+        final transport = FaroTransport(
+          collectorUrl: 'https://some-url.com',
+          apiKey: apiKey,
+          sessionIdResolver: () => Faro().meta.session!.id!,
+          httpClient: client,
+        );
+        final config = FaroConfig(
+          appName: appName,
+          appVersion: appVersion,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+          transports: [transport],
+        );
+
+        await Faro().init(optionsConfiguration: config);
+        final initialSessionId = Faro().meta.session!.id;
+        clearInteractions(mockBatchTransport);
+
+        await transport.send({
+          'meta': Faro().meta.toJson(),
+          'events': <dynamic>[],
+        });
+
+        final session = Faro().meta.session!;
+        expect(session.id, isNot(initialSessionId));
+        expect(session.attributes?['previousSession'], initialSessionId);
+        verifyInOrder([
+          () => mockBatchTransport.updatePayloadMeta(
+            any(
+              that: isA<Meta>().having(
+                (meta) => meta.session?.id,
+                'session.id',
+                session.id,
+              ),
+            ),
+          ),
+          () => mockBatchTransport.addEvent(
+            any(
+              that: isA<Event>().having(
+                (event) => event.name,
+                'name',
+                'session_extend',
+              ),
+            ),
+          ),
+        ]);
+      },
+    );
 
     test('preserves session attributes across rotation', () async {
       await initFaro();

--- a/test/src/transport/faro_transport_test.dart
+++ b/test/src/transport/faro_transport_test.dart
@@ -29,15 +29,20 @@ void main() {
 
     FaroTransport buildTransport({
       SessionIdResolver? sessionIdResolver,
+      SessionInvalidatedHandler? onSessionInvalidated,
       Map<String, String>? headers,
     }) {
-      return FaroTransport(
+      final transport = FaroTransport(
         collectorUrl: 'https://collector.example/collect',
         apiKey: 'test-key',
         sessionIdResolver: sessionIdResolver ?? () => 'session-id',
         headers: headers,
         httpClient: client,
       );
+      if (onSessionInvalidated != null) {
+        transport.sessionInvalidatedHandler = onSessionInvalidated;
+      }
+      return transport;
     }
 
     Map<String, dynamic> payload() => {
@@ -94,6 +99,120 @@ void main() {
           'session-1',
           'session-2',
         ]);
+      });
+    });
+
+    group('session invalidation response:', () {
+      test('reports an invalid session from an accepted response', () async {
+        client = MockClient((request) async {
+          captured.add(request);
+          return http.Response(
+            '',
+            202,
+            headers: {'X-Faro-Session-Status': 'invalid'},
+          );
+        });
+        final invalidatedSessionIds = <String>[];
+
+        await buildTransport(
+          sessionIdResolver: () => 'session-1',
+          onSessionInvalidated: invalidatedSessionIds.add,
+        ).send(payload());
+
+        expect(invalidatedSessionIds, ['session-1']);
+      });
+
+      test('reports the session id used by the request', () async {
+        var currentSessionId = 'session-1';
+        client = MockClient((request) async {
+          captured.add(request);
+          currentSessionId = 'session-2';
+          return http.Response(
+            '',
+            202,
+            headers: {'x-faro-session-status': 'invalid'},
+          );
+        });
+        final invalidatedSessionIds = <String>[];
+
+        await buildTransport(
+          sessionIdResolver: () => currentSessionId,
+          onSessionInvalidated: invalidatedSessionIds.add,
+        ).send(payload());
+
+        expect(captured.single.headers['x-faro-session-id'], 'session-1');
+        expect(invalidatedSessionIds, ['session-1']);
+      });
+
+      test('reports an overridden request session id', () async {
+        client = MockClient((request) async {
+          captured.add(request);
+          return http.Response(
+            '',
+            202,
+            headers: {'X-Faro-Session-Status': 'invalid'},
+          );
+        });
+        final invalidatedSessionIds = <String>[];
+
+        await buildTransport(
+          sessionIdResolver: () => 'resolver-session',
+          headers: {'X-Faro-Session-Id': 'header-session'},
+          onSessionInvalidated: invalidatedSessionIds.add,
+        ).send(payload());
+
+        expect(captured.single.headers['x-faro-session-id'], 'header-session');
+        expect(invalidatedSessionIds, ['header-session']);
+      });
+
+      test('ignores the header on a non-accepted response', () async {
+        client = MockClient((request) async {
+          captured.add(request);
+          return http.Response(
+            '',
+            200,
+            headers: {'X-Faro-Session-Status': 'invalid'},
+          );
+        });
+        final invalidatedSessionIds = <String>[];
+
+        await buildTransport(
+          onSessionInvalidated: invalidatedSessionIds.add,
+        ).send(payload());
+
+        expect(invalidatedSessionIds, isEmpty);
+      });
+
+      test('ignores accepted responses without an invalid status', () async {
+        client = MockClient((request) async {
+          captured.add(request);
+          return http.Response(
+            '',
+            202,
+            headers: {'X-Faro-Session-Status': 'valid'},
+          );
+        });
+        final invalidatedSessionIds = <String>[];
+
+        await buildTransport(
+          onSessionInvalidated: invalidatedSessionIds.add,
+        ).send(payload());
+
+        expect(invalidatedSessionIds, isEmpty);
+      });
+
+      test('ignores accepted responses without the status header', () async {
+        client = MockClient((request) async {
+          captured.add(request);
+          return http.Response('', 202);
+        });
+        final invalidatedSessionIds = <String>[];
+
+        await buildTransport(
+          onSessionInvalidated: invalidatedSessionIds.add,
+        ).send(payload());
+
+        expect(invalidatedSessionIds, isEmpty);
       });
     });
 


### PR DESCRIPTION
## Description

The receiver can accept a payload while marking its session invalid. Flutter previously ignored that response, so it could keep using a session the receiver had already expired.

This reads `X-Faro-Session-Status: invalid` from accepted responses and rotates the matching active session. Delayed or duplicate responses for an older session are ignored.

## Related Issue(s)

Fixes #286

## Type of Change

- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Screenshots (if applicable)

Not applicable; this changes transport and session behavior without UI changes.

## Additional Notes

Validated with `dart tool/pre_release_check.dart`, the example analyzer, and a release APK build.