### PR TITLE
chore(renovate): group bumps and align npm release age with org default

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
   "separateMultipleMajor": true,
   "prHourlyLimit": 2,
   "prConcurrentLimit": 10,
+  "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,13 @@
       "groupName": "gradle"
     },
     {
-      "description": "Collect patch-only bumps from every manager into a single low-risk PR, matching faro-web-sdk. Placed after the manager groups so it overrides them: a Gradle or Kotlin patch rides here rather than in the gradle group. Fires only when a dependency's sole pending update is a patch.",
+      "description": "Keep the Flutter SDK pin atomic — setup-flutter fails if .fvmrc and .tool-versions disagree.",
+      "matchManagers": ["fvm", "asdf", "mise"],
+      "groupName": "flutter-sdk"
+    },
+    {
+      "description": "Collect patch-only bumps from the grouped managers into one low-risk PR, matching faro-web-sdk. Scoped to those managers so Flutter SDK pin bumps stay standalone; pub and swift only ever emit majors.",
+      "matchManagers": ["github-actions", "npm", "gradle", "gradle-wrapper"],
       "matchUpdateTypes": ["patch"],
       "groupName": "patch updates"
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 5am on Monday", "before 5am on Wednesday", "before 5am on Friday"],
+  "semanticCommits": "enabled",
+  "separateMajorMinor": true,
+  "separateMultipleMajor": true,
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 10,
+  "internalChecksFilter": "strict",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions bumps into a single PR. These are SHA pins across four workflows; reviewing them one-by-one costs a rebase + CI cycle each because main requires up-to-date branches.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Group the example/webview_demo JS toolchain into a single PR. Nothing installs or builds this app in CI (it only appears in osv-scanner.yml as a lockfile path), so per-package PRs buy no extra signal.",
+      "matchManagers": ["npm"],
+      "groupName": "npm-dependencies"
+    },
+    {
+      "description": "Keep Gradle/Kotlin toolchain bumps ungrouped. These are the only dependencies here with real CI coverage (build-example-app and :faro:testDebugUnitTest), so they are worth individual review and individual revertability.",
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "groupName": null
+    },
+    {
+      "description": "Renovate cannot resolve this plugin marker on the maven datasource (no-result), which stamps a 'Package lookup failures' WARN onto every PR body in this repo. It is supplied by the Flutter SDK itself and is not independently upgradable.",
+      "matchPackageNames": [
+        "dev.flutter.flutter-plugin-loader:dev.flutter.flutter-plugin-loader.gradle.plugin"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Enforce the org-default 3-day release-age cooldown on ALL npm depTypes (incl @grafana/*, which the injected Grafana org preset exempts) to match yarn's npmMinimalAgeGate in example/webview_demo/.yarnrc.yml. Placed last so it overrides that preset. Without this, Renovate proposes @grafana/faro-web-sdk versions younger than the gate that yarn then refuses to lock, producing PRs whose renovate/artifacts check fails and whose package.json drifts from yarn.lock. Keep this value in sync with that .yarnrc.yml.",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,9 +25,9 @@
       "groupName": "npm-dependencies"
     },
     {
-      "description": "Keep Gradle/Kotlin toolchain bumps ungrouped. These are the only dependencies here with real CI coverage (build-example-app and :faro:testDebugUnitTest), so they are worth individual review and individual revertability.",
+      "description": "Group Gradle/Kotlin toolchain bumps for the example app into a single PR. These are the only dependencies here with real CI coverage (build-example-app and :faro:testDebugUnitTest), so a grouped failure still points at a small and related set.",
       "matchManagers": ["gradle", "gradle-wrapper"],
-      "groupName": null
+      "groupName": "gradle"
     },
     {
       "description": "Renovate cannot resolve this plugin marker on the maven datasource (no-result), which stamps a 'Package lookup failures' WARN onto every PR body in this repo. It is supplied by the Flutter SDK itself and is not independently upgradable.",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,11 @@
       "groupName": "gradle"
     },
     {
+      "description": "Collect patch-only bumps from every manager into a single low-risk PR, matching faro-web-sdk. Placed after the manager groups so it overrides them: a Gradle or Kotlin patch rides here rather than in the gradle group. Fires only when a dependency's sole pending update is a patch.",
+      "matchUpdateTypes": ["patch"],
+      "groupName": "patch updates"
+    },
+    {
       "description": "Renovate cannot resolve this plugin marker on the maven datasource (no-result), which stamps a 'Package lookup failures' WARN onto every PR body in this repo. It is supplied by the Flutter SDK itself and is not independently upgradable.",
       "matchPackageNames": [
         "dev.flutter.flutter-plugin-loader:dev.flutter.flutter-plugin-loader.gradle.plugin"

--- a/example/webview_demo/.yarnrc.yml
+++ b/example/webview_demo/.yarnrc.yml
@@ -6,4 +6,4 @@ enableScripts: false
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 7d
+npmMinimalAgeGate: 3d


### PR DESCRIPTION
First Renovate config for this repo (previously org defaults only).

## Summary

- `.github/renovate.json` — groups bumps by manager (`github-actions`, `npm-dependencies`, `gradle`) plus a shared `patch updates` lane, and disables the `dev.flutter.flutter-plugin-loader` marker that Renovate cannot resolve and that warns on every PR body.
- `example/webview_demo/.yarnrc.yml` — `npmMinimalAgeGate` 7d → 3d to match the org-default Renovate `minimumReleaseAge`; that mismatch is why #291 fails `renovate/artifacts`. Shortens the quarantine window set in #260.

Turns today's 11 bump PRs into ~5. Validated with `renovate-config-validator`.

_PR description authored by Claude on Domas's behalf._