### PR TITLE
fix(android): filter background low-memory exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Filter Android `LOW_MEMORY` exits for service and less important process
+  states regardless of whether Android records status `0` or `SIGKILL`.
+  Foreground, foreground-service, visible, and perceptible exits remain
+  reportable ([#307](https://github.com/grafana/faro-flutter-sdk/issues/307)).
 - Report Flutter framework errors even when no stack trace is available
   ([#271](https://github.com/grafana/faro-flutter-sdk/issues/271)).
 - HTTP network-error fallback logs are now correlated with their request

--- a/android/src/main/java/com/grafana/faro/ApplicationExitInfoExt.java
+++ b/android/src/main/java/com/grafana/faro/ApplicationExitInfoExt.java
@@ -1,5 +1,6 @@
 package com.grafana.faro;
 
+import android.app.ActivityManager;
 import android.app.ApplicationExitInfo;
 import android.os.Build;
 import android.util.Log;
@@ -120,20 +121,29 @@ public class ApplicationExitInfoExt {
     @RequiresApi(api = Build.VERSION_CODES.R)
     public static boolean shouldBeFilteredOut(@NonNull ApplicationExitInfo exitInfo) {
         try {
-            // Status code 0 (normal exit) + importance > 300 (background)
-            boolean isBackgroundNormalExit = exitInfo.getStatus() == 0 && exitInfo.getImportance() > 300;
-            
-            // Filter out LOW_MEMORY and EXCESSIVE_RESOURCE_USAGE for backgroundNormalExits
-            if (isBackgroundNormalExit) {
-                int reason = exitInfo.getReason();
-                return reason == ApplicationExitInfo.REASON_LOW_MEMORY || 
-                       reason == ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE;
-            }
-            
-            return false;
+            return shouldBeFilteredOut(
+                    exitInfo.getReason(),
+                    exitInfo.getStatus(),
+                    exitInfo.getImportance());
         } catch (Exception e) {
             Log.e(TAG, "Error checking if exit info should be filtered out", e);
             return false; // When in doubt, don't filter out
         }
+    }
+
+    static boolean shouldBeFilteredOut(int reason, int status, int importance) {
+        if (reason == ApplicationExitInfo.REASON_LOW_MEMORY) {
+            // LMKD and zygote update exit records independently, so Android can
+            // expose the same low-memory kill with status 0 or SIGKILL.
+            return importance >= ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE;
+        }
+
+        // Status code 0 (normal exit) + importance > 300 (background)
+        boolean isBackgroundNormalExit = status == 0
+                && importance > ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE;
+
+        // Preserve the existing filtering behavior for excessive resource usage.
+        return isBackgroundNormalExit
+                && reason == ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE;
     }
 }

--- a/android/src/test/java/com/grafana/faro/ApplicationExitInfoExtTest.java
+++ b/android/src/test/java/com/grafana/faro/ApplicationExitInfoExtTest.java
@@ -1,0 +1,65 @@
+package com.grafana.faro;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.app.ActivityManager;
+import android.app.ApplicationExitInfo;
+
+import org.junit.Test;
+
+public class ApplicationExitInfoExtTest {
+    private static final int SIGKILL = 9;
+
+    @Test
+    public void lowMemory_serviceExitIsFiltered() {
+        assertTrue(ApplicationExitInfoExt.shouldBeFilteredOut(
+                ApplicationExitInfo.REASON_LOW_MEMORY,
+                0,
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE));
+    }
+
+    @Test
+    public void lowMemory_cachedSigkillIsFiltered() {
+        assertTrue(ApplicationExitInfoExt.shouldBeFilteredOut(
+                ApplicationExitInfo.REASON_LOW_MEMORY,
+                SIGKILL,
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED));
+    }
+
+    @Test
+    public void lowMemory_foregroundServiceExitIsReported() {
+        assertFalse(ApplicationExitInfoExt.shouldBeFilteredOut(
+                ApplicationExitInfo.REASON_LOW_MEMORY,
+                0,
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE));
+    }
+
+    @Test
+    public void lowMemory_perceptibleExitIsReported() {
+        assertFalse(ApplicationExitInfoExt.shouldBeFilteredOut(
+                ApplicationExitInfo.REASON_LOW_MEMORY,
+                0,
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE));
+    }
+
+    @Test
+    public void excessiveResourceUsageFilteringRemainsUnchanged() {
+        assertTrue(ApplicationExitInfoExt.shouldBeFilteredOut(
+                ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE,
+                0,
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED));
+        assertFalse(ApplicationExitInfoExt.shouldBeFilteredOut(
+                ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE,
+                SIGKILL,
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED));
+    }
+
+    @Test
+    public void crashIsNotFiltered() {
+        assertFalse(ApplicationExitInfoExt.shouldBeFilteredOut(
+                ApplicationExitInfo.REASON_CRASH,
+                0,
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED));
+    }
+}

--- a/android/src/test/java/com/grafana/faro/ApplicationExitInfoExtTest.java
+++ b/android/src/test/java/com/grafana/faro/ApplicationExitInfoExtTest.java
@@ -45,6 +45,10 @@ public class ApplicationExitInfoExtTest {
 
     @Test
     public void excessiveResourceUsageFilteringRemainsUnchanged() {
+        assertFalse(ApplicationExitInfoExt.shouldBeFilteredOut(
+                ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE,
+                0,
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE));
         assertTrue(ApplicationExitInfoExt.shouldBeFilteredOut(
                 ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE,
                 0,

--- a/doc/error-categorization.md
+++ b/doc/error-categorization.md
@@ -80,6 +80,10 @@ Notes:
   exits) are detected and reported on the **next launch**. The Android
   runtime **ANR watchdog** is different: it detects a blocked main thread
   **while the app is running** and reports within the same session.
+- Android low-memory exits from service and less important process states are
+  filtered because they are normal system reclamation rather than user-facing
+  crashes. Foreground, foreground-service, visible, and perceptible low-memory
+  exits remain reportable.
 
 ---
 


### PR DESCRIPTION
## Description

Android can record normal low-memory process reclamation with status `0` or `SIGKILL`. The current filter only handles status `0`, so service and cached exits can be reported as crashes.

This uses process importance for `LOW_MEMORY` exits instead. User-facing states remain reportable, and `EXCESSIVE_RESOURCE_USAGE` behavior is unchanged.

## Related Issue(s)

Fixes #307

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Validated with Android unit tests, 748 Flutter tests, `flutter analyze`, and an example Android APK build.

`IMPORTANCE_PERCEPTIBLE` (`230`) remains reportable because Android defines it as work the user is aware of. Filtering starts at `IMPORTANCE_SERVICE` (`300`).