### PR TITLE
fix: preserve view metadata for unnamed routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   states regardless of whether Android records status `0` or `SIGKILL`.
   Foreground, foreground-service, visible, and perceptible exits remain
   reportable ([#307](https://github.com/grafana/faro-flutter-sdk/issues/307)).
+- Preserve the last known view metadata when navigating through unnamed
+  Flutter routes, and suppress empty `view_changed` events.
+  ([#305](https://github.com/grafana/faro-flutter-sdk/issues/305))
 - Report Flutter framework errors even when no stack trace is available
   ([#271](https://github.com/grafana/faro-flutter-sdk/issues/271)).
 - HTTP network-error fallback logs are now correlated with their request

--- a/lib/src/faro_navigation_observer.dart
+++ b/lib/src/faro_navigation_observer.dart
@@ -1,5 +1,7 @@
 import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/faro.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/session/session_manager.dart';
 import 'package:faro/src/user_actions/user_action_lifecycle_signal_channel.dart';
 import 'package:flutter/widgets.dart';
 
@@ -9,14 +11,18 @@ class FaroNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
       lifecycleSignalChannel: pod.resolve(
         userActionLifecycleSignalChannelProvider,
       ),
+      sessionManager: pod.resolve(sessionManagerProvider),
     );
   }
 
   FaroNavigationObserver._({
     required UserActionLifecycleSignalChannel lifecycleSignalChannel,
-  }) : _lifecycleSignalChannel = lifecycleSignalChannel;
+    required SessionManager sessionManager,
+  }) : _lifecycleSignalChannel = lifecycleSignalChannel,
+       _sessionManager = sessionManager;
 
   final UserActionLifecycleSignalChannel _lifecycleSignalChannel;
+  final SessionManager _sessionManager;
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
@@ -61,6 +67,8 @@ class FaroNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
         'view_changed',
         attributes: {'fromView': fromView, 'toView': toView},
       );
+    } else {
+      _sessionManager.checkSession(activity: SessionActivityKind.active);
     }
     _lifecycleSignalChannel.emitActivity(source: activitySource);
   }

--- a/lib/src/faro_navigation_observer.dart
+++ b/lib/src/faro_navigation_observer.dart
@@ -21,42 +21,47 @@ class FaroNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
-    Faro().setViewMeta(name: previousRoute?.settings.name);
-    Faro().pushEvent(
-      'view_changed',
-      attributes: {
-        'fromView': route.settings.name,
-        'toView': previousRoute?.settings.name,
-      },
+    _recordNavigation(
+      fromView: route.settings.name,
+      toView: previousRoute?.settings.name,
+      activitySource: 'navigation.pop',
     );
-    _lifecycleSignalChannel.emitActivity(source: 'navigation.pop');
   }
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
-    Faro().setViewMeta(name: route.settings.name);
-    Faro().pushEvent(
-      'view_changed',
-      attributes: {
-        'fromView': previousRoute?.settings.name,
-        'toView': route.settings.name,
-      },
+    _recordNavigation(
+      fromView: previousRoute?.settings.name,
+      toView: route.settings.name,
+      activitySource: 'navigation.push',
     );
-    _lifecycleSignalChannel.emitActivity(source: 'navigation.push');
   }
 
   @override
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-    Faro().setViewMeta(name: newRoute?.settings.name);
-    Faro().pushEvent(
-      'view_changed',
-      attributes: {
-        'fromView': oldRoute?.settings.name,
-        'toView': newRoute?.settings.name,
-      },
+    _recordNavigation(
+      fromView: oldRoute?.settings.name,
+      toView: newRoute?.settings.name,
+      activitySource: 'navigation.replace',
     );
-    _lifecycleSignalChannel.emitActivity(source: 'navigation.replace');
+  }
+
+  void _recordNavigation({
+    required String? fromView,
+    required String? toView,
+    required String activitySource,
+  }) {
+    if (toView != null) {
+      Faro().setViewMeta(name: toView);
+    }
+    if (fromView != null || toView != null) {
+      Faro().pushEvent(
+        'view_changed',
+        attributes: {'fromView': fromView, 'toView': toView},
+      );
+    }
+    _lifecycleSignalChannel.emitActivity(source: activitySource);
   }
 }

--- a/test/src/faro_navigation_observer_test.dart
+++ b/test/src/faro_navigation_observer_test.dart
@@ -1,0 +1,91 @@
+import 'package:faro/src/faro.dart';
+import 'package:faro/src/faro_navigation_observer.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockFaro extends Mock implements Faro {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockFaro mockFaro;
+  late FaroNavigationObserver observer;
+
+  PageRoute<void> route([String? name]) {
+    return PageRouteBuilder<void>(
+      settings: RouteSettings(name: name),
+      pageBuilder: (_, _, _) => const SizedBox.shrink(),
+    );
+  }
+
+  setUp(() {
+    mockFaro = MockFaro();
+    Faro.instance = mockFaro;
+    observer = FaroNavigationObserver();
+
+    when(() => mockFaro.setViewMeta(name: any(named: 'name'))).thenReturn(null);
+    when(
+      () => mockFaro.pushEvent(any(), attributes: any(named: 'attributes')),
+    ).thenReturn(null);
+  });
+
+  group('FaroNavigationObserver', () {
+    test('preserves the current view when pushing an unnamed route', () {
+      observer.didPush(route(), route('/home'));
+
+      verifyNever(() => mockFaro.setViewMeta(name: any(named: 'name')));
+      verify(
+        () => mockFaro.pushEvent(
+          'view_changed',
+          attributes: {'fromView': '/home', 'toView': null},
+        ),
+      ).called(1);
+    });
+
+    test('sets the previous named view when popping', () {
+      observer.didPop(route(), route('/home'));
+
+      verify(() => mockFaro.setViewMeta(name: '/home')).called(1);
+      verify(
+        () => mockFaro.pushEvent(
+          'view_changed',
+          attributes: {'fromView': null, 'toView': '/home'},
+        ),
+      ).called(1);
+    });
+
+    test('preserves the current view when popping to an unnamed route', () {
+      observer.didPop(route('/details'), route());
+
+      verifyNever(() => mockFaro.setViewMeta(name: any(named: 'name')));
+      verify(
+        () => mockFaro.pushEvent(
+          'view_changed',
+          attributes: {'fromView': '/details', 'toView': null},
+        ),
+      ).called(1);
+    });
+
+    test('preserves the current view when replacing with an unnamed route', () {
+      observer.didReplace(newRoute: route(), oldRoute: route('/home'));
+
+      verifyNever(() => mockFaro.setViewMeta(name: any(named: 'name')));
+      verify(
+        () => mockFaro.pushEvent(
+          'view_changed',
+          attributes: {'fromView': '/home', 'toView': null},
+        ),
+      ).called(1);
+    });
+
+    test('does not emit a view change when both route names are null', () {
+      observer.didReplace(newRoute: route(), oldRoute: route());
+
+      verifyNever(() => mockFaro.setViewMeta(name: any(named: 'name')));
+      verifyNever(
+        () => mockFaro.pushEvent(any(), attributes: any(named: 'attributes')),
+      );
+    });
+  });
+}

--- a/test/src/faro_navigation_observer_test.dart
+++ b/test/src/faro_navigation_observer_test.dart
@@ -1,15 +1,21 @@
+import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/faro_navigation_observer.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/session/session_manager.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockFaro extends Mock implements Faro {}
 
+class MockSessionManager extends Mock implements SessionManager {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late MockFaro mockFaro;
+  late MockSessionManager mockSessionManager;
   late FaroNavigationObserver observer;
 
   PageRoute<void> route([String? name]) {
@@ -19,15 +25,25 @@ void main() {
     );
   }
 
+  setUpAll(() {
+    registerFallbackValue(SessionActivityKind.active);
+  });
+
   setUp(() {
     mockFaro = MockFaro();
+    mockSessionManager = MockSessionManager();
     Faro.instance = mockFaro;
+    pod.overrideProvider(sessionManagerProvider, (_) => mockSessionManager);
     observer = FaroNavigationObserver();
 
     when(() => mockFaro.setViewMeta(name: any(named: 'name'))).thenReturn(null);
     when(
       () => mockFaro.pushEvent(any(), attributes: any(named: 'attributes')),
     ).thenReturn(null);
+  });
+
+  tearDown(() {
+    pod.removeOverride(sessionManagerProvider);
   });
 
   group('FaroNavigationObserver', () {
@@ -79,13 +95,18 @@ void main() {
       ).called(1);
     });
 
-    test('does not emit a view change when both route names are null', () {
+    test('refreshes the session without emitting an empty view change', () {
       observer.didReplace(newRoute: route(), oldRoute: route());
 
       verifyNever(() => mockFaro.setViewMeta(name: any(named: 'name')));
       verifyNever(
         () => mockFaro.pushEvent(any(), attributes: any(named: 'attributes')),
       );
+      verify(
+        () => mockSessionManager.checkSession(
+          activity: SessionActivityKind.active,
+        ),
+      ).called(1);
     });
   });
 }


### PR DESCRIPTION
## Description

Unnamed Flutter routes currently replace the last known `view.name` with `null`, which leaves subsequent telemetry without useful view metadata. This change updates view metadata only when the destination route has a name and suppresses `view_changed` events when both route names are null. Navigation activity signals continue to be emitted for every push, pop, and replacement.

## Related Issue(s)

Fixes #305

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Verification

- `flutter test test/src/faro_navigation_observer_test.dart` (5 tests)
- `flutter analyze`
- `flutter test` (753 tests)
- `cd example/android && gradle 8.14.5 :faro:testDebugUnitTest`
- `dart tool/pre_release_check.dart` (all 6 checks)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The regression coverage includes unnamed pushes, pops, replacements, returning to a named route, and the both-names-null case.