### PR TITLE
poc: explore reference kit composition

### DIFF
--- a/doc/reference-kit-composition-poc.md
+++ b/doc/reference-kit-composition-poc.md
@@ -1,0 +1,51 @@
+# Flutter Reference Kit composition POC
+
+## Goal
+
+Test whether a Grafana Reference Kit can add Grafana behavior while preserving
+direct access to the selected telemetry SDK. The POC intentionally avoids a
+wrapper that would need to mirror every Faro or OpenTelemetry method.
+
+## Shape
+
+```dart
+final otelSdk = FutureOpenTelemetrySdk();
+final kit = GrafanaReferenceKit(
+  sdk: otelSdk,
+  plugins: [GrafanaCloudPlugin()],
+);
+
+await kit.start();
+
+// The application still uses the native SDK directly.
+kit.sdk.tracerProvider.getTracer('checkout');
+```
+
+`GrafanaReferenceKit` owns only plugin lifecycle:
+
+- It preserves the exact SDK object supplied by the application.
+- It starts Grafana plugins in registration order.
+- It stops them in reverse order.
+- It rolls back partially installed plugins when startup fails.
+- It does not proxy tracing, logging, metrics, or other native SDK methods.
+
+The POC is generic because the future Flutter OpenTelemetry SDK API is not yet
+available. A concrete adapter can be added once that SDK exposes its
+initialization and extension points.
+
+## Current Faro constraint
+
+Faro currently initializes `dartastic_opentelemetry` through a process-global
+static API. That does not match the proposed `GrafanaReferenceKit(otelSdk)`
+constructor because there is no SDK instance to inject. This POC should not be
+moved into the public package until we decide whether to:
+
+1. adopt an instance-based Flutter OpenTelemetry SDK,
+2. introduce an instance-based boundary around Faro's OTel bootstrap, or
+3. keep Faro and OTel initialization as separate concrete plugins.
+
+## Decision this POC supports
+
+Composition is viable without creating a broad Grafana shim. The remaining
+design question is the concrete lifecycle and extension API offered by the
+future Flutter OpenTelemetry SDK.

--- a/doc/reference-kit-composition-poc.md
+++ b/doc/reference-kit-composition-poc.md
@@ -2,13 +2,16 @@
 
 ## Goal
 
-Test whether a Grafana Reference Kit can add Grafana behavior while preserving
-direct access to the selected telemetry SDK. The POC intentionally avoids a
-wrapper that would need to mirror every Faro or OpenTelemetry method.
+Test whether a Grafana Reference Kit can compose an OpenTelemetry SDK with
+Grafana instrumentation and plugins without creating a second telemetry API.
+Applications continue to instrument through the stable OpenTelemetry API. The
+underlying SDK remains available only where advanced configuration or extension
+points require it.
 
 ## Shape
 
 ```dart
+final otelApi = FutureOpenTelemetryApi();
 final otelSdk = FutureOpenTelemetrySdk();
 final kit = GrafanaReferenceKit(
   sdk: otelSdk,
@@ -17,17 +20,21 @@ final kit = GrafanaReferenceKit(
 
 await kit.start();
 
-// The application still uses the native SDK directly.
+// Application instrumentation continues through the stable OTel API.
+final tracer = otelApi.getTracer('checkout');
+
+// The SDK remains available for advanced configuration when needed.
 kit.sdk.tracerProvider.getTracer('checkout');
 ```
 
 `GrafanaReferenceKit` owns only plugin lifecycle:
 
-- It preserves the exact SDK object supplied by the application.
+- It does not replace or wrap the OpenTelemetry API used for instrumentation.
+- It preserves the exact SDK object for advanced configuration and extensions.
 - It starts Grafana plugins in registration order.
 - It stops them in reverse order.
 - It rolls back partially installed plugins when startup fails.
-- It does not proxy tracing, logging, metrics, or other native SDK methods.
+- It does not define Grafana versions of tracing, logging, or metrics methods.
 
 The POC is generic because the future Flutter OpenTelemetry SDK API is not yet
 available. A concrete adapter can be added once that SDK exposes its
@@ -46,6 +53,8 @@ moved into the public package until we decide whether to:
 
 ## Decision this POC supports
 
-Composition is viable without creating a broad Grafana shim. The remaining
-design question is the concrete lifecycle and extension API offered by the
-future Flutter OpenTelemetry SDK.
+Composition is viable without creating a Grafana-specific telemetry API. The
+OpenTelemetry API remains the stable customer contract, while the Reference Kit
+assembles the SDK with Grafana instrumentation, configuration, and plugins. The
+remaining design question is the concrete lifecycle and extension API offered
+by the future Flutter OpenTelemetry SDK.

--- a/test/poc/grafana_reference_kit_test.dart
+++ b/test/poc/grafana_reference_kit_test.dart
@@ -4,7 +4,7 @@ import '../../tool/poc/reference_kit/grafana_reference_kit.dart';
 
 void main() {
   group('GrafanaReferenceKit', () {
-    test('keeps the native SDK available without wrapping its API', () {
+    test('keeps the native SDK available for advanced configuration', () {
       final sdk = _FakeTelemetrySdk();
       final kit = GrafanaReferenceKit<_FakeTelemetrySdk>(
         sdk: sdk,

--- a/test/poc/grafana_reference_kit_test.dart
+++ b/test/poc/grafana_reference_kit_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/poc/reference_kit/grafana_reference_kit.dart';
+
+void main() {
+  group('GrafanaReferenceKit', () {
+    test('keeps the native SDK available without wrapping its API', () {
+      final sdk = _FakeTelemetrySdk();
+      final kit = GrafanaReferenceKit<_FakeTelemetrySdk>(
+        sdk: sdk,
+        plugins: const [],
+      );
+
+      expect(identical(kit.sdk, sdk), isTrue);
+      expect(kit.sdk.nativeOperation(), 'native result');
+    });
+
+    test('starts plugins in registration order only once', () async {
+      final calls = <String>[];
+      final kit = GrafanaReferenceKit<_FakeTelemetrySdk>(
+        sdk: _FakeTelemetrySdk(),
+        plugins: [
+          _RecordingPlugin('one', calls),
+          _RecordingPlugin('two', calls),
+        ],
+      );
+
+      await kit.start();
+      await kit.start();
+
+      expect(calls, ['start one', 'start two']);
+    });
+
+    test('stops installed plugins in reverse order only once', () async {
+      final calls = <String>[];
+      final kit = GrafanaReferenceKit<_FakeTelemetrySdk>(
+        sdk: _FakeTelemetrySdk(),
+        plugins: [
+          _RecordingPlugin('one', calls),
+          _RecordingPlugin('two', calls),
+        ],
+      );
+
+      await kit.start();
+      await kit.stop();
+      await kit.stop();
+
+      expect(calls, ['start one', 'start two', 'stop two', 'stop one']);
+    });
+
+    test('rolls back installed plugins when startup fails', () async {
+      final calls = <String>[];
+      final kit = GrafanaReferenceKit<_FakeTelemetrySdk>(
+        sdk: _FakeTelemetrySdk(),
+        plugins: [
+          _RecordingPlugin('one', calls),
+          _RecordingPlugin('two', calls, failOnStart: true),
+          _RecordingPlugin('three', calls),
+        ],
+      );
+
+      await expectLater(kit.start(), throwsStateError);
+
+      expect(calls, ['start one', 'start two', 'stop two', 'stop one']);
+      expect(kit.isRunning, isFalse);
+    });
+
+    test('attempts all cleanup when one plugin fails to stop', () async {
+      final calls = <String>[];
+      final kit = GrafanaReferenceKit<_FakeTelemetrySdk>(
+        sdk: _FakeTelemetrySdk(),
+        plugins: [
+          _RecordingPlugin('one', calls),
+          _RecordingPlugin('two', calls, failOnStop: true),
+          _RecordingPlugin('three', calls),
+        ],
+      );
+      await kit.start();
+
+      await expectLater(kit.stop(), throwsStateError);
+
+      expect(calls, [
+        'start one',
+        'start two',
+        'start three',
+        'stop three',
+        'stop two',
+        'stop one',
+      ]);
+      expect(kit.isRunning, isFalse);
+    });
+  });
+}
+
+final class _FakeTelemetrySdk {
+  String nativeOperation() => 'native result';
+}
+
+final class _RecordingPlugin
+    implements GrafanaReferenceKitPlugin<_FakeTelemetrySdk> {
+  _RecordingPlugin(
+    this.name,
+    this.calls, {
+    this.failOnStart = false,
+    this.failOnStop = false,
+  });
+
+  final String name;
+  final List<String> calls;
+  final bool failOnStart;
+  final bool failOnStop;
+
+  @override
+  Future<void> start(_FakeTelemetrySdk sdk) async {
+    calls.add('start $name');
+    if (failOnStart) {
+      throw StateError('start $name failed');
+    }
+  }
+
+  @override
+  Future<void> stop(_FakeTelemetrySdk sdk) async {
+    calls.add('stop $name');
+    if (failOnStop) {
+      throw StateError('stop $name failed');
+    }
+  }
+}

--- a/tool/poc/reference_kit/grafana_reference_kit.dart
+++ b/tool/poc/reference_kit/grafana_reference_kit.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+/// Adds Grafana behavior to a telemetry SDK without wrapping its native API.
+abstract interface class GrafanaReferenceKitPlugin<TSdk extends Object> {
+  /// Installs this plugin on [sdk].
+  FutureOr<void> start(TSdk sdk);
+
+  /// Removes this plugin from [sdk].
+  FutureOr<void> stop(TSdk sdk);
+}
+
+/// A composition-first proof of concept for the Flutter Reference Kit.
+///
+/// The native [sdk] remains public so applications can use its complete API.
+/// Grafana-specific behavior is added through small lifecycle plugins instead
+/// of a wrapper that mirrors every SDK method.
+final class GrafanaReferenceKit<TSdk extends Object> {
+  GrafanaReferenceKit({
+    required this.sdk,
+    required List<GrafanaReferenceKitPlugin<TSdk>> plugins,
+  }) : _plugins = List.unmodifiable(plugins);
+
+  /// The unwrapped telemetry SDK supplied by the application.
+  final TSdk sdk;
+
+  final List<GrafanaReferenceKitPlugin<TSdk>> _plugins;
+  final List<GrafanaReferenceKitPlugin<TSdk>> _startedPlugins = [];
+  _ReferenceKitState _state = _ReferenceKitState.idle;
+
+  /// Whether every plugin started successfully.
+  bool get isRunning => _state == _ReferenceKitState.running;
+
+  /// Starts each plugin in registration order.
+  ///
+  /// A repeated call after successful startup has no effect. If startup fails,
+  /// plugins that already started are stopped in reverse order before the
+  /// original error is rethrown.
+  Future<void> start() async {
+    if (_state == _ReferenceKitState.running) {
+      return;
+    }
+    if (_state != _ReferenceKitState.idle) {
+      throw StateError('Reference Kit lifecycle change already in progress.');
+    }
+
+    _state = _ReferenceKitState.starting;
+    try {
+      for (final plugin in _plugins) {
+        _startedPlugins.add(plugin);
+        await plugin.start(sdk);
+      }
+      _state = _ReferenceKitState.running;
+    } catch (error, stackTrace) {
+      await _stopStartedPlugins(ignoreErrors: true);
+      _state = _ReferenceKitState.idle;
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
+
+  /// Stops each installed plugin in reverse order.
+  ///
+  /// Cleanup continues after an individual plugin fails. The first cleanup
+  /// error is rethrown after all plugins have had a chance to stop.
+  Future<void> stop() async {
+    if (_state == _ReferenceKitState.idle) {
+      return;
+    }
+    if (_state != _ReferenceKitState.running) {
+      throw StateError('Reference Kit lifecycle change already in progress.');
+    }
+
+    _state = _ReferenceKitState.stopping;
+    final failure = await _stopStartedPlugins(ignoreErrors: false);
+    _state = _ReferenceKitState.idle;
+    if (failure != null) {
+      Error.throwWithStackTrace(failure.error, failure.stackTrace);
+    }
+  }
+
+  Future<_PluginFailure?> _stopStartedPlugins({
+    required bool ignoreErrors,
+  }) async {
+    _PluginFailure? firstFailure;
+    for (final plugin in _startedPlugins.reversed) {
+      try {
+        await plugin.stop(sdk);
+      } catch (error, stackTrace) {
+        firstFailure ??= _PluginFailure(error, stackTrace);
+      }
+    }
+    _startedPlugins.clear();
+    return ignoreErrors ? null : firstFailure;
+  }
+}
+
+enum _ReferenceKitState { idle, starting, running, stopping }
+
+final class _PluginFailure {
+  const _PluginFailure(this.error, this.stackTrace);
+
+  final Object error;
+  final StackTrace stackTrace;
+}

--- a/tool/poc/reference_kit/grafana_reference_kit.dart
+++ b/tool/poc/reference_kit/grafana_reference_kit.dart
@@ -11,16 +11,17 @@ abstract interface class GrafanaReferenceKitPlugin<TSdk extends Object> {
 
 /// A composition-first proof of concept for the Flutter Reference Kit.
 ///
-/// The native [sdk] remains public so applications can use its complete API.
+/// Applications instrument through the stable OpenTelemetry API. The native
+/// [sdk] remains available for advanced configuration and extension points.
 /// Grafana-specific behavior is added through small lifecycle plugins instead
-/// of a wrapper that mirrors every SDK method.
+/// of introducing another telemetry API or mirroring every SDK method.
 final class GrafanaReferenceKit<TSdk extends Object> {
   GrafanaReferenceKit({
     required this.sdk,
     required List<GrafanaReferenceKitPlugin<TSdk>> plugins,
   }) : _plugins = List.unmodifiable(plugins);
 
-  /// The unwrapped telemetry SDK supplied by the application.
+  /// The unwrapped telemetry SDK for advanced configuration and extensions.
   final TSdk sdk;
 
   final List<GrafanaReferenceKitPlugin<TSdk>> _plugins;


### PR DESCRIPTION
## Description

POC for a composition-first Flutter Reference Kit. Applications keep the OTel
API as their instrumentation contract, while the Reference Kit assembles the
SDK with Grafana lifecycle plugins and configuration.

Direct SDK access remains available for advanced configuration without adding
a second Grafana telemetry API. Includes lifecycle and rollback tests plus notes
on the current process-global Faro OTel bootstrap constraint.

## Related Issue(s)

Tracks the Reference Kit strategy investigation: https://github.com/grafana/frontend-o11y-knowledge-workbench/issues/105

## Type of Change

- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [x] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md under the "Unreleased" section

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Validated with `dart format --set-exit-if-changed .`, `flutter analyze`, and
the full `flutter test --reporter failures-only` suite (800 tests).

The local pre-release helper could not run Android unit tests because this
checkout does not contain the `example/android/gradlew` launcher. CI remains
the authoritative Android build and test validation.