### PR TITLE
fix(session): attribute recovered crashes to original session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Attribute recovered Android and iOS native crashes to the persisted session
   in which they occurred without changing the new live session. Recovered
   crash metadata includes `crashedSessionId` and preserves the original
-  session sampling decision
+  session sampling decision. Historical Android exits are matched to their
+  retained per-process sessions
   ([#151](https://github.com/grafana/faro-flutter-sdk/issues/151)).
 - Filter Android `LOW_MEMORY` exits for service and less important process
   states regardless of whether Android records status `0` or `SIGKILL`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Attribute recovered Android and iOS native crashes to the persisted session
+  in which they occurred without changing the new live session. Recovered
+  crash metadata includes `crashedSessionId` and preserves the original
+  session sampling decision
+  ([#151](https://github.com/grafana/faro-flutter-sdk/issues/151)).
 - Filter Android `LOW_MEMORY` exits for service and less important process
   states regardless of whether Android records status `0` or `SIGKILL`.
   Foreground, foreground-service, visible, and perceptible exits remain

--- a/android/src/main/java/com/grafana/faro/ExitInfoHelper.java
+++ b/android/src/main/java/com/grafana/faro/ExitInfoHelper.java
@@ -106,9 +106,8 @@ public class ExitInfoHelper {
 
         for (ApplicationExitInfo exitInfo : exitInfoList) {
             String exitInfoKey = ApplicationExitInfoExt.getUniqueId(exitInfo);
-            if (!handledExitInfo.contains(exitInfoKey)) {
+            if (updatedHandledExitInfo.add(exitInfoKey)) {
                 newExitInfo.add(exitInfo);
-                updatedHandledExitInfo.add(exitInfoKey);
             }
         }
 
@@ -214,5 +213,4 @@ public class ExitInfoHelper {
         }
     }
 }
-
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -412,6 +412,16 @@ engine keeps its in-memory session until it initializes again. When native
 process identity is available, telemetry includes `process_name` and
 `dart_isolate_name` session attributes for correlation.
 
+**Recovered crashes.** When crash reporting and session persistence are
+enabled, Android and iOS native crashes recovered on the next launch retain
+the persisted session ID that was active when the process stopped. The crash
+payload also includes `crashedSessionId` in the session attributes and uses
+that session's persisted sampling decision. Sending the recovered crash does
+not rotate or otherwise change the new live session. Android continues to
+deduplicate historical `ApplicationExitInfo` records, while iOS purges the
+pending PLCrashReporter record after processing it. If session persistence is
+disabled or unavailable, the SDK cannot recover the prior session identity.
+
 **What counts as activity.** Faro classifies telemetry as meaningful work or
 passive telemetry. Every item checks session expiry before it is attributed,
 but only meaningful work refreshes the 15-minute inactivity window.

--- a/doc/error-categorization.md
+++ b/doc/error-categorization.md
@@ -82,7 +82,9 @@ Notes:
   **while the app is running** and reports within the same session.
 - With session persistence enabled, next-launch native crash reports retain
   the prior session ID and include `crashedSessionId` in the session
-  attributes. Reporting them does not change the new live session.
+  attributes. Reporting them does not change the new live session. When
+  Android returns several historical exits, each report is matched by process
+  and timestamp to its retained session. Reports without a match are ignored.
 - Android low-memory exits from service and less important process states are
   filtered because they are normal system reclamation rather than user-facing
   crashes. Foreground, foreground-service, visible, and perceptible low-memory

--- a/doc/error-categorization.md
+++ b/doc/error-categorization.md
@@ -80,6 +80,9 @@ Notes:
   exits) are detected and reported on the **next launch**. The Android
   runtime **ANR watchdog** is different: it detects a blocked main thread
   **while the app is running** and reports within the same session.
+- With session persistence enabled, next-launch native crash reports retain
+  the prior session ID and include `crashedSessionId` in the session
+  attributes. Reporting them does not change the new live session.
 - Android low-memory exits from service and less important process states are
   filtered because they are normal system reclamation rather than user-facing
   crashes. Foreground, foreground-service, visible, and perceptible low-memory

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		A15100000000000000000002 /* CrashReportingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15100000000000000000001 /* CrashReportingIntegrationTests.swift */; };
 		B511AF535290F278CF5DAF24 /* AppStartTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5ACEA664AC22AE6DD3074A /* AppStartTrackerTests.swift */; };
 		C76BAB755F8132D3850B32A2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54FB4329F82A1DBA2EEFE406 /* Foundation.framework */; };
 /* End PBXBuildFile section */
@@ -60,6 +61,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A15100000000000000000001 /* CrashReportingIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CrashReportingIntegrationTests.swift; sourceTree = "<group>"; };
 		DA5ACEA664AC22AE6DD3074A /* AppStartTrackerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppStartTrackerTests.swift; sourceTree = "<group>"; };
 		FA00FA00FA00FA00FA00FA00 /* faro */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = faro; path = ../../ios/faro; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -88,6 +90,7 @@
 			isa = PBXGroup;
 			children = (
 				DA5ACEA664AC22AE6DD3074A /* AppStartTrackerTests.swift */,
+				A15100000000000000000001 /* CrashReportingIntegrationTests.swift */,
 			);
 			name = RunnerTests;
 			path = RunnerTests;
@@ -301,6 +304,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B511AF535290F278CF5DAF24 /* AppStartTrackerTests.swift in Sources */,
+				A15100000000000000000002 /* CrashReportingIntegrationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/example/ios/RunnerTests/CrashReportingIntegrationTests.swift
+++ b/example/ios/RunnerTests/CrashReportingIntegrationTests.swift
@@ -1,0 +1,30 @@
+import Testing
+
+@testable import faro
+
+@Suite("CrashReportingIntegration")
+struct CrashReportingIntegrationTests {
+
+  @Test("reports pending crashes by default")
+  func reportsPendingCrashByDefault() {
+    #expect(CrashReportingIntegration.shouldReportPendingCrash(config: [:]))
+  }
+
+  @Test("does not report a crash from an unsampled session")
+  func skipsPendingCrashForUnsampledSession() {
+    #expect(
+      !CrashReportingIntegration.shouldReportPendingCrash(
+        config: ["reportPendingCrash": false]
+      )
+    )
+  }
+
+  @Test("ignores malformed sampling configuration")
+  func ignoresMalformedSamplingConfiguration() {
+    #expect(
+      CrashReportingIntegration.shouldReportPendingCrash(
+        config: ["reportPendingCrash": "false"]
+      )
+    )
+  }
+}

--- a/ios/faro/Sources/faro/CrashReportingIntegration.swift
+++ b/ios/faro/Sources/faro/CrashReportingIntegration.swift
@@ -1,6 +1,10 @@
 import CrashReporter
 
 class  CrashReportingIntegration {
+    static func shouldReportPendingCrash(config: [String: Any]) -> Bool {
+        return config["reportPendingCrash"] as? Bool ?? true
+    }
+
     init(crashReporterConfig: [String: Any]) throws {
         //if (!isDebuggerAttached()) {
         
@@ -25,7 +29,8 @@ class  CrashReportingIntegration {
             print("Warning: Could not enable crash reporter: \(error)")
         }
         // Try loading the crash report.
-        if crashReporter.hasPendingCrashReport() {
+        let reportPendingCrash = Self.shouldReportPendingCrash(config: crashReporterConfig)
+        if crashReporter.hasPendingCrashReport() && reportPendingCrash {
             do {
                 let data = try crashReporter.loadPendingCrashReportDataAndReturnError()
                 

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -214,7 +214,7 @@ class Faro {
       installationId: '$installationId',
     );
 
-    final persistedPreviousSessionId = await _initializeSessionPersistence(
+    final persistedPreviousSession = await _initializeSessionPersistence(
       optionsConfiguration,
     );
 
@@ -265,6 +265,7 @@ class Faro {
         app: _instance.meta.app!,
         apiKey: optionsConfiguration.apiKey,
         collectorUrl: optionsConfiguration.collectorUrl ?? '',
+        recoveredSession: persistedPreviousSession,
       );
     }
     if (Platform.isAndroid || Platform.isIOS) {
@@ -278,7 +279,9 @@ class Faro {
     }
     await FaroOtelBootstrap.initialize();
     // Announce the initial session; the listener emits `session_start`.
-    sessionManager.start(previousSessionId: persistedPreviousSessionId);
+    sessionManager.start(
+      previousSessionId: persistedPreviousSession?.currentSessionId,
+    );
     await _sessionPersistence?.flush();
     _reportColdStartAfterFirstFrame();
 
@@ -387,7 +390,9 @@ class Faro {
     );
   }
 
-  Future<String?> _initializeSessionPersistence(FaroConfig options) async {
+  Future<PersistedSessionRecord?> _initializeSessionPersistence(
+    FaroConfig options,
+  ) async {
     if (!_isMobilePlatform()) {
       return null;
     }
@@ -427,7 +432,7 @@ class Faro {
       }
 
       _sessionPersistence = persistence;
-      return (await persistence.load())?.currentSessionId;
+      return persistence.load();
     } catch (error) {
       log('Faro: Session persistence unavailable: $error');
       _sessionPersistence = null;
@@ -985,19 +990,32 @@ class Faro {
     required App app,
     required String apiKey,
     required String collectorUrl,
+    PersistedSessionRecord? recoveredSession,
   }) async {
     try {
-      final metadata = meta.toJson();
+      final recoveredCrashMeta = recoveredSession == null
+          ? null
+          : _metaForRecoveredSession(recoveredSession);
+      final metadata = (recoveredCrashMeta ?? meta).toJson();
       metadata['app'] = app.toJson();
       metadata['apiKey'] = apiKey;
       metadata['collectorUrl'] = collectorUrl;
+      metadata['reportPendingCrash'] =
+          (recoveredSession?.isSampled ?? true) && enableDataCollection;
       if (Platform.isIOS) {
         _nativeChannel?.enableCrashReporter(metadata);
       }
       if (Platform.isAndroid) {
         final crashReports = await _nativeChannel?.getCrashReport();
         if (crashReports != null) {
-          _reportAndroidCrashReports(crashReports);
+          // Recovery sends must not hold up the next app launch.
+          unawaited(
+            _reportAndroidCrashReports(
+              crashReports,
+              recoveredSession: recoveredSession,
+              recoveredCrashMeta: recoveredCrashMeta,
+            ),
+          );
         }
       }
     } catch (error, stacktrace) {
@@ -1009,45 +1027,143 @@ class Faro {
   }
 
   @visibleForTesting
-  void reportAndroidCrashesForTesting(List<String> crashReports) {
-    _reportAndroidCrashReports(crashReports);
+  Future<void> reportAndroidCrashesForTesting(
+    List<String> crashReports, {
+    PersistedSessionRecord? recoveredSession,
+  }) {
+    return _reportAndroidCrashReports(
+      crashReports,
+      recoveredSession: recoveredSession,
+      recoveredCrashMeta: recoveredSession == null
+          ? null
+          : _metaForRecoveredSession(recoveredSession),
+    );
   }
 
-  void _reportAndroidCrashReports(List<String> crashReports) {
+  Meta _metaForRecoveredSession(PersistedSessionRecord recoveredSession) {
+    final attributes = <String, dynamic>{
+      'crashedSessionId': recoveredSession.currentSessionId,
+      'isSampled': recoveredSession.isSampled,
+    };
+    final previousSessionId = recoveredSession.previousSessionId;
+    if (previousSessionId != null) {
+      attributes['previousSession'] = previousSessionId;
+    }
+
+    return Meta(
+      session: Session(
+        recoveredSession.currentSessionId,
+        attributes: attributes,
+      ),
+      sdk: meta.sdk,
+      app: meta.app,
+      device: meta.device,
+      os: meta.os,
+    );
+  }
+
+  Future<void> _reportAndroidCrashReports(
+    List<String> crashReports, {
+    required PersistedSessionRecord? recoveredSession,
+    required Meta? recoveredCrashMeta,
+  }) async {
     for (final crashInfo in crashReports) {
-      final crashInfoJson = json.decode(crashInfo);
-      final String reason = crashInfoJson['reason'];
-      final int status = crashInfoJson['status'];
+      late final FaroException exception;
+      try {
+        final decoded = json.decode(crashInfo);
+        if (decoded is! Map<String, dynamic>) {
+          throw const FormatException('Crash report must be an object');
+        }
 
-      final stringifiedContext = <String, String>{};
-      crashInfoJson.forEach((String key, dynamic value) {
-        stringifiedContext[key] = value?.toString() ?? '';
-      });
+        exception = _androidCrashException(
+          decoded,
+          crashedSessionId: recoveredSession?.currentSessionId,
+        );
+      } catch (error, stacktrace) {
+        log(
+          'Faro: Ignoring malformed Android crash report: $error',
+          stackTrace: stacktrace,
+        );
+        continue;
+      }
 
-      final description = stringifiedContext['description'] ?? 'No description';
-      final stacktrace =
+      try {
+        if (recoveredSession == null || recoveredCrashMeta == null) {
+          _instance.pushError(
+            type: exception.type,
+            value: exception.value,
+            fatal: exception.fatal,
+            context: exception.context,
+          );
+        } else if (recoveredSession.isSampled) {
+          await _sendRecoveredCrash(exception, recoveredCrashMeta);
+        }
+      } catch (error, stacktrace) {
+        log(
+          'Faro: Failed to report recovered Android crash: $error',
+          stackTrace: stacktrace,
+        );
+      }
+    }
+  }
+
+  FaroException _androidCrashException(
+    Map<String, dynamic> crashInfo, {
+    String? crashedSessionId,
+  }) {
+    final stringifiedContext = <String, String>{};
+    crashInfo.forEach((key, value) {
+      stringifiedContext[key] = value?.toString() ?? '';
+    });
+
+    final reason = stringifiedContext['reason'] ?? 'UNKNOWN';
+    final status = stringifiedContext['status'] ?? 'unknown';
+    final timestamp = stringifiedContext['timestamp'] ?? 'No timestamp';
+    final readableTimestamp = timestamp.toHumanReadableTimestamp();
+    final context = <String, String>{
+      'description': stringifiedContext['description'] ?? 'No description',
+      'stacktrace':
           stringifiedContext['trace'] ??
           stringifiedContext['stacktrace'] ??
-          'No stacktrace';
-      final timestamp = stringifiedContext['timestamp'] ?? 'No timestamp';
-      final humanReadableTimestamp = timestamp.toHumanReadableTimestamp();
+          'No stacktrace',
+      'timestamp': timestamp,
+      'timestamp_readable_utc': readableTimestamp,
+      'importance': stringifiedContext['importance'] ?? 'No importance',
+      'processName': stringifiedContext['processName'] ?? 'No processName',
+    };
+    if (crashedSessionId != null) {
+      context['crashedSessionId'] = crashedSessionId;
+    }
+    final exception = FaroException(
+      'crash',
+      '$reason, status: $status',
+      const <String, dynamic>{},
+      fatal: true,
+      context: context,
+    );
+    if (DateTime.tryParse(readableTimestamp) != null) {
+      exception.timestamp = readableTimestamp;
+    }
+    return exception;
+  }
 
-      final importance = stringifiedContext['importance'] ?? 'No importance';
-      final processName = stringifiedContext['processName'] ?? 'No processName';
-
-      _instance.pushError(
-        type: 'crash',
-        value: '$reason , status: $status',
-        fatal: true,
-        context: {
-          'description': description,
-          'stacktrace': stacktrace,
-          'timestamp': timestamp,
-          'timestamp_readable_utc': humanReadableTimestamp,
-          'importance': importance,
-          'processName': processName,
-        },
-      );
+  Future<void> _sendRecoveredCrash(
+    FaroException exception,
+    Meta recoveredCrashMeta,
+  ) async {
+    if (_dataCollectionPolicy?.isEnabled == false) {
+      return;
+    }
+    // The live batch carries the new session metadata, so recovered crashes
+    // must use an isolated payload.
+    final payload = Payload(recoveredCrashMeta)..exceptions.add(exception);
+    final payloadJson = payload.toJson();
+    for (final transport in List<BaseTransport>.of(_transports)) {
+      if (transport is FaroTransport) {
+        await transport.sendHistorical(payloadJson);
+      } else {
+        await transport.send(payloadJson);
+      }
     }
   }
 }

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -90,6 +90,11 @@ class Faro {
       SessionPersistenceFactory();
   bool Function() _isMobilePlatform = () =>
       Platform.isAndroid || Platform.isIOS;
+  bool Function() _isAndroidPlatform = () => Platform.isAndroid;
+  bool Function() _isIOSPlatform = () => Platform.isIOS;
+  List<PersistedSessionRecord> _recoveredSessionHistory =
+      const <PersistedSessionRecord>[];
+  String? _sessionProcessIdentifier;
   bool _isSampled = true;
   bool _isInitialized = false;
   FaroWidgetsBindingObserver? _widgetsBindingObserver;
@@ -165,6 +170,16 @@ class Faro {
   @visibleForTesting
   set mobilePlatformResolver(bool Function() resolver) {
     _isMobilePlatform = resolver;
+  }
+
+  @visibleForTesting
+  set androidPlatformResolver(bool Function() resolver) {
+    _isAndroidPlatform = resolver;
+  }
+
+  @visibleForTesting
+  set iosPlatformResolver(bool Function() resolver) {
+    _isIOSPlatform = resolver;
   }
 
   Future<void> init({required FaroConfig optionsConfiguration}) async {
@@ -408,6 +423,7 @@ class Faro {
     if (runtimeInfo == null) {
       return null;
     }
+    _sessionProcessIdentifier = runtimeInfo.processIdentifier;
 
     final session = meta.session;
     if (session != null) {
@@ -432,7 +448,10 @@ class Faro {
       }
 
       _sessionPersistence = persistence;
-      return persistence.load();
+      _recoveredSessionHistory = await persistence.loadHistory();
+      return _recoveredSessionHistory.isEmpty
+          ? null
+          : _recoveredSessionHistory.last;
     } catch (error) {
       log('Faro: Session persistence unavailable: $error');
       _sessionPersistence = null;
@@ -996,24 +1015,31 @@ class Faro {
       final recoveredCrashMeta = recoveredSession == null
           ? null
           : _metaForRecoveredSession(recoveredSession);
-      final metadata = (recoveredCrashMeta ?? meta).toJson();
+      final metadata = (recoveredCrashMeta ?? meta).toFaroJson();
       metadata['app'] = app.toJson();
       metadata['apiKey'] = apiKey;
       metadata['collectorUrl'] = collectorUrl;
       metadata['reportPendingCrash'] =
           (recoveredSession?.isSampled ?? true) && enableDataCollection;
-      if (Platform.isIOS) {
+      if (_isIOSPlatform()) {
         _nativeChannel?.enableCrashReporter(metadata);
       }
-      if (Platform.isAndroid) {
+      if (_isAndroidPlatform()) {
         final crashReports = await _nativeChannel?.getCrashReport();
         if (crashReports != null) {
+          final recoveredSessions = _sessionPersistence != null
+              ? _recoveredSessionHistory
+              : recoveredSession == null
+              ? null
+              : <PersistedSessionRecord>[recoveredSession];
           // Recovery sends must not hold up the next app launch.
           unawaited(
             _reportAndroidCrashReports(
               crashReports,
-              recoveredSession: recoveredSession,
-              recoveredCrashMeta: recoveredCrashMeta,
+              recoveredSessions: recoveredSessions,
+              processIdentifier: _sessionPersistence == null
+                  ? null
+                  : _sessionProcessIdentifier,
             ),
           );
         }
@@ -1030,13 +1056,17 @@ class Faro {
   Future<void> reportAndroidCrashesForTesting(
     List<String> crashReports, {
     PersistedSessionRecord? recoveredSession,
+    List<PersistedSessionRecord>? recoveredSessions,
+    String? processIdentifier,
   }) {
     return _reportAndroidCrashReports(
       crashReports,
-      recoveredSession: recoveredSession,
-      recoveredCrashMeta: recoveredSession == null
-          ? null
-          : _metaForRecoveredSession(recoveredSession),
+      recoveredSessions:
+          recoveredSessions ??
+          (recoveredSession == null
+              ? null
+              : <PersistedSessionRecord>[recoveredSession]),
+      processIdentifier: processIdentifier,
     );
   }
 
@@ -1064,15 +1094,28 @@ class Faro {
 
   Future<void> _reportAndroidCrashReports(
     List<String> crashReports, {
-    required PersistedSessionRecord? recoveredSession,
-    required Meta? recoveredCrashMeta,
+    required List<PersistedSessionRecord>? recoveredSessions,
+    required String? processIdentifier,
   }) async {
     for (final crashInfo in crashReports) {
       late final FaroException exception;
+      PersistedSessionRecord? recoveredSession;
       try {
         final decoded = json.decode(crashInfo);
         if (decoded is! Map<String, dynamic>) {
           throw const FormatException('Crash report must be an object');
+        }
+
+        if (recoveredSessions != null) {
+          recoveredSession = _matchRecoveredSession(
+            decoded,
+            recoveredSessions,
+            processIdentifier: processIdentifier,
+          );
+          if (recoveredSession == null) {
+            log('Faro: Ignoring Android crash without a matching session');
+            continue;
+          }
         }
 
         exception = _androidCrashException(
@@ -1088,7 +1131,7 @@ class Faro {
       }
 
       try {
-        if (recoveredSession == null || recoveredCrashMeta == null) {
+        if (recoveredSession == null) {
           _instance.pushError(
             type: exception.type,
             value: exception.value,
@@ -1096,7 +1139,10 @@ class Faro {
             context: exception.context,
           );
         } else if (recoveredSession.isSampled) {
-          await _sendRecoveredCrash(exception, recoveredCrashMeta);
+          await _sendRecoveredCrash(
+            exception,
+            _metaForRecoveredSession(recoveredSession),
+          );
         }
       } catch (error, stacktrace) {
         log(
@@ -1105,6 +1151,42 @@ class Faro {
         );
       }
     }
+  }
+
+  PersistedSessionRecord? _matchRecoveredSession(
+    Map<String, dynamic> crashInfo,
+    List<PersistedSessionRecord> recoveredSessions, {
+    required String? processIdentifier,
+  }) {
+    if (processIdentifier != null &&
+        crashInfo['processName'] != processIdentifier) {
+      return null;
+    }
+
+    final timestampValue = crashInfo['timestamp'];
+    final timestamp = timestampValue is int
+        ? timestampValue
+        : int.tryParse(timestampValue?.toString() ?? '');
+    if (timestamp == null || timestamp < 0) {
+      return null;
+    }
+    final crashTime = DateTime.fromMillisecondsSinceEpoch(
+      timestamp,
+      isUtc: true,
+    );
+
+    PersistedSessionRecord? match;
+    for (final session in recoveredSessions) {
+      if (session.startedAt.isAfter(crashTime)) {
+        continue;
+      }
+      // The most recently started eligible session owned the process when the
+      // exit occurred. Equal timestamps prefer the later persisted record.
+      if (match == null || !session.startedAt.isBefore(match.startedAt)) {
+        match = session;
+      }
+    }
+    return match;
   }
 
   FaroException _androidCrashException(

--- a/lib/src/session/session_persistence.dart
+++ b/lib/src/session/session_persistence.dart
@@ -134,26 +134,41 @@ class SessionPersistence {
   final SessionFileStore _store;
   final Duration activityWriteDelay;
 
+  // Android returns at most 15 historical exits. Keep those sessions plus the
+  // session that becomes current after recovery.
+  static const int _maxHistoryLength = 16;
+  static const int _historySchemaVersion = 2;
+
   Timer? _activityWriteTimer;
-  PersistedSessionRecord? _pendingRecord;
-  PersistedSessionRecord? _enqueuedRecord;
+  List<PersistedSessionRecord> _history = <PersistedSessionRecord>[];
+  List<PersistedSessionRecord>? _pendingHistory;
+  List<PersistedSessionRecord>? _enqueuedHistory;
   Future<void> _writeQueue = Future<void>.value();
 
   Future<PersistedSessionRecord?> load() async {
+    final history = await loadHistory();
+    return history.isEmpty ? null : history.last;
+  }
+
+  Future<List<PersistedSessionRecord>> loadHistory() async {
     try {
       final persistedValue = await _store.read();
       if (persistedValue == null) {
-        return null;
+        _history = <PersistedSessionRecord>[];
+        return const <PersistedSessionRecord>[];
       }
       final decoded = jsonDecode(persistedValue);
       if (decoded is! Map<String, dynamic>) {
         throw const FormatException('Session record must be an object');
       }
-      return PersistedSessionRecord.fromJson(decoded);
+      final history = _decodeHistory(decoded);
+      _history = List<PersistedSessionRecord>.of(history);
+      return List<PersistedSessionRecord>.unmodifiable(history);
     } catch (error) {
       log('Faro: Ignoring invalid persisted session state: $error');
       await _deleteSafely();
-      return null;
+      _history = <PersistedSessionRecord>[];
+      return const <PersistedSessionRecord>[];
     }
   }
 
@@ -165,13 +180,24 @@ class SessionPersistence {
     final lastActivityAt = state.lastActivityAt.isBefore(state.startedAt)
         ? state.startedAt
         : state.lastActivityAt;
-    _pendingRecord = PersistedSessionRecord(
+    final record = PersistedSessionRecord(
       currentSessionId: state.currentSessionId,
       previousSessionId: state.previousSessionId,
       startedAt: state.startedAt,
       lastActivityAt: lastActivityAt,
       isSampled: isSampled,
     );
+    final existingIndex = _history.indexWhere(
+      (item) => item.currentSessionId == record.currentSessionId,
+    );
+    if (existingIndex != -1) {
+      _history.removeAt(existingIndex);
+    }
+    _history.add(record);
+    if (_history.length > _maxHistoryLength) {
+      _history.removeRange(0, _history.length - _maxHistoryLength);
+    }
+    _pendingHistory = List<PersistedSessionRecord>.unmodifiable(_history);
 
     if (immediate) {
       _activityWriteTimer?.cancel();
@@ -189,7 +215,8 @@ class SessionPersistence {
   Future<void> clear() async {
     _activityWriteTimer?.cancel();
     _activityWriteTimer = null;
-    _pendingRecord = null;
+    _history = <PersistedSessionRecord>[];
+    _pendingHistory = null;
     _writeQueue = _writeQueue.then((_) => _deleteSafely());
     await _writeQueue;
   }
@@ -202,25 +229,30 @@ class SessionPersistence {
   }
 
   void _enqueuePendingWrite() {
-    final record = _pendingRecord;
-    if (record == null || identical(record, _enqueuedRecord)) {
+    final history = _pendingHistory;
+    if (history == null || identical(history, _enqueuedHistory)) {
       return;
     }
-    _enqueuedRecord = record;
+    _enqueuedHistory = history;
     _writeQueue = _writeQueue.then((_) async {
-      final writeSucceeded = await _writeSafely(record);
-      if (identical(_enqueuedRecord, record)) {
-        _enqueuedRecord = null;
+      final writeSucceeded = await _writeSafely(history);
+      if (identical(_enqueuedHistory, history)) {
+        _enqueuedHistory = null;
       }
-      if (writeSucceeded && identical(_pendingRecord, record)) {
-        _pendingRecord = null;
+      if (writeSucceeded && identical(_pendingHistory, history)) {
+        _pendingHistory = null;
       }
     });
   }
 
-  Future<bool> _writeSafely(PersistedSessionRecord record) async {
+  Future<bool> _writeSafely(List<PersistedSessionRecord> history) async {
     try {
-      await _store.write(jsonEncode(record.toJson()));
+      await _store.write(
+        jsonEncode(<String, dynamic>{
+          'schemaVersion': _historySchemaVersion,
+          'records': history.map((record) => record.toJson()).toList(),
+        }),
+      );
       return true;
     } catch (error) {
       log('Faro: Failed to persist session state: $error');
@@ -234,6 +266,30 @@ class SessionPersistence {
     } catch (error) {
       log('Faro: Failed to clear persisted session state: $error');
     }
+  }
+
+  List<PersistedSessionRecord> _decodeHistory(Map<String, dynamic> json) {
+    if (json['schemaVersion'] == PersistedSessionRecord.schemaVersion) {
+      return <PersistedSessionRecord>[PersistedSessionRecord.fromJson(json)];
+    }
+    if (json['schemaVersion'] != _historySchemaVersion) {
+      throw const FormatException('Unsupported session schema version');
+    }
+
+    final encodedRecords = json['records'];
+    if (encodedRecords is! List) {
+      throw const FormatException('Session history must contain records');
+    }
+    final records = encodedRecords.map((encodedRecord) {
+      if (encodedRecord is! Map<String, dynamic>) {
+        throw const FormatException('Session history record must be an object');
+      }
+      return PersistedSessionRecord.fromJson(encodedRecord);
+    }).toList();
+    if (records.length <= _maxHistoryLength) {
+      return records;
+    }
+    return records.sublist(records.length - _maxHistoryLength);
   }
 }
 

--- a/lib/src/transport/faro_transport.dart
+++ b/lib/src/transport/faro_transport.dart
@@ -58,6 +58,19 @@ class FaroTransport extends BaseTransport {
 
   @override
   Future<void> send(Map<String, dynamic> payloadJson) async {
+    await _send(payloadJson, processSessionInvalidation: true);
+  }
+
+  /// Sends historical telemetry without applying receiver session
+  /// invalidation to the live session.
+  Future<void> sendHistorical(Map<String, dynamic> payloadJson) async {
+    await _send(payloadJson, processSessionInvalidation: false);
+  }
+
+  Future<void> _send(
+    Map<String, dynamic> payloadJson, {
+    required bool processSessionInvalidation,
+  }) async {
     if (Faro().enableDataCollection == false) {
       log('Data collection is disabled. Skipping sending data.');
       return;
@@ -93,6 +106,7 @@ class FaroTransport extends BaseTransport {
       }
 
       if (response != null &&
+          processSessionInvalidation &&
           sentSessionId != null &&
           response.statusCode == _accepted &&
           _headerValue(response.headers, _sessionStatusHeader) ==

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -641,6 +641,35 @@ java.lang.NullPointerException: test crash
       verifyNever(() => mockBatchTransport.addExceptions(any()));
     });
 
+    test('iOS crash metadata uses Faro session attribute values', () async {
+      Faro().iosPlatformResolver = () => true;
+      Faro().androidPlatformResolver = () => false;
+      final recoveredSession = PersistedSessionRecord(
+        currentSessionId: 'crashed-session',
+        previousSessionId: 'older-session',
+        startedAt: DateTime.utc(2026, 8, 14, 12),
+        lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
+        isSampled: true,
+      );
+
+      await Faro().enableCrashReporter(
+        app: App(name: appName, version: appVersion, environment: appEnv),
+        apiKey: apiKey,
+        collectorUrl: 'https://some-url.com',
+        recoveredSession: recoveredSession,
+      );
+
+      final config =
+          verify(
+                () => mockFaroNativeMethods.enableCrashReporter(captureAny()),
+              ).captured.single
+              as Map<String, dynamic>;
+      expect(
+        config['session']['attributes'],
+        containsPair('isSampled', 'true'),
+      );
+    });
+
     test('recovered crash from an unsampled session is not sent', () async {
       final recoveredSession = PersistedSessionRecord(
         currentSessionId: 'unsampled-session',
@@ -685,27 +714,55 @@ java.lang.NullPointerException: test crash
       verifyNever(() => mockFaroTransport.sendHistorical(any()));
     });
 
-    test('multiple recovered crashes are sent independently', () async {
-      final recoveredSession = PersistedSessionRecord(
-        currentSessionId: 'crashed-session',
+    test('multiple recovered crashes use their matching sessions', () async {
+      final firstSession = PersistedSessionRecord(
+        currentSessionId: 'first-session',
         previousSessionId: null,
         startedAt: DateTime.utc(2026, 8, 14, 12),
         lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
         isSampled: true,
       );
+      final secondSession = PersistedSessionRecord(
+        currentSessionId: 'second-session',
+        previousSessionId: 'first-session',
+        startedAt: DateTime.utc(2026, 8, 14, 12, 10),
+        lastActivityAt: DateTime.utc(2026, 8, 14, 12, 15),
+        isSampled: true,
+      );
 
-      await Faro().reportAndroidCrashesForTesting([
-        json.encode({
-          'reason': 'CRASH',
-          'status': 0,
-          'timestamp': '1786710000000',
-        }),
-        json.encode({
-          'reason': 'ANR',
-          'status': 0,
-          'timestamp': '1786710060000',
-        }),
-      ], recoveredSession: recoveredSession);
+      await Faro().reportAndroidCrashesForTesting(
+        [
+          json.encode({
+            'reason': 'CRASH',
+            'status': 0,
+            'timestamp': DateTime.utc(
+              2026,
+              8,
+              14,
+              12,
+              5,
+            ).millisecondsSinceEpoch,
+            'processName': 'com.example.app',
+          }),
+          json.encode({
+            'reason': 'ANR',
+            'status': 0,
+            'timestamp': DateTime.utc(
+              2026,
+              8,
+              14,
+              12,
+              20,
+            ).millisecondsSinceEpoch,
+            'processName': 'com.example.app',
+          }),
+        ],
+        recoveredSessions: <PersistedSessionRecord>[
+          firstSession,
+          secondSession,
+        ],
+        processIdentifier: 'com.example.app',
+      );
 
       final payloads = verify(
         () => mockFaroTransport.sendHistorical(captureAny()),
@@ -716,8 +773,40 @@ java.lang.NullPointerException: test crash
           (payload) =>
               (payload as Map<String, dynamic>)['meta']['session']['id'],
         ),
-        everyElement('crashed-session'),
+        <String>['first-session', 'second-session'],
       );
+    });
+
+    test('recovered crash from another process is ignored', () async {
+      final recoveredSession = PersistedSessionRecord(
+        currentSessionId: 'main-process-session',
+        previousSessionId: null,
+        startedAt: DateTime.utc(2026, 8, 14, 12),
+        lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
+        isSampled: true,
+      );
+
+      await Faro().reportAndroidCrashesForTesting(
+        [
+          json.encode({
+            'reason': 'CRASH',
+            'status': 0,
+            'timestamp': DateTime.utc(
+              2026,
+              8,
+              14,
+              12,
+              5,
+            ).millisecondsSinceEpoch,
+            'processName': 'com.example.app:worker',
+          }),
+        ],
+        recoveredSessions: <PersistedSessionRecord>[recoveredSession],
+        processIdentifier: 'com.example.app',
+      );
+
+      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockBatchTransport.addExceptions(any()));
     });
 
     test('malformed recovered crash does not block later reports', () async {

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -352,18 +352,28 @@ void main() {
 
       test('storage failures fall back to an unlinked session', () async {
         stubRuntimeInfo(ownsPersistence: true);
+        Faro().iosPlatformResolver = () => true;
+        Faro().androidPlatformResolver = () => false;
         Faro().sessionPersistenceFactory = SessionPersistenceFactory(
           applicationSupportDirectory: () =>
               Future<Directory>.error(StateError('storage unavailable')),
         );
 
-        await Faro().init(optionsConfiguration: createConfig());
+        await Faro().init(
+          optionsConfiguration: createConfig(enableCrashReporting: true),
+        );
 
         expect(Faro().meta.session?.id, isNotEmpty);
         expect(
           Faro().meta.session?.attributes?.containsKey('previousSession'),
           isFalse,
         );
+        final config =
+            verify(
+                  () => mockFaroNativeMethods.enableCrashReporter(captureAny()),
+                ).captured.single
+                as Map<String, dynamic>;
+        expect(config['reportPendingCrash'], isTrue);
       });
     });
 

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -103,6 +103,9 @@ void main() {
         () => mockBatchTransport.updatePayloadMeta(any()),
       ).thenAnswer((_) async {});
       when(() => mockFaroTransport.send(any())).thenAnswer((_) async {});
+      when(
+        () => mockFaroTransport.sendHistorical(any()),
+      ).thenAnswer((_) async {});
     });
 
     tearDown(() async {
@@ -512,7 +515,7 @@ void main() {
       expect(capturedException.fatal, isTrue);
     });
 
-    test('native Android crash forwards the captured trace', () {
+    test('native Android crash forwards the captured trace', () async {
       const nativeTrace = '''
 java.lang.NullPointerException: test crash
     at com.example.MainActivity.crash(MainActivity.kt:42)
@@ -527,7 +530,7 @@ java.lang.NullPointerException: test crash
         'processName': 'com.example.app',
       });
 
-      Faro().reportAndroidCrashesForTesting([crashReport]);
+      await Faro().reportAndroidCrashesForTesting([crashReport]);
 
       final capturedException =
           verify(
@@ -538,7 +541,7 @@ java.lang.NullPointerException: test crash
       expect(capturedException.context?['stacktrace'], nativeTrace);
     });
 
-    test('native Android crash accepts the legacy stacktrace key', () {
+    test('native Android crash accepts the legacy stacktrace key', () async {
       const nativeTrace = 'legacy native trace';
       final crashReport = json.encode({
         'reason': 'CRASH',
@@ -550,7 +553,7 @@ java.lang.NullPointerException: test crash
         'processName': 'com.example.app',
       });
 
-      Faro().reportAndroidCrashesForTesting([crashReport]);
+      await Faro().reportAndroidCrashesForTesting([crashReport]);
 
       final capturedException =
           verify(
@@ -560,7 +563,7 @@ java.lang.NullPointerException: test crash
       expect(capturedException.context?['stacktrace'], nativeTrace);
     });
 
-    test('native Android crash keeps the missing trace fallback', () {
+    test('native Android crash keeps the missing trace fallback', () async {
       final crashReport = json.encode({
         'reason': 'CRASH',
         'status': 0,
@@ -570,7 +573,7 @@ java.lang.NullPointerException: test crash
         'processName': 'com.example.app',
       });
 
-      Faro().reportAndroidCrashesForTesting([crashReport]);
+      await Faro().reportAndroidCrashesForTesting([crashReport]);
 
       final capturedException =
           verify(
@@ -578,6 +581,155 @@ java.lang.NullPointerException: test crash
               ).captured.single
               as FaroException;
       expect(capturedException.context?['stacktrace'], 'No stacktrace');
+    });
+
+    test('recovered crash is sent with the crashed session metadata', () async {
+      final currentSessionId = Faro().meta.session?.id;
+      final recoveredSession = PersistedSessionRecord(
+        currentSessionId: 'crashed-session',
+        previousSessionId: 'older-session',
+        startedAt: DateTime.utc(2026, 8, 14, 12),
+        lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
+        isSampled: true,
+      );
+      final crashReport = json.encode({
+        'reason': 'CRASH',
+        'status': 0,
+        'description': 'Native crash',
+        'timestamp': '1786710000000',
+        'importance': 100,
+        'processName': 'com.example.app',
+      });
+
+      await Faro().reportAndroidCrashesForTesting([
+        crashReport,
+      ], recoveredSession: recoveredSession);
+
+      final payload =
+          verify(
+                () => mockFaroTransport.sendHistorical(captureAny()),
+              ).captured.single
+              as Map<String, dynamic>;
+      expect(payload['meta']['session']['id'], 'crashed-session');
+      expect(
+        payload['meta']['session']['attributes'],
+        containsPair('previousSession', 'older-session'),
+      );
+      expect(
+        payload['meta']['session']['attributes'],
+        containsPair('crashedSessionId', 'crashed-session'),
+      );
+      expect(
+        payload['meta']['session']['attributes'],
+        containsPair('isSampled', 'true'),
+      );
+      expect(payload['meta'], isNot(contains('view')));
+      expect(payload['meta'], isNot(contains('user')));
+      expect(payload['meta'], isNot(contains('page')));
+      expect(
+        payload['exceptions'][0]['context']['crashedSessionId'],
+        'crashed-session',
+      );
+      expect(
+        payload['exceptions'][0]['timestamp'],
+        DateTime.fromMillisecondsSinceEpoch(
+          1786710000000,
+          isUtc: true,
+        ).toIso8601String(),
+      );
+      expect(Faro().meta.session?.id, currentSessionId);
+      verifyNever(() => mockBatchTransport.addExceptions(any()));
+    });
+
+    test('recovered crash from an unsampled session is not sent', () async {
+      final recoveredSession = PersistedSessionRecord(
+        currentSessionId: 'unsampled-session',
+        previousSessionId: null,
+        startedAt: DateTime.utc(2026, 8, 14, 12),
+        lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
+        isSampled: false,
+      );
+      final crashReport = json.encode({
+        'reason': 'CRASH',
+        'status': 0,
+        'timestamp': '1786710000000',
+      });
+
+      await Faro().reportAndroidCrashesForTesting([
+        crashReport,
+      ], recoveredSession: recoveredSession);
+
+      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockBatchTransport.addExceptions(any()));
+    });
+
+    test('recovered crash respects disabled data collection', () async {
+      Faro().dataCollectionPolicy = mockDataCollectionPolicy;
+      when(() => mockDataCollectionPolicy.isEnabled).thenReturn(false);
+      final recoveredSession = PersistedSessionRecord(
+        currentSessionId: 'crashed-session',
+        previousSessionId: null,
+        startedAt: DateTime.utc(2026, 8, 14, 12),
+        lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
+        isSampled: true,
+      );
+
+      await Faro().reportAndroidCrashesForTesting([
+        json.encode({
+          'reason': 'CRASH',
+          'status': 0,
+          'timestamp': '1786710000000',
+        }),
+      ], recoveredSession: recoveredSession);
+
+      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+    });
+
+    test('multiple recovered crashes are sent independently', () async {
+      final recoveredSession = PersistedSessionRecord(
+        currentSessionId: 'crashed-session',
+        previousSessionId: null,
+        startedAt: DateTime.utc(2026, 8, 14, 12),
+        lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
+        isSampled: true,
+      );
+
+      await Faro().reportAndroidCrashesForTesting([
+        json.encode({
+          'reason': 'CRASH',
+          'status': 0,
+          'timestamp': '1786710000000',
+        }),
+        json.encode({
+          'reason': 'ANR',
+          'status': 0,
+          'timestamp': '1786710060000',
+        }),
+      ], recoveredSession: recoveredSession);
+
+      final payloads = verify(
+        () => mockFaroTransport.sendHistorical(captureAny()),
+      ).captured;
+      expect(payloads, hasLength(2));
+      expect(
+        payloads.map(
+          (payload) =>
+              (payload as Map<String, dynamic>)['meta']['session']['id'],
+        ),
+        everyElement('crashed-session'),
+      );
+    });
+
+    test('malformed recovered crash does not block later reports', () async {
+      final crashReport = json.encode({
+        'reason': 'CRASH',
+        'status': 0,
+        'timestamp': '1786710000000',
+      });
+
+      await Faro().reportAndroidCrashesForTesting(['not-json', crashReport]);
+
+      verify(() => mockBatchTransport.addExceptions(any())).called(1);
     });
 
     test('send custom measurement', () {

--- a/test/src/session/session_persistence_test.dart
+++ b/test/src/session/session_persistence_test.dart
@@ -49,13 +49,20 @@ void main() {
     );
   }
 
-  test('round-trips only the versioned minimal session record', () async {
+  test('round-trips a versioned history of minimal session records', () async {
     final sut = persistence();
     sut.record(state(), isSampled: true, immediate: true);
     await sut.flush();
 
     final decoded = jsonDecode(await stateFile.readAsString());
     expect((decoded as Map<String, dynamic>).keys, <String>{
+      'schemaVersion',
+      'records',
+    });
+    expect(decoded['schemaVersion'], 2);
+    final records = decoded['records'] as List<dynamic>;
+    expect(records, hasLength(1));
+    expect((records.single as Map<String, dynamic>).keys, <String>{
       'schemaVersion',
       'currentSessionId',
       'previousSessionId',
@@ -68,6 +75,25 @@ void main() {
     expect(loaded?.currentSessionId, 'current-session');
     expect(loaded?.previousSessionId, 'previous-session');
     expect(loaded?.isSampled, isTrue);
+  });
+
+  test('loads a legacy single-record file', () async {
+    await stateFile.writeAsString(
+      jsonEncode(
+        PersistedSessionRecord(
+          currentSessionId: 'legacy-session',
+          previousSessionId: null,
+          startedAt: DateTime.utc(2026, 8, 11, 12),
+          lastActivityAt: DateTime.utc(2026, 8, 11, 12, 5),
+          isSampled: true,
+        ).toJson(),
+      ),
+    );
+
+    final history = await persistence().loadHistory();
+
+    expect(history, hasLength(1));
+    expect(history.single.currentSessionId, 'legacy-session');
   });
 
   test('missing state starts an unlinked session', () async {
@@ -152,6 +178,7 @@ void main() {
       (await sut.load())?.lastActivityAt,
       start.add(const Duration(minutes: 1)),
     );
+    expect(await sut.loadHistory(), hasLength(1));
   });
 
   test('backward clock changes are clamped before persistence', () async {
@@ -192,6 +219,33 @@ void main() {
     expect(loaded?.currentSessionId, 'second');
     expect(loaded?.previousSessionId, 'first');
     expect(loaded?.isSampled, isTrue);
+    expect(
+      (await sut.loadHistory()).map((record) => record.currentSessionId),
+      <String>['first', 'second'],
+    );
+  });
+
+  test('keeps a bounded session history', () async {
+    const maxHistoryLength = 16;
+    final sut = persistence();
+    final start = DateTime.utc(2026, 8, 11, 12);
+    for (var index = 0; index <= maxHistoryLength; index++) {
+      sut.record(
+        state(
+          currentSessionId: 'session-$index',
+          previousSessionId: index == 0 ? null : 'session-${index - 1}',
+          startedAt: start.add(Duration(minutes: index)),
+        ),
+        isSampled: true,
+        immediate: true,
+      );
+    }
+    await sut.flush();
+
+    final history = await sut.loadHistory();
+    expect(history, hasLength(maxHistoryLength));
+    expect(history.first.currentSessionId, 'session-1');
+    expect(history.last.currentSessionId, 'session-$maxHistoryLength');
   });
 
   test('a failed write remains pending for the next flush', () async {

--- a/test/src/transport/faro_transport_test.dart
+++ b/test/src/transport/faro_transport_test.dart
@@ -122,6 +122,26 @@ void main() {
         expect(invalidatedSessionIds, ['session-1']);
       });
 
+      test('historical sends do not invalidate the live session', () async {
+        client = MockClient((request) async {
+          captured.add(request);
+          return http.Response(
+            '',
+            202,
+            headers: {'X-Faro-Session-Status': 'invalid'},
+          );
+        });
+        final invalidatedSessionIds = <String>[];
+
+        await buildTransport(
+          sessionIdResolver: () => 'live-session',
+          onSessionInvalidated: invalidatedSessionIds.add,
+        ).sendHistorical(payload());
+
+        expect(captured, hasLength(1));
+        expect(invalidatedSessionIds, isEmpty);
+      });
+
       test('reports the session id used by the request', () async {
         var currentSessionId = 'session-1';
         client = MockClient((request) async {


### PR DESCRIPTION

Keeps recovered Android crashes, ANRs, and iOS crashes attached to the session that crashed instead of the new session created after restart.

Fixes #151

#### Validation:

- iOS simulator native crash and relaunch: the recovered crash stayed on session `4qXTC2rax8`, while the new session `7JFtFN9cTD` linked back through `previousSession`.

https://github.com/user-attachments/assets/3bc0d251-fe38-4736-b8f6-286c4981701b

Reliable iOS crash transport remains tracked separately in #269.