### PR TITLE
fix(session): emit session_start for every new session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,9 +77,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Session lifecycle events now use `session_start` for every new session.**
   Flutter no longer emits the Web-only `session_extend` event when rotation
   creates a new session. **Expect `session_extend` volume to drop to zero on
-  Flutter.** Dashboards and alerts matching it should match `session_start`
-  and read `meta.session.attributes.previousSession` to identify linked
-  sessions
+  Flutter and `session_start` volume to increase by the same number of rotation
+  events.** Dashboards and alerts matching `session_extend` should match
+  `session_start` and read `meta.session.attributes.previousSession` to
+  identify linked sessions
   ([#316](https://github.com/grafana/faro-flutter-sdk/issues/316)).
 - Filter Android `LOW_MEMORY` exits for service and less important process
   states regardless of whether Android records status `0` or `SIGKILL`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Emit `session_start` whenever Faro creates a session after cold start,
-  expiry, explicit reset, or receiver invalidation. Rotations previously
-  emitted `session_extend` even though they created a new session ID
+- **Session lifecycle events now use `session_start` for every new session.**
+  Sessions created after expiry, explicit reset, or receiver invalidation no
+  longer emit `session_extend`; predecessor linkage remains available through
+  `previousSession`
   ([#316](https://github.com/grafana/faro-flutter-sdk/issues/316)).
 - Filter Android `LOW_MEMORY` exits for service and less important process
   states regardless of whether Android records status `0` or `SIGKILL`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,9 +75,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Session lifecycle events now use `session_start` for every new session.**
-  Sessions created after expiry, explicit reset, or receiver invalidation no
-  longer emit `session_extend`; predecessor linkage remains available through
-  `previousSession`
+  Flutter no longer emits the Web-only `session_extend` event when rotation
+  creates a new session. **Expect `session_extend` volume to drop to zero on
+  Flutter.** Dashboards and alerts matching it should match `session_start`
+  and read `meta.session.attributes.previousSession` to identify linked
+  sessions
   ([#316](https://github.com/grafana/faro-flutter-sdk/issues/316)).
 - Filter Android `LOW_MEMORY` exits for service and less important process
   states regardless of whether Android records status `0` or `SIGKILL`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Emit `session_start` whenever Faro creates a session after cold start,
+  expiry, explicit reset, or receiver invalidation. Rotations previously
+  emitted `session_extend` even though they created a new session ID
+  ([#316](https://github.com/grafana/faro-flutter-sdk/issues/316)).
 - Filter Android `LOW_MEMORY` exits for service and less important process
   states regardless of whether Android records status `0` or `SIGKILL`.
   Foreground, foreground-service, visible, and perceptible exits remain

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -388,10 +388,13 @@ data loss.
 
 **Lifecycle events.** Faro emits an event whenever the session id changes, so you can follow the user journey in Grafana:
 
-| Event           | When                                                                                 |
-| --------------- | ------------------------------------------------------------------------------------ |
-| `session_start` | The initial session or an explicit reset                                              |
-| `session_extend` | A rotation: a new session was auto-created after local expiry or receiver invalidation |
+| Event           | When                                                                                  |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `session_start` | A session is created on cold start, expiry, explicit reset, or receiver invalidation |
+
+Faro does not emit `session_extend` for rotations because each rotation creates
+a new session ID. The new session instead emits `session_start` and links its
+predecessor through `previousSession`.
 
 **Linking rotated sessions.** On rotation, the previous session id is recorded in the `previousSession` session attribute, so backends can link a rotated session back to its predecessor. Existing custom session attributes are preserved across rotation. All telemetry created after a rotation — events, logs, exceptions, and spans — automatically carries the new session id.
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -386,15 +386,12 @@ receiver enforces the same windows server-side and drops telemetry from
 sessions that exceed them, so a longer client-side value would cause silent
 data loss.
 
-**Lifecycle events.** Faro emits an event whenever the session id changes, so you can follow the user journey in Grafana:
-
-| Event           | When                                                                                  |
-| --------------- | ------------------------------------------------------------------------------------- |
-| `session_start` | A session is created on cold start, expiry, explicit reset, or receiver invalidation |
-
-Faro does not emit `session_extend` for rotations because each rotation creates
-a new session ID. The new session instead emits `session_start` and links its
-predecessor through `previousSession`.
+**Lifecycle events.** Faro emits `session_start` whenever it creates a session
+on cold start, expiry, explicit reset, or receiver invalidation.
+`session_extend` is a web-only event that means user activity kept an existing
+session alive, so it does not apply when Flutter rotation creates a new session
+ID. Use `previousSession` rather than the event name to identify linked
+sessions.
 
 **Linking rotated sessions.** On rotation, the previous session id is recorded in the `previousSession` session attribute, so backends can link a rotated session back to its predecessor. Existing custom session attributes are preserved across rotation. All telemetry created after a rotation — events, logs, exceptions, and spans — automatically carries the new session id.
 

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -368,15 +368,10 @@ class Faro {
       _restartSamplingForNewSession();
     }
 
-    final eventName = switch (trigger) {
-      SessionStartTrigger.initial ||
-      SessionStartTrigger.explicitReset => 'session_start',
-      SessionStartTrigger.rotation => 'session_extend',
-    };
     // Lifecycle events bypass user-action buffering and never count as
     // session activity (SDK-emitted, not app/user behavior).
     _telemetryRouter.ingest(
-      TelemetryItem.fromEvent(Event(eventName)),
+      TelemetryItem.fromEvent(Event('session_start')),
       skipBuffer: true,
       activity: SessionActivityKind.passive,
     );

--- a/lib/src/session/session_manager.dart
+++ b/lib/src/session/session_manager.dart
@@ -19,7 +19,7 @@ enum SessionStartTrigger {
 
 /// Called when a new session becomes active.
 ///
-/// [trigger] identifies whether this is the initial session or a rotation.
+/// [trigger] identifies why the session became active.
 typedef SessionChangedListener =
     void Function({
       required String currentId,

--- a/test/src/session/session_manager_test.dart
+++ b/test/src/session/session_manager_test.dart
@@ -325,7 +325,7 @@ void main() {
     test('ignores re-entrant calls during rotation', () {
       final manager = createManager();
       // Set the hook after start()/reset so it only fires on rotation.
-      // Simulates the rotation emitting a session_extend event that
+      // Simulates the rotation emitting a session_start event that
       // flows back through the ingestion path.
       observer.onStarted = () =>
           manager.checkSession(activity: SessionActivityKind.meaningful);
@@ -373,7 +373,7 @@ void main() {
         final manager = createManager();
         final sessionStart = now;
 
-        // SDK lifecycle events (e.g. session_extend) never move
+        // SDK lifecycle events (e.g. session_start) never move
         // lastActivity forward.
         now = now.add(const Duration(minutes: 5));
         manager.checkSession(activity: SessionActivityKind.passive);

--- a/test/src/session/session_rotation_integration_test.dart
+++ b/test/src/session/session_rotation_integration_test.dart
@@ -239,6 +239,7 @@ void main() {
     test('rotates the session when inactivity reaches 15 minutes', () async {
       await initFaro();
       final initialSessionId = Faro().meta.session?.id;
+      clearInteractions(mockBatchTransport);
 
       now = now.add(const Duration(minutes: 15));
       Faro().pushEvent('some_event');
@@ -246,6 +247,7 @@ void main() {
       final session = Faro().meta.session;
       expect(session?.id, isNot(initialSessionId));
       expect(session?.attributes?['previousSession'], initialSessionId);
+      expect(capturedEventNames(), contains('session_start'));
     });
 
     test('rotates the session when lifetime reaches 4 hours', () async {
@@ -258,6 +260,7 @@ void main() {
         Faro().setViewMeta(name: 'view_$i');
       }
       expect(Faro().meta.session?.id, initialSessionId);
+      clearInteractions(mockBatchTransport);
 
       now = now.add(const Duration(minutes: 10));
       Faro().setViewMeta(name: 'after_lifetime');
@@ -265,9 +268,10 @@ void main() {
       final session = Faro().meta.session;
       expect(session?.id, isNot(initialSessionId));
       expect(session?.attributes?['previousSession'], initialSessionId);
+      expect(capturedEventNames(), <String>['session_start']);
     });
 
-    test('emits session_extend for the new session and attributes the '
+    test('emits session_start for the new session and attributes the '
         'triggering telemetry to it', () async {
       await initFaro();
       clearInteractions(mockBatchTransport);
@@ -276,7 +280,7 @@ void main() {
       Faro().pushEvent('trigger_event');
 
       // Rotation updates the payload meta first, then emits
-      // session_extend, then the triggering event follows — so both
+      // session_start, then the triggering event follows — so both
       // events belong to the new session.
       final rotatedSessionId = Faro().meta.session?.id;
       verifyInOrder([
@@ -291,7 +295,7 @@ void main() {
         ),
         () => mockBatchTransport.addEvent(
           any(
-            that: isA<Event>().having((e) => e.name, 'name', 'session_extend'),
+            that: isA<Event>().having((e) => e.name, 'name', 'session_start'),
           ),
         ),
         () => mockBatchTransport.addEvent(
@@ -354,7 +358,7 @@ void main() {
               that: isA<Event>().having(
                 (event) => event.name,
                 'name',
-                'session_extend',
+                'session_start',
               ),
             ),
           ),
@@ -407,7 +411,7 @@ void main() {
         () => mockBatchTransport.updatePayloadMeta(any()),
         () => mockBatchTransport.addEvent(
           any(
-            that: isA<Event>().having((e) => e.name, 'name', 'session_extend'),
+            that: isA<Event>().having((e) => e.name, 'name', 'session_start'),
           ),
         ),
         () => mockBatchTransport.addLog(any()),
@@ -444,11 +448,7 @@ void main() {
           () => mockBatchTransport.updatePayloadMeta(any()),
           () => mockBatchTransport.addEvent(
             any(
-              that: isA<Event>().having(
-                (e) => e.name,
-                'name',
-                'session_extend',
-              ),
+              that: isA<Event>().having((e) => e.name, 'name', 'session_start'),
             ),
           ),
           () => mockBatchTransport.addMeasurement(any()),
@@ -527,7 +527,7 @@ void main() {
               that: isA<Event>().having(
                 (event) => event.name,
                 'name',
-                'session_extend',
+                'session_start',
               ),
             ),
           ),
@@ -593,17 +593,19 @@ void main() {
       expect(session?.attributes?['previousSession'], initialSessionId);
     });
 
-    test('emits a single session_extend on rotation', () async {
+    test('emits a single session_start on rotation', () async {
       await initFaro();
       clearInteractions(mockBatchTransport);
 
       now = now.add(const Duration(minutes: 16));
       Faro().pushEvent('trigger_event');
 
-      final sessionExtends = capturedEventNames()
-          .where((name) => name == 'session_extend')
+      final eventNames = capturedEventNames();
+      final sessionStarts = eventNames
+          .where((name) => name == 'session_start')
           .length;
-      expect(sessionExtends, 1);
+      expect(sessionStarts, 1);
+      expect(eventNames, isNot(contains('session_extend')));
     });
   });
 }

--- a/test/src/session/session_rotation_integration_test.dart
+++ b/test/src/session/session_rotation_integration_test.dart
@@ -247,7 +247,7 @@ void main() {
       final session = Faro().meta.session;
       expect(session?.id, isNot(initialSessionId));
       expect(session?.attributes?['previousSession'], initialSessionId);
-      expect(capturedEventNames(), contains('session_start'));
+      expect(capturedEventNames(), <String>['session_start', 'some_event']);
     });
 
     test('rotates the session when lifetime reaches 4 hours', () async {

--- a/test/src/user_actions/telemetry_router_test.dart
+++ b/test/src/user_actions/telemetry_router_test.dart
@@ -151,7 +151,7 @@ void main() {
     });
 
     test('forwards SessionActivityKind.passive', () {
-      final item = TelemetryItem.fromEvent(Event('session_extend'));
+      final item = TelemetryItem.fromEvent(Event('session_start'));
       final router = buildRouter();
 
       router.ingest(


### PR DESCRIPTION
## Description

Emit `session_start` whenever Faro creates a new session. The Faro lifecycle convention reserves `session_extend` for Web activity that keeps an existing session alive, while Flutter rotation creates a new session ID.

Rotated sessions continue to link to their predecessor through `meta.session.attributes.previousSession`. Dashboards and alerts matching Flutter `session_extend` events should move to `session_start` and use that attribute to identify linked sessions.

## Related Issue(s)

Fixes #316

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Chore / Housekeeping

## Checklist

- [x] Documentation updated
- [x] Tests added or updated
- [x] CHANGELOG updated under Unreleased

## Validation

- `dart tool/pre_release_check.dart`

## Additional Notes

The Web SDK currently emits `session_extend` for some linked new sessions. Aligning that behavior is outside this Flutter fix.
