### PR TITLE
fix(runtime): classify Android headless engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Accurate Android runtime metadata.** Root Flutter engines that never attach
   to an Activity now report `dart_isolate_name=headless` instead of `main`.
-  Activity-backed engines remain `main`, and session-persistence ownership is
-  unchanged
+  Activity-backed engines remain `main`; dashboards filtering only for
+  `dart_isolate_name=main` no longer include Android background engines.
+  Pre-warmed UI engines can opt into `FaroEngineRole.foreground`, and
+  session-persistence ownership is unchanged
   ([#333](https://github.com/grafana/faro-flutter-sdk/issues/333)).
 - Filter Android `LOW_MEMORY` exits for service and less important process
   states regardless of whether Android records status `0` or `SIGKILL`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Accurate Android runtime metadata.** Root Flutter engines that never attach
+  to an Activity now report `dart_isolate_name=headless` instead of `main`.
+  Activity-backed engines remain `main`, and session-persistence ownership is
+  unchanged
+  ([#333](https://github.com/grafana/faro-flutter-sdk/issues/333)).
 - Filter Android `LOW_MEMORY` exits for service and less important process
   states regardless of whether Android records status `0` or `SIGKILL`.
   Foreground, foreground-service, visible, and perceptible exits remain

--- a/android/src/main/java/com/grafana/faro/FaroPlugin.java
+++ b/android/src/main/java/com/grafana/faro/FaroPlugin.java
@@ -63,6 +63,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
     private @Nullable Window window;
     private @Nullable Application application;
     private boolean ownsSessionPersistence = false;
+    // Once attached, this engine remains the main engine across Activity detaches.
     private final EngineRoleTracker engineRoleTracker = new EngineRoleTracker();
 
     private FlutterPluginBinding pluginBinding;
@@ -236,7 +237,6 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
     @Override
     public void onDetachedFromActivityForConfigChanges() {
         Log.d(TAG, "detached from Activity (config change)");
-        engineRoleTracker.onActivityDetached();
         
         // Set isActivityResumed to false during config changes
         isActivityResumed = false;
@@ -307,7 +307,6 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
     @Override
     public void onDetachedFromActivity() {
         Log.d(TAG, "detached from Activity");
-        engineRoleTracker.onActivityDetached();
         
         // Stop ANR tracking if running
         if (isAnrTrackerRunning && anrTracker != null) {
@@ -575,10 +574,6 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
 
         void onActivityAttached() {
             hasAttachedToActivity = true;
-        }
-
-        void onActivityDetached() {
-            // Keep the main role stable across configuration changes and detaches.
         }
 
         String getEngineRole() {

--- a/android/src/main/java/com/grafana/faro/FaroPlugin.java
+++ b/android/src/main/java/com/grafana/faro/FaroPlugin.java
@@ -63,6 +63,8 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
     private @Nullable Window window;
     private @Nullable Application application;
     private boolean ownsSessionPersistence = false;
+    // Engine role is stable across Activity detach/reattach cycles.
+    private boolean hasAttachedToActivity = false;
 
     private FlutterPluginBinding pluginBinding;
     private long lastFrameTimeNanos = 0;
@@ -186,6 +188,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
         Log.d(TAG, "attached to Activity");
         
         if (binding.getActivity() != null) {
+            hasAttachedToActivity = true;
             activity = new WeakReference<>(binding.getActivity());
             window = activity.get().getWindow();
             // Update application context from activity if needed
@@ -264,6 +267,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
         Log.d(TAG, "reattached to Activity");
         
         if (binding.getActivity() != null) {
+            hasAttachedToActivity = true;
             activity = new WeakReference<>(binding.getActivity());
             window = activity.get().getWindow();
             
@@ -412,6 +416,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
                         Map<String, Object> runtimeInfo = new HashMap<>();
                         runtimeInfo.put("processIdentifier", processIdentifier);
                         runtimeInfo.put("ownsSessionPersistence", ownsSessionPersistence);
+                        runtimeInfo.put("engineRole", getEngineRole(hasAttachedToActivity));
                         result.success(runtimeInfo);
                         break;
                     default:
@@ -561,6 +566,10 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
             && SESSION_PERSISTENCE_OWNER_CLAIMED.compareAndSet(false, true)) {
             ownsSessionPersistence = true;
         }
+    }
+
+    static String getEngineRole(boolean isAttachedToActivity) {
+        return isAttachedToActivity ? "ui" : "headless";
     }
 
     private void handleFrameDrop() {

--- a/android/src/main/java/com/grafana/faro/FaroPlugin.java
+++ b/android/src/main/java/com/grafana/faro/FaroPlugin.java
@@ -63,8 +63,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
     private @Nullable Window window;
     private @Nullable Application application;
     private boolean ownsSessionPersistence = false;
-    // Engine role is stable across Activity detach/reattach cycles.
-    private boolean hasAttachedToActivity = false;
+    private final EngineRoleTracker engineRoleTracker = new EngineRoleTracker();
 
     private FlutterPluginBinding pluginBinding;
     private long lastFrameTimeNanos = 0;
@@ -188,7 +187,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
         Log.d(TAG, "attached to Activity");
         
         if (binding.getActivity() != null) {
-            hasAttachedToActivity = true;
+            engineRoleTracker.onActivityAttached();
             activity = new WeakReference<>(binding.getActivity());
             window = activity.get().getWindow();
             // Update application context from activity if needed
@@ -237,6 +236,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
     @Override
     public void onDetachedFromActivityForConfigChanges() {
         Log.d(TAG, "detached from Activity (config change)");
+        engineRoleTracker.onActivityDetached();
         
         // Set isActivityResumed to false during config changes
         isActivityResumed = false;
@@ -267,7 +267,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
         Log.d(TAG, "reattached to Activity");
         
         if (binding.getActivity() != null) {
-            hasAttachedToActivity = true;
+            engineRoleTracker.onActivityAttached();
             activity = new WeakReference<>(binding.getActivity());
             window = activity.get().getWindow();
             
@@ -307,6 +307,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
     @Override
     public void onDetachedFromActivity() {
         Log.d(TAG, "detached from Activity");
+        engineRoleTracker.onActivityDetached();
         
         // Stop ANR tracking if running
         if (isAnrTrackerRunning && anrTracker != null) {
@@ -416,7 +417,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
                         Map<String, Object> runtimeInfo = new HashMap<>();
                         runtimeInfo.put("processIdentifier", processIdentifier);
                         runtimeInfo.put("ownsSessionPersistence", ownsSessionPersistence);
-                        runtimeInfo.put("engineRole", getEngineRole(hasAttachedToActivity));
+                        runtimeInfo.put("engineRole", engineRoleTracker.getEngineRole());
                         result.success(runtimeInfo);
                         break;
                     default:
@@ -568,8 +569,21 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
         }
     }
 
-    static String getEngineRole(boolean isAttachedToActivity) {
-        return isAttachedToActivity ? "ui" : "headless";
+    /** Tracks whether this Flutter engine has ever been attached to an Activity. */
+    static final class EngineRoleTracker {
+        private boolean hasAttachedToActivity = false;
+
+        void onActivityAttached() {
+            hasAttachedToActivity = true;
+        }
+
+        void onActivityDetached() {
+            // Keep the main role stable across configuration changes and detaches.
+        }
+
+        String getEngineRole() {
+            return hasAttachedToActivity ? "main" : "headless";
+        }
     }
 
     private void handleFrameDrop() {

--- a/android/src/test/java/com/grafana/faro/FaroPluginTest.java
+++ b/android/src/test/java/com/grafana/faro/FaroPluginTest.java
@@ -13,8 +13,5 @@ public class FaroPluginTest {
 
         tracker.onActivityAttached();
         assertEquals("main", tracker.getEngineRole());
-
-        tracker.onActivityDetached();
-        assertEquals("main", tracker.getEngineRole());
     }
 }

--- a/android/src/test/java/com/grafana/faro/FaroPluginTest.java
+++ b/android/src/test/java/com/grafana/faro/FaroPluginTest.java
@@ -6,12 +6,15 @@ import org.junit.Test;
 
 public class FaroPluginTest {
     @Test
-    public void attachedActivityIdentifiesUiEngine() {
-        assertEquals("ui", FaroPlugin.getEngineRole(true));
-    }
+    public void engineRoleTracksActivityAttachment() {
+        FaroPlugin.EngineRoleTracker tracker = new FaroPlugin.EngineRoleTracker();
 
-    @Test
-    public void missingActivityIdentifiesHeadlessEngine() {
-        assertEquals("headless", FaroPlugin.getEngineRole(false));
+        assertEquals("headless", tracker.getEngineRole());
+
+        tracker.onActivityAttached();
+        assertEquals("main", tracker.getEngineRole());
+
+        tracker.onActivityDetached();
+        assertEquals("main", tracker.getEngineRole());
     }
 }

--- a/android/src/test/java/com/grafana/faro/FaroPluginTest.java
+++ b/android/src/test/java/com/grafana/faro/FaroPluginTest.java
@@ -1,0 +1,17 @@
+package com.grafana.faro;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class FaroPluginTest {
+    @Test
+    public void attachedActivityIdentifiesUiEngine() {
+        assertEquals("ui", FaroPlugin.getEngineRole(true));
+    }
+
+    @Test
+    public void missingActivityIdentifiesHeadlessEngine() {
+        assertEquals("headless", FaroPlugin.getEngineRole(false));
+    }
+}

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -435,9 +435,13 @@ With automatic detection, iOS root isolates continue to use `main`.
 
 If an Android app pre-warms its foreground `FlutterEngine` and initializes
 Faro before attaching that engine to an Activity, set
-`engineRole: FaroEngineRole.foreground` in `FaroConfig`. Configure background
-entrypoints separately; reusing the foreground override in a headless engine
-would label that engine as `main`.
+`engineRole: FaroEngineRole.foreground` in `FaroConfig`. This records
+`dart_isolate_name=main`. Android or iOS background entrypoints can set
+`FaroEngineRole.headless` to record `dart_isolate_name=headless` when automatic
+detection is unavailable or insufficient. Overrides apply only to the root
+isolate and are not checked against the native signal, so configure each
+entrypoint separately. Reusing either override for an engine with the opposite
+role would mislabel that engine.
 
 **What counts as activity.** Faro classifies telemetry as meaningful work or
 passive telemetry. Every item checks session expiry before it is attributed,

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -427,7 +427,11 @@ background isolates cannot concurrently update that record. Ownership is not
 transferred to an already-running secondary engine if the owner detaches; that
 engine keeps its in-memory session until it initializes again. When native
 process identity is available, telemetry includes `process_name` and
-`dart_isolate_name` session attributes for correlation.
+`dart_isolate_name` session attributes for correlation. An Android engine that
+has attached to an Activity is identified as `main`; a root engine that has
+never attached to an Activity is identified as `headless`. Secondary Dart
+isolates use their debug name when available and otherwise use `background`.
+iOS root isolates continue to use `main`.
 
 **What counts as activity.** Faro classifies telemetry as meaningful work or
 passive telemetry. Every item checks session expiry before it is attributed,

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -431,7 +431,13 @@ process identity is available, telemetry includes `process_name` and
 has attached to an Activity is identified as `main`; a root engine that has
 never attached to an Activity is identified as `headless`. Secondary Dart
 isolates use their debug name when available and otherwise use `background`.
-iOS root isolates continue to use `main`.
+With automatic detection, iOS root isolates continue to use `main`.
+
+If an Android app pre-warms its foreground `FlutterEngine` and initializes
+Faro before attaching that engine to an Activity, set
+`engineRole: FaroEngineRole.foreground` in `FaroConfig`. Configure background
+entrypoints separately; reusing the foreground override in a headless engine
+would label that engine as `main`.
 
 **What counts as activity.** Faro classifies telemetry as meaningful work or
 passive telemetry. Every item checks session expiry before it is attributed,

--- a/lib/src/configurations/faro_config.dart
+++ b/lib/src/configurations/faro_config.dart
@@ -4,6 +4,19 @@ import 'package:faro/src/models/faro_user.dart';
 import 'package:faro/src/tracing/span_exception_options.dart';
 import 'package:faro/src/transport/faro_transport.dart';
 
+/// Identifies the role of the Flutter engine that initializes Faro.
+enum FaroEngineRole {
+  /// Infer the role from whether the Android engine has attached to an
+  /// Activity. iOS root isolates continue to use `main`.
+  automatic,
+
+  /// Treat this engine as the application's foreground engine.
+  foreground,
+
+  /// Treat this engine as a background or headless engine.
+  headless,
+}
+
 class FaroConfig {
   FaroConfig({
     required this.appName,
@@ -29,6 +42,7 @@ class FaroConfig {
     this.initialUser,
     this.persistUser = true,
     this.persistSession = true,
+    this.engineRole = FaroEngineRole.automatic,
     this.sampling,
     this.spanExceptionOptions = SpanExceptionOptions.defaults,
   }) : assert(appName.isNotEmpty, 'appName cannot be empty'),
@@ -97,6 +111,15 @@ class FaroConfig {
   /// contains only session identity, timing, sampling, and schema information.
   /// It never resumes the same live session across a process start.
   final bool persistSession;
+
+  /// The role of the Flutter engine that initializes Faro.
+  ///
+  /// The default, [FaroEngineRole.automatic], identifies Android engines that
+  /// have attached to an Activity as `main` and unattached engines as
+  /// `headless`. Set this to [FaroEngineRole.foreground] when a pre-warmed UI
+  /// engine initializes Faro before it attaches to an Activity. Use
+  /// [FaroEngineRole.headless] only when the engine's role is known explicitly.
+  final FaroEngineRole engineRole;
 
   /// Session sampling configuration.
   ///

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -405,6 +405,7 @@ class Faro {
 
     final runtimeInfo = await SessionRuntimeInfoProvider(
       nativeMethods: nativeChannel,
+      engineRole: options.engineRole,
     ).getRuntimeInfo();
     if (runtimeInfo == null) {
       return null;

--- a/lib/src/session/session_runtime_info.dart
+++ b/lib/src/session/session_runtime_info.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 import 'dart:isolate';
 import 'dart:ui' show RootIsolateToken;
 
+import 'package:faro/src/configurations/faro_config.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
 
 class SessionRuntimeInfo {
@@ -21,11 +22,14 @@ class SessionRuntimeInfoProvider {
   SessionRuntimeInfoProvider({
     required FaroNativeMethods nativeMethods,
     bool Function()? isRootIsolate,
+    FaroEngineRole engineRole = FaroEngineRole.automatic,
   }) : _nativeMethods = nativeMethods,
+       _engineRole = engineRole,
        _isRootIsolate =
            isRootIsolate ?? (() => RootIsolateToken.instance != null);
 
   final FaroNativeMethods _nativeMethods;
+  final FaroEngineRole _engineRole;
   final bool Function() _isRootIsolate;
 
   Future<SessionRuntimeInfo?> getRuntimeInfo() async {
@@ -43,11 +47,13 @@ class SessionRuntimeInfoProvider {
       }
 
       final debugName = Isolate.current.debugName;
-      final isHeadlessEngine = nativeInfo?['engineRole'] == 'headless';
       final isolateIdentifier = isRootIsolate
-          ? isHeadlessEngine
-                ? 'headless'
-                : 'main'
+          ? switch (_engineRole) {
+              FaroEngineRole.automatic =>
+                nativeInfo?['engineRole'] == 'headless' ? 'headless' : 'main',
+              FaroEngineRole.foreground => 'main',
+              FaroEngineRole.headless => 'headless',
+            }
           : debugName != null && debugName != 'main'
           ? debugName
           : 'background';

--- a/lib/src/session/session_runtime_info.dart
+++ b/lib/src/session/session_runtime_info.dart
@@ -43,8 +43,11 @@ class SessionRuntimeInfoProvider {
       }
 
       final debugName = Isolate.current.debugName;
+      final isHeadlessEngine = nativeInfo?['engineRole'] == 'headless';
       final isolateIdentifier = isRootIsolate
-          ? 'main'
+          ? isHeadlessEngine
+                ? 'headless'
+                : 'main'
           : debugName != null && debugName != 'main'
           ? debugName
           : 'background';

--- a/test/src/configurations/faro_config_test.dart
+++ b/test/src/configurations/faro_config_test.dart
@@ -11,6 +11,7 @@ void main() {
       String collectorUrl = 'https://example.com',
       Sampling? sampling,
       bool persistSession = true,
+      FaroEngineRole engineRole = FaroEngineRole.automatic,
     }) {
       return FaroConfig(
         appName: appName,
@@ -19,6 +20,7 @@ void main() {
         collectorUrl: collectorUrl,
         sampling: sampling,
         persistSession: persistSession,
+        engineRole: engineRole,
       );
     }
 
@@ -53,6 +55,19 @@ void main() {
 
       test('can be disabled', () {
         expect(createConfig(persistSession: false).persistSession, isFalse);
+      });
+    });
+
+    group('engine role:', () {
+      test('is inferred automatically by default', () {
+        expect(createConfig().engineRole, FaroEngineRole.automatic);
+      });
+
+      test('can identify a pre-warmed foreground engine', () {
+        expect(
+          createConfig(engineRole: FaroEngineRole.foreground).engineRole,
+          FaroEngineRole.foreground,
+        );
       });
     });
   });

--- a/test/src/session/session_runtime_info_test.dart
+++ b/test/src/session/session_runtime_info_test.dart
@@ -132,6 +132,7 @@ void main() {
     final provider = SessionRuntimeInfoProvider(
       nativeMethods: nativeMethods,
       isRootIsolate: () => false,
+      engineRole: FaroEngineRole.headless,
     );
 
     final info = await provider.getRuntimeInfo();

--- a/test/src/session/session_runtime_info_test.dart
+++ b/test/src/session/session_runtime_info_test.dart
@@ -1,3 +1,4 @@
+import 'package:faro/src/configurations/faro_config.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
 import 'package:faro/src/session/session_runtime_info.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -19,7 +20,7 @@ void main() {
       (_) async => <String, dynamic>{
         'processIdentifier': 'com.example.app',
         'ownsSessionPersistence': true,
-        'engineRole': 'ui',
+        'engineRole': 'main',
       },
     );
     final provider = SessionRuntimeInfoProvider(
@@ -33,6 +34,48 @@ void main() {
     expect(info?.isolateIdentifier, 'main');
     expect(info?.ownsSessionPersistence, isTrue);
   });
+
+  test('allows a pre-warmed UI engine to override native inference', () async {
+    when(
+      () => nativeMethods.getSessionRuntimeInfo(claimSessionPersistence: true),
+    ).thenAnswer(
+      (_) async => <String, dynamic>{
+        'processIdentifier': 'com.example.app',
+        'ownsSessionPersistence': true,
+        'engineRole': 'headless',
+      },
+    );
+    final provider = SessionRuntimeInfoProvider(
+      nativeMethods: nativeMethods,
+      isRootIsolate: () => true,
+      engineRole: FaroEngineRole.foreground,
+    );
+
+    expect((await provider.getRuntimeInfo())?.isolateIdentifier, 'main');
+  });
+
+  test(
+    'allows an explicit headless role to override native inference',
+    () async {
+      when(
+        () =>
+            nativeMethods.getSessionRuntimeInfo(claimSessionPersistence: true),
+      ).thenAnswer(
+        (_) async => <String, dynamic>{
+          'processIdentifier': 'com.example.app',
+          'ownsSessionPersistence': true,
+          'engineRole': 'main',
+        },
+      );
+      final provider = SessionRuntimeInfoProvider(
+        nativeMethods: nativeMethods,
+        isRootIsolate: () => true,
+        engineRole: FaroEngineRole.headless,
+      );
+
+      expect((await provider.getRuntimeInfo())?.isolateIdentifier, 'headless');
+    },
+  );
 
   test('identifies a root isolate in a headless Android engine', () async {
     when(
@@ -83,6 +126,7 @@ void main() {
       (_) async => <String, dynamic>{
         'processIdentifier': 'com.example.app',
         'ownsSessionPersistence': true,
+        'engineRole': 'headless',
       },
     );
     final provider = SessionRuntimeInfoProvider(

--- a/test/src/session/session_runtime_info_test.dart
+++ b/test/src/session/session_runtime_info_test.dart
@@ -55,22 +55,26 @@ void main() {
     expect(info?.ownsSessionPersistence, isTrue);
   });
 
-  test('keeps iOS root classification when engine role is unavailable', () async {
-    when(
-      () => nativeMethods.getSessionRuntimeInfo(claimSessionPersistence: true),
-    ).thenAnswer(
-      (_) async => <String, dynamic>{
-        'processIdentifier': 'com.example.app',
-        'ownsSessionPersistence': true,
-      },
-    );
-    final provider = SessionRuntimeInfoProvider(
-      nativeMethods: nativeMethods,
-      isRootIsolate: () => true,
-    );
+  test(
+    'keeps iOS root classification when engine role is unavailable',
+    () async {
+      when(
+        () =>
+            nativeMethods.getSessionRuntimeInfo(claimSessionPersistence: true),
+      ).thenAnswer(
+        (_) async => <String, dynamic>{
+          'processIdentifier': 'com.example.app',
+          'ownsSessionPersistence': true,
+        },
+      );
+      final provider = SessionRuntimeInfoProvider(
+        nativeMethods: nativeMethods,
+        isRootIsolate: () => true,
+      );
 
-    expect((await provider.getRuntimeInfo())?.isolateIdentifier, 'main');
-  });
+      expect((await provider.getRuntimeInfo())?.isolateIdentifier, 'main');
+    },
+  );
 
   test('secondary isolates keep identity but cannot persist', () async {
     when(

--- a/test/src/session/session_runtime_info_test.dart
+++ b/test/src/session/session_runtime_info_test.dart
@@ -19,6 +19,7 @@ void main() {
       (_) async => <String, dynamic>{
         'processIdentifier': 'com.example.app',
         'ownsSessionPersistence': true,
+        'engineRole': 'ui',
       },
     );
     final provider = SessionRuntimeInfoProvider(
@@ -31,6 +32,44 @@ void main() {
     expect(info?.processIdentifier, 'com.example.app');
     expect(info?.isolateIdentifier, 'main');
     expect(info?.ownsSessionPersistence, isTrue);
+  });
+
+  test('identifies a root isolate in a headless Android engine', () async {
+    when(
+      () => nativeMethods.getSessionRuntimeInfo(claimSessionPersistence: true),
+    ).thenAnswer(
+      (_) async => <String, dynamic>{
+        'processIdentifier': 'com.example.app',
+        'ownsSessionPersistence': true,
+        'engineRole': 'headless',
+      },
+    );
+    final provider = SessionRuntimeInfoProvider(
+      nativeMethods: nativeMethods,
+      isRootIsolate: () => true,
+    );
+
+    final info = await provider.getRuntimeInfo();
+
+    expect(info?.isolateIdentifier, 'headless');
+    expect(info?.ownsSessionPersistence, isTrue);
+  });
+
+  test('keeps iOS root classification when engine role is unavailable', () async {
+    when(
+      () => nativeMethods.getSessionRuntimeInfo(claimSessionPersistence: true),
+    ).thenAnswer(
+      (_) async => <String, dynamic>{
+        'processIdentifier': 'com.example.app',
+        'ownsSessionPersistence': true,
+      },
+    );
+    final provider = SessionRuntimeInfoProvider(
+      nativeMethods: nativeMethods,
+      isRootIsolate: () => true,
+    );
+
+    expect((await provider.getRuntimeInfo())?.isolateIdentifier, 'main');
   });
 
   test('secondary isolates keep identity but cannot persist', () async {


### PR DESCRIPTION
## Description

Android headless Flutter engines now report `dart_isolate_name=headless` instead of being mistaken for `main`. Activity-backed engines remain `main`, and secondary isolates keep their existing names. Session persistence ownership is unchanged.

## Related Issue(s)

Fixes #333
Related to #6

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Testing

- `dart tool/pre_release_check.dart`
- Android example debug APK build

## Screenshots

Not applicable. This only changes session metadata.

## Additional Notes

Android classifies the engine by whether it has ever attached to an Activity, so the role stays stable across Activity detach and reattach cycles. iOS behavior is unchanged.