### PR TITLE
feat(session): resample automatic rotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Automatic session rotations now re-evaluate sampling.** Sessions created
+  after inactivity, maximum lifetime, or receiver invalidation make an
+  independent sampling decision, matching explicit resets and Faro Web.
+  **Telemetry collection can now start or stop when a session rotates instead
+  of retaining the previous session's decision.**
+  ([#284](https://github.com/grafana/faro-flutter-sdk/issues/284))
 - **BREAKING (behavioral)**: Session inactivity now refreshes only for
   user interactions, view or navigation changes, foreground returns,
   explicit user actions, and spans linked to those actions. Generic telemetry,

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -462,10 +462,9 @@ response. Faro rotates that session immediately. Delayed or duplicate
 responses for an older session are ignored, so they cannot rotate the current
 session again.
 
-> **Sampling note:** the session sampling decision is made once per session.
-> Automatic expiry and receiver invalidation retain the current decision for
-> compatibility. An explicit `resetSession` starts a new sampling window (see
-> [Session Sampling](#session-sampling)).
+> **Sampling note:** every new session makes an independent sampling decision,
+> including sessions created by automatic expiry, receiver invalidation, or
+> `resetSession` (see [Session Sampling](#session-sampling)).
 
 ---
 
@@ -1320,8 +1319,8 @@ Faro().runApp(
 
 **How it works:**
 
-- The sampling decision is made at initialization and applies until an explicit session reset
-- Automatic expiry and receiver invalidation retain the current decision; [`resetSession`](#session-lifecycle--rotation) evaluates a new decision for the new session
+- A fresh sampling decision is made when each session starts
+- Automatic expiry, receiver invalidation, and [`resetSession`](#session-lifecycle--rotation) each start a new sampling window
 - When a session is not sampled, all telemetry (events, logs, exceptions, measurements, traces) is silently dropped
 - A debug log is emitted when a session is not sampled, for transparency during development
 - Invalid return values (< 0.0 or > 1.0) are clamped to the valid range
@@ -1341,8 +1340,10 @@ Faro().runApp(
 
 **Notes:**
 
-- Sampling is head-based: initialization and each explicit `resetSession` make one decision that remains fixed for that session
-- The broader [Faro sampling model](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/sampling/) also re-samples after automatic rotation; matching that behavior remains planned in #284
+- Sampling is head-based: each new session makes one decision that remains fixed
+  until the next rotation
+- `SamplingFunction` receives the new session ID and its `previousSession`
+  attribute when a rotation links it to an earlier session
 
 **Use cases:**
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -1330,6 +1330,10 @@ Faro().runApp(
 );
 ```
 
+The function runs synchronously whenever a new session starts. Keep it fast and
+side-effect free; use values already available in the sampling context or
+locally cached configuration.
+
 **How it works:**
 
 - A fresh sampling decision is made when each session starts

--- a/lib/src/configurations/faro_config.dart
+++ b/lib/src/configurations/faro_config.dart
@@ -104,7 +104,9 @@ class FaroConfig {
   /// is not sampled, no telemetry (events, logs, exceptions, measurements,
   /// traces) is sent for that session.
   ///
-  /// The sampling decision is made once per session at initialization time.
+  /// A fresh sampling decision is made whenever a session starts, including
+  /// after automatic expiry, receiver invalidation, or an explicit reset. The
+  /// decision remains fixed for that session.
   ///
   /// If not provided, defaults to [SamplingRate(1.0)] (all sessions sampled).
   ///

--- a/lib/src/configurations/sampling.dart
+++ b/lib/src/configurations/sampling.dart
@@ -63,6 +63,8 @@ class SamplingRate extends Sampling {
 ///
 /// Use this when you want to make sampling decisions based on session
 /// metadata like user attributes, app environment, or other context.
+/// The function runs synchronously whenever a new session starts, so it should
+/// be fast and side-effect free.
 ///
 /// Example:
 /// ```dart

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -371,6 +371,13 @@ class Faro {
     String? previousId,
     required SessionStartTrigger trigger,
   }) {
+    final startsNewSamplingWindow = trigger != SessionStartTrigger.initial;
+    if (startsNewSamplingWindow) {
+      // Buffered action telemetry belongs to the session where the action
+      // started and must be dispatched before metadata or transport changes.
+      _userActionsService.endActiveUserAction();
+    }
+
     final attributes = <String, dynamic>{...?meta.session?.attributes};
     if (previousId != null) {
       attributes['previousSession'] = previousId;
@@ -382,7 +389,7 @@ class Faro {
     });
     _batchTransport?.updatePayloadMeta(meta);
 
-    if (trigger != SessionStartTrigger.initial) {
+    if (startsNewSamplingWindow) {
       _restartSamplingForNewSession();
     }
 
@@ -974,23 +981,24 @@ class Faro {
   /// ```
   ///
   /// **Note:** The action lifecycle is managed automatically by internal
-  /// user-action services.
+  /// user-action services. If the current session has expired, Faro rotates it
+  /// before the new action starts.
   UserActionHandle? startUserAction(
     String name, {
     Map<String, String>? attributes,
     StartUserActionOptions? options,
   }) {
-    final action = _userActionsService.startUserAction(
-      name,
-      attributes: attributes,
-      options: options,
-    );
-    if (action != null) {
+    if (_isInitialized && _userActionsService.getActiveUserAction() == null) {
       pod
           .resolve(sessionManagerProvider)
           .checkSession(activity: SessionActivityKind.meaningful);
     }
-    return action;
+
+    return _userActionsService.startUserAction(
+      name,
+      attributes: attributes,
+      options: options,
+    );
   }
 
   /// Returns the currently active user action, if any.

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -364,7 +364,7 @@ class Faro {
     });
     _batchTransport?.updatePayloadMeta(meta);
 
-    if (trigger == SessionStartTrigger.explicitReset) {
+    if (trigger != SessionStartTrigger.initial) {
       _restartSamplingForNewSession();
     }
 

--- a/lib/src/session/session_sampling_provider.dart
+++ b/lib/src/session/session_sampling_provider.dart
@@ -63,8 +63,9 @@ class SessionSamplingProviderFactory {
 
   /// Creates and stores a fresh sampling decision for a new session.
   ///
-  /// Unlike [create], this always replaces the cached decision. Use it when an
-  /// explicit session reset starts a new sampling window in the same process.
+  /// Unlike [create], this always replaces the cached decision. Use it when a
+  /// rotation or explicit reset starts a new sampling window in the same
+  /// process.
   SessionSamplingProvider createForNewSession({
     Sampling? sampling,
     required Meta meta,

--- a/test/src/integrations/sampling_integration_test.dart
+++ b/test/src/integrations/sampling_integration_test.dart
@@ -3,6 +3,8 @@
 import 'package:faro/src/configurations/batch_config.dart';
 import 'package:faro/src/configurations/faro_config.dart';
 import 'package:faro/src/configurations/sampling.dart';
+import 'package:faro/src/core/current_time_provider.dart';
+import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/models/models.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
@@ -29,6 +31,8 @@ class SequenceRandomValueProvider implements RandomValueProvider {
   final List<double> _values;
   var _index = 0;
 
+  int get callCount => _index;
+
   @override
   double nextDouble() {
     if (_index >= _values.length) {
@@ -47,6 +51,7 @@ void main() {
 
     late MockFaroTransport mockFaroTransport;
     late MockFaroNativeMethods mockFaroNativeMethods;
+    late DateTime now;
 
     setUpAll(() {
       registerFallbackValue(
@@ -86,6 +91,13 @@ void main() {
 
       Faro().transports = [mockFaroTransport];
       Faro().nativeChannel = mockFaroNativeMethods;
+
+      now = DateTime(2026, 8, 17, 12);
+      pod.overrideProvider(
+        currentTimeProvider,
+        (_) =>
+            () => now,
+      );
 
       when(
         () => mockFaroNativeMethods.enableCrashReporter(any()),
@@ -281,6 +293,114 @@ void main() {
         isNot(isA<NoOpBatchTransport>()),
       );
       expect(BatchTransportFactory().instance?.payloadSize(), 1);
+    });
+
+    test(
+      'automatic expiry starts a new unsampled window after flushing the old '
+      'session',
+      () async {
+        final random = SequenceRandomValueProvider(<double>[0.1, 0.9]);
+        RandomValueProviderFactory().setInstance(random);
+        await Faro().init(
+          optionsConfiguration: FaroConfig(
+            appName: appName,
+            appVersion: appVersion,
+            appEnv: appEnv,
+            apiKey: apiKey,
+            collectorUrl: 'https://some-url.com',
+            sampling: const SamplingRate(0.5),
+            cpuUsageVitals: false,
+            memoryUsageVitals: false,
+          ),
+        );
+        final initialSessionId = Faro().meta.session?.id;
+        Faro().pushEvent('old-session-event');
+
+        now = now.add(const Duration(minutes: 15));
+        Faro().pushEvent('new-session-event');
+
+        expect(random.callCount, 2);
+        expect(Faro().meta.session?.id, isNot(initialSessionId));
+        expect(Faro().isSampled, isFalse);
+        expect(BatchTransportFactory().instance, isA<NoOpBatchTransport>());
+        final payloads = verify(
+          () => mockFaroTransport.send(captureAny()),
+        ).captured.cast<Map<String, dynamic>>();
+        expect(payloads, hasLength(1));
+        final payload = payloads.single;
+        final payloadSession = payload['meta'] as Map<String, dynamic>;
+        expect(
+          (payloadSession['session'] as Map<String, dynamic>)['id'],
+          initialSessionId,
+        );
+        final eventNames = (payload['events'] as List<dynamic>)
+            .map((event) => (event as Map<String, dynamic>)['name'])
+            .toList();
+        expect(eventNames, contains('old-session-event'));
+        expect(eventNames, isNot(contains('new-session-event')));
+      },
+    );
+
+    test('automatic expiry starts a new sampled window', () async {
+      final random = SequenceRandomValueProvider(<double>[0.9, 0.1]);
+      RandomValueProviderFactory().setInstance(random);
+      await Faro().init(
+        optionsConfiguration: FaroConfig(
+          appName: appName,
+          appVersion: appVersion,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+          sampling: const SamplingRate(0.5),
+          cpuUsageVitals: false,
+          memoryUsageVitals: false,
+        ),
+      );
+      final initialSessionId = Faro().meta.session?.id;
+
+      now = now.add(const Duration(minutes: 15));
+      Faro().pushEvent('new-session-event');
+
+      expect(random.callCount, 2);
+      expect(Faro().meta.session?.id, isNot(initialSessionId));
+      expect(Faro().isSampled, isTrue);
+      expect(
+        BatchTransportFactory().instance,
+        isNot(isA<NoOpBatchTransport>()),
+      );
+      expect(BatchTransportFactory().instance?.payloadSize(), 2);
+      verifyNever(() => mockFaroTransport.send(any()));
+    });
+
+    test('automatic rotation samples with the new session context', () async {
+      final contexts = <SamplingContext>[];
+      await Faro().init(
+        optionsConfiguration: FaroConfig(
+          appName: appName,
+          appVersion: appVersion,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+          sampling: SamplingFunction((context) {
+            contexts.add(context);
+            return 1;
+          }),
+          cpuUsageVitals: false,
+          memoryUsageVitals: false,
+        ),
+      );
+      final initialSessionId = Faro().meta.session?.id;
+
+      now = now.add(const Duration(minutes: 15));
+      Faro().pushEvent('new-session-event');
+
+      expect(contexts, hasLength(2));
+      expect(contexts.first.meta.session?.id, initialSessionId);
+      expect(contexts.last.meta.session?.id, Faro().meta.session?.id);
+      expect(
+        contexts.last.meta.session?.attributes?['previousSession'],
+        initialSessionId,
+      );
     });
 
     test(

--- a/test/src/integrations/sampling_integration_test.dart
+++ b/test/src/integrations/sampling_integration_test.dart
@@ -17,6 +17,7 @@ import 'package:faro/src/session/session_sampling_provider.dart';
 import 'package:faro/src/transport/batch_transport.dart';
 import 'package:faro/src/transport/faro_transport.dart';
 import 'package:faro/src/transport/no_op_batch_transport.dart';
+import 'package:faro/src/user_actions/constants.dart';
 import 'package:faro/src/util/random_value_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -374,6 +375,134 @@ void main() {
       );
       expect(BatchTransportFactory().instance?.payloadSize(), 2);
       verifyNever(() => mockFaroTransport.send(any()));
+    });
+
+    test(
+      'sampled action is flushed before rotation becomes unsampled',
+      () async {
+        RandomValueProviderFactory().setInstance(
+          SequenceRandomValueProvider(<double>[0.1, 0.9]),
+        );
+        await Faro().init(
+          optionsConfiguration: FaroConfig(
+            appName: appName,
+            appVersion: appVersion,
+            appEnv: appEnv,
+            apiKey: apiKey,
+            collectorUrl: 'https://some-url.com',
+            sampling: const SamplingRate(0.5),
+            batchConfig: BatchConfig(enabled: false),
+            cpuUsageVitals: false,
+            memoryUsageVitals: false,
+          ),
+        );
+        final initialSessionId = Faro().meta.session!.id!;
+        expect(Faro().startUserAction('old-session-action'), isNotNull);
+        Faro().pushEvent('old-session-event');
+
+        now = now.add(const Duration(minutes: 15));
+        Faro().pushEvent('new-session-event');
+
+        expect(Faro().isSampled, isFalse);
+        expect(Faro().getActiveUserAction(), isNull);
+        final payloads = verify(
+          () => mockFaroTransport.send(captureAny()),
+        ).captured.cast<Map<String, dynamic>>();
+        final eventNames = payloads
+            .expand(
+              (payload) => payload['events'] as List<dynamic>? ?? const [],
+            )
+            .map((event) => (event as Map<String, dynamic>)['name'])
+            .toList();
+        expect(eventNames, contains('old-session-event'));
+        expect(eventNames, contains(UserActionConstants.userActionEventName));
+        expect(eventNames, isNot(contains('new-session-event')));
+        for (final payload in payloads) {
+          final payloadMeta = payload['meta'] as Map<String, dynamic>;
+          final session = payloadMeta['session'] as Map<String, dynamic>;
+          expect(session['id'], initialSessionId);
+        }
+      },
+    );
+
+    test(
+      'unsampled action is dropped before rotation becomes sampled',
+      () async {
+        RandomValueProviderFactory().setInstance(
+          SequenceRandomValueProvider(<double>[0.9, 0.1]),
+        );
+        await Faro().init(
+          optionsConfiguration: FaroConfig(
+            appName: appName,
+            appVersion: appVersion,
+            appEnv: appEnv,
+            apiKey: apiKey,
+            collectorUrl: 'https://some-url.com',
+            sampling: const SamplingRate(0.5),
+            batchConfig: BatchConfig(enabled: false),
+            cpuUsageVitals: false,
+            memoryUsageVitals: false,
+          ),
+        );
+        expect(Faro().startUserAction('old-session-action'), isNotNull);
+        Faro().pushEvent('old-session-event');
+
+        now = now.add(const Duration(minutes: 15));
+        Faro().pushEvent('new-session-event');
+        final rotatedSessionId = Faro().meta.session!.id!;
+
+        expect(Faro().isSampled, isTrue);
+        expect(Faro().getActiveUserAction(), isNull);
+        final payloads = verify(
+          () => mockFaroTransport.send(captureAny()),
+        ).captured.cast<Map<String, dynamic>>();
+        final eventNames = payloads
+            .expand(
+              (payload) => payload['events'] as List<dynamic>? ?? const [],
+            )
+            .map((event) => (event as Map<String, dynamic>)['name'])
+            .toList();
+        expect(
+          eventNames,
+          containsAll(<String>['session_start', 'new-session-event']),
+        );
+        expect(eventNames, isNot(contains('old-session-event')));
+        expect(
+          eventNames,
+          isNot(contains(UserActionConstants.userActionEventName)),
+        );
+        for (final payload in payloads) {
+          final payloadMeta = payload['meta'] as Map<String, dynamic>;
+          final session = payloadMeta['session'] as Map<String, dynamic>;
+          expect(session['id'], rotatedSessionId);
+        }
+      },
+    );
+
+    test('expired session rotates before a new user action starts', () async {
+      final random = SequenceRandomValueProvider(<double>[0.1, 0.1]);
+      RandomValueProviderFactory().setInstance(random);
+      await Faro().init(
+        optionsConfiguration: FaroConfig(
+          appName: appName,
+          appVersion: appVersion,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+          sampling: const SamplingRate(0.5),
+          cpuUsageVitals: false,
+          memoryUsageVitals: false,
+        ),
+      );
+      final initialSessionId = Faro().meta.session!.id!;
+
+      now = now.add(const Duration(minutes: 15));
+      final action = Faro().startUserAction('new-session-action');
+
+      expect(random.callCount, 2);
+      expect(Faro().meta.session?.id, isNot(initialSessionId));
+      expect(action, isNotNull);
+      expect(Faro().getActiveUserAction(), same(action));
     });
 
     test('automatic rotation samples with the new session context', () async {

--- a/test/src/integrations/sampling_integration_test.dart
+++ b/test/src/integrations/sampling_integration_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values, prefer_int_literals, lines_longer_than_80_chars
 
+import 'dart:io';
+
 import 'package:faro/src/configurations/batch_config.dart';
 import 'package:faro/src/configurations/faro_config.dart';
 import 'package:faro/src/configurations/sampling.dart';
@@ -9,6 +11,8 @@ import 'package:faro/src/faro.dart';
 import 'package:faro/src/models/models.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
 import 'package:faro/src/session/sampling_context.dart';
+import 'package:faro/src/session/session_manager.dart';
+import 'package:faro/src/session/session_persistence.dart';
 import 'package:faro/src/session/session_sampling_provider.dart';
 import 'package:faro/src/transport/batch_transport.dart';
 import 'package:faro/src/transport/faro_transport.dart';
@@ -401,6 +405,125 @@ void main() {
         contexts.last.meta.session?.attributes?['previousSession'],
         initialSessionId,
       );
+    });
+
+    test('maximum lifetime starts a new sampling window', () async {
+      final random = SequenceRandomValueProvider(<double>[0.1, 0.9]);
+      RandomValueProviderFactory().setInstance(random);
+      await Faro().init(
+        optionsConfiguration: FaroConfig(
+          appName: appName,
+          appVersion: appVersion,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+          sampling: const SamplingRate(0.5),
+          cpuUsageVitals: false,
+          memoryUsageVitals: false,
+        ),
+      );
+      final initialSessionId = Faro().meta.session?.id;
+
+      // Keep inactivity fresh so only the four-hour lifetime can rotate.
+      for (var index = 0; index < 23; index++) {
+        now = now.add(const Duration(minutes: 10));
+        Faro().setViewMeta(name: 'view_$index');
+      }
+      expect(Faro().meta.session?.id, initialSessionId);
+
+      now = now.add(const Duration(minutes: 10));
+      Faro().setViewMeta(name: 'after-lifetime');
+
+      expect(random.callCount, 2);
+      expect(Faro().meta.session?.id, isNot(initialSessionId));
+      expect(Faro().isSampled, isFalse);
+      expect(BatchTransportFactory().instance, isA<NoOpBatchTransport>());
+    });
+
+    test('receiver invalidation starts a new sampled window', () async {
+      final random = SequenceRandomValueProvider(<double>[0.9, 0.1]);
+      RandomValueProviderFactory().setInstance(random);
+      await Faro().init(
+        optionsConfiguration: FaroConfig(
+          appName: appName,
+          appVersion: appVersion,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+          sampling: const SamplingRate(0.5),
+          cpuUsageVitals: false,
+          memoryUsageVitals: false,
+        ),
+      );
+      final initialSessionId = Faro().meta.session!.id!;
+
+      pod.resolve(sessionManagerProvider).invalidateSession(initialSessionId);
+
+      expect(random.callCount, 2);
+      expect(Faro().meta.session?.id, isNot(initialSessionId));
+      expect(Faro().isSampled, isTrue);
+      expect(
+        BatchTransportFactory().instance,
+        isNot(isA<NoOpBatchTransport>()),
+      );
+      expect(BatchTransportFactory().instance?.payloadSize(), 1);
+    });
+
+    test('automatic rotation persists the new sampling decision', () async {
+      final temporaryDirectory = await Directory.systemTemp.createTemp(
+        'faro-sampling-persistence-',
+      );
+      addTearDown(() {
+        if (temporaryDirectory.existsSync()) {
+          temporaryDirectory.deleteSync(recursive: true);
+        }
+      });
+      final persistenceFactory = SessionPersistenceFactory(
+        applicationSupportDirectory: () async => temporaryDirectory,
+      );
+      final random = SequenceRandomValueProvider(<double>[0.1, 0.9]);
+      RandomValueProviderFactory().setInstance(random);
+      Faro().mobilePlatformResolver = () => true;
+      Faro().sessionPersistenceFactory = persistenceFactory;
+      when(
+        () => mockFaroNativeMethods.getSessionRuntimeInfo(
+          claimSessionPersistence: true,
+        ),
+      ).thenAnswer(
+        (_) async => <String, dynamic>{
+          'processIdentifier': 'com.grafana.sampling-test',
+          'ownsSessionPersistence': true,
+        },
+      );
+
+      await Faro().init(
+        optionsConfiguration: FaroConfig(
+          appName: appName,
+          appVersion: appVersion,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+          sampling: const SamplingRate(0.5),
+          cpuUsageVitals: false,
+          memoryUsageVitals: false,
+        ),
+      );
+      final initialSessionId = Faro().meta.session!.id!;
+
+      now = now.add(const Duration(minutes: 15));
+      Faro().pushEvent('new-session-event');
+      final rotatedSessionId = Faro().meta.session!.id!;
+      await Faro.resetForTesting();
+
+      final persisted = await (await persistenceFactory.create(
+        processIdentifier: 'com.grafana.sampling-test',
+      )).loadHistory();
+      expect(persisted, hasLength(2));
+      expect(persisted.first.currentSessionId, initialSessionId);
+      expect(persisted.first.isSampled, isTrue);
+      expect(persisted.last.currentSessionId, rotatedSessionId);
+      expect(persisted.last.previousSessionId, initialSessionId);
+      expect(persisted.last.isSampled, isFalse);
     });
 
     test(


### PR DESCRIPTION
Sampling is now decided per session, including sessions created by inactivity, maximum lifetime, receiver invalidation, or reset. Active user actions end before rotation so their telemetry stays with the correct session, and the new sampling decision is persisted.

Fixes #284

No screenshots needed. This is an SDK-only change.