### PR TITLE
fix(ios): route native crash reports through SDK transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,10 +94,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **iOS crash reports now use the configured SDK transports.** Pending
   PLCrashReporter data returns to Dart on the next launch and follows the
   configured collector and custom transport paths, sampling, data collection
-  policy, and collector headers. Successfully handed-off reports are purged;
-  opted-out reports and reports rejected by a custom transport remain pending
-  instead of also entering `OfflineTransport`, because the native report is
-  already the durable retry copy
+  policy, and collector headers. Successfully handed-off reports are purged.
+  Collector rejections and thrown transport failures remain pending. Reports
+  are discarded when data collection is disabled during launch recovery.
+  Pending native reports do not also enter `OfflineTransport`, because the
+  native report is already the durable retry copy
   ([#269](https://github.com/grafana/faro-flutter-sdk/issues/269)).
 - **Recovered native crashes retain their original session.** Android and iOS
   crash metadata includes `crashedSessionId` and preserves the persisted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING (behavioral): iOS recovered crashes now use `type: crash`.**
+  The native signal and code remain available in `context.nativeType`.
+  Dashboards and alerts matching signal names in `exception.type` should match
+  `crash` and read `context.nativeType` instead
+  ([#269](https://github.com/grafana/faro-flutter-sdk/issues/269)).
 - **BREAKING (behavioral)**: Session inactivity now refreshes only for
   user interactions, view or navigation changes, foreground returns,
   explicit user actions, and spans linked to those actions. Generic telemetry,
@@ -72,13 +77,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   iOS prewarmed the process, `0` otherwise). `appStartDuration` and `coldStart`
   are unchanged, so existing dashboards keep working.
 
+### Deprecated
+
+- Deprecate direct calls to `Faro.enableCrashReporter`. Enable crash reporting
+  and configure its transports through `FaroConfig` instead.
+
 ### Fixed
 
 - **iOS crash reports now use the configured SDK transports.** Pending
   PLCrashReporter data returns to Dart on the next launch and follows the
   configured collector and custom transport paths, sampling, data collection
-  policy, and collector headers. iOS reports now use `type: crash` while
-  retaining the native signal in context
+  policy, and collector headers. Successfully handed-off reports are purged;
+  opted-out reports and reports rejected by a custom transport remain pending
   ([#269](https://github.com/grafana/faro-flutter-sdk/issues/269)).
 - **Recovered native crashes retain their original session.** Android and iOS
   crash metadata includes `crashedSessionId` and preserves the persisted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configured collector and custom transport paths, sampling, data collection
   policy, and collector headers. Successfully handed-off reports are purged;
   opted-out reports and reports rejected by a custom transport remain pending
+  instead of also entering `OfflineTransport`, because the native report is
+  already the durable retry copy
   ([#269](https://github.com/grafana/faro-flutter-sdk/issues/269)).
 - **Recovered native crashes retain their original session.** Android and iOS
   crash metadata includes `crashedSessionId` and preserves the persisted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **iOS crash reports now use the configured SDK transports.** Pending
+  PLCrashReporter data returns to Dart on the next launch and follows the
+  configured collector and custom transport paths, sampling, data collection
+  policy, and collector headers. iOS reports now use `type: crash` while
+  retaining the native signal in context
+  ([#269](https://github.com/grafana/faro-flutter-sdk/issues/269)).
 - **Recovered native crashes retain their original session.** Android and iOS
   crash metadata includes `crashedSessionId` and preserves the persisted
   sampling decision without changing the new live session. Historical Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- Deprecate direct calls to `Faro.enableCrashReporter`. Enable crash reporting
-  and configure its transports through `FaroConfig` instead.
+- **Direct crash-reporter setup is deprecated.** Enable crash reporting and
+  configure its transports through `FaroConfig` instead of calling
+  `Faro.enableCrashReporter`.
 
 ### Fixed
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -453,7 +453,9 @@ deduplicate historical `ApplicationExitInfo` records, while iOS purges the
 pending PLCrashReporter record after Dart accepts it for transport. The report
 uses the configured collector and custom transports, sampling decision, data
 collection policy, collector headers, and `type: crash`; its native signal and
-code are preserved in `context.nativeType`. If persistence is active
+code are preserved in `context.nativeType`. A pending iOS report is discarded
+without being sent when data collection was disabled at launch. If persistence
+is active
 but a recovered crash cannot be matched to a persisted session, the SDK
 discards that crash rather than attributing it to the new live session. If
 persistence is disabled or unavailable, the SDK cannot recover the prior

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -450,10 +450,10 @@ payload also includes `crashedSessionId` in the session attributes and uses
 that session's persisted sampling decision. Sending the recovered crash does
 not rotate or otherwise change the new live session. Android continues to
 deduplicate historical `ApplicationExitInfo` records, while iOS purges the
-pending PLCrashReporter record after encoding it for Dart. The iOS report then
+pending PLCrashReporter record after Dart accepts it for transport. The report
 uses the configured collector and custom transports, sampling decision, data
-collection policy, collector headers, and `type: crash`; its native signal is
-preserved in `context.nativeType`. If persistence is active
+collection policy, collector headers, and `type: crash`; its native signal and
+code are preserved in `context.nativeType`. If persistence is active
 but a recovered crash cannot be matched to a persisted session, the SDK
 discards that crash rather than attributing it to the new live session. If
 persistence is disabled or unavailable, the SDK cannot recover the prior

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -450,7 +450,10 @@ payload also includes `crashedSessionId` in the session attributes and uses
 that session's persisted sampling decision. Sending the recovered crash does
 not rotate or otherwise change the new live session. Android continues to
 deduplicate historical `ApplicationExitInfo` records, while iOS purges the
-pending PLCrashReporter record after processing it. If persistence is active
+pending PLCrashReporter record after encoding it for Dart. The iOS report then
+uses the configured collector and custom transports, sampling decision, data
+collection policy, collector headers, and `type: crash`; its native signal is
+preserved in `context.nativeType`. If persistence is active
 but a recovered crash cannot be matched to a persisted session, the SDK
 discards that crash rather than attributing it to the new live session. If
 persistence is disabled or unavailable, the SDK cannot recover the prior

--- a/doc/error-categorization.md
+++ b/doc/error-categorization.md
@@ -81,8 +81,8 @@ Notes:
   runtime **ANR watchdog** is different: it detects a blocked main thread
   **while the app is running** and reports within the same session.
 - iOS pending crashes return to Dart on the next launch and use the configured
-  collector and custom transports. The original signal name remains available
-  as `context.nativeType`.
+  collector and custom transports. The original signal name and code remain
+  available as `context.nativeType`.
 - With session persistence enabled, next-launch native crash reports retain
   the prior session ID and include `crashedSessionId` in the session
   attributes. Reporting them does not change the new live session. When

--- a/doc/error-categorization.md
+++ b/doc/error-categorization.md
@@ -63,7 +63,7 @@ The SDK organizes error-like signals into four categories:
 | Manual `Faro().pushError(...)` | `lib/src/faro.dart` | exception | caller-defined | caller-defined (default `false`) |
 | Android previous-session exits via `ApplicationExitInfo` | `lib/src/faro.dart` (`enableCrashReporter`), `android/.../ExitInfoHelper.java` | fatal exception | `crash` | `true` |
 | Android runtime ANR watchdog (main thread blocked) | `android/.../ANRTracker.java`, `lib/src/integrations/native_integration.dart` | exception (plus an `anr` measurement) | `flutter_error` | `true` |
-| iOS previous-session crashes (PLCrashReporter) | `ios/faro/Sources/faro/CrashReportingIntegration.swift` | fatal exception | signal name (e.g. `SIGSEGV`) | `true` |
+| iOS previous-session crashes (PLCrashReporter) | `ios/faro/Sources/faro/CrashReportingIntegration.swift`, `lib/src/faro.dart` | fatal exception | `crash` | `true` |
 | Manual `Faro().pushLog(..., level: LogLevel.error)` | `lib/src/faro.dart` | log | — | — |
 
 Notes:
@@ -80,6 +80,9 @@ Notes:
   exits) are detected and reported on the **next launch**. The Android
   runtime **ANR watchdog** is different: it detects a blocked main thread
   **while the app is running** and reports within the same session.
+- iOS pending crashes return to Dart on the next launch and use the configured
+  collector and custom transports. The original signal name remains available
+  as `context.nativeType`.
 - With session persistence enabled, next-launch native crash reports retain
   the prior session ID and include `crashedSessionId` in the session
   attributes. Reporting them does not change the new live session. When

--- a/example/ios/RunnerTests/CrashReportingIntegrationTests.swift
+++ b/example/ios/RunnerTests/CrashReportingIntegrationTests.swift
@@ -105,4 +105,16 @@ struct CrashReportingIntegrationTests {
     #expect(integration.takePendingCrashReports().isEmpty)
     #expect(purgeCount == 1)
   }
+
+  @Test("reports when a pending crash cannot be purged")
+  func purgeFailure() {
+    let integration = CrashReportingIntegration(
+      hasPendingCrashReport: { true },
+      loadPendingCrashReport: { Data() },
+      purgePendingCrashReport: { false },
+      exportCrashReport: { _ in [:] }
+    )
+
+    #expect(!integration.purgePendingCrashReport())
+  }
 }

--- a/example/ios/RunnerTests/CrashReportingIntegrationTests.swift
+++ b/example/ios/RunnerTests/CrashReportingIntegrationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import faro
@@ -5,26 +6,83 @@ import Testing
 @Suite("CrashReportingIntegration")
 struct CrashReportingIntegrationTests {
 
-  @Test("reports pending crashes by default")
-  func reportsPendingCrashByDefault() {
-    #expect(CrashReportingIntegration.shouldReportPendingCrash(config: [:]))
+  private struct TestError: Error {}
+
+  @Test("leaves the reporter untouched when no crash is pending")
+  func noPendingCrash() {
+    var loadCount = 0
+    var purgeCount = 0
+    let integration = CrashReportingIntegration(
+      hasPendingCrashReport: { false },
+      loadPendingCrashReport: {
+        loadCount += 1
+        return Data()
+      },
+      purgePendingCrashReport: {
+        purgeCount += 1
+        return true
+      },
+      exportCrashReport: { _ in [:] }
+    )
+
+    #expect(integration.takePendingCrashReports().isEmpty)
+    #expect(loadCount == 0)
+    #expect(purgeCount == 0)
   }
 
-  @Test("does not report a crash from an unsampled session")
-  func skipsPendingCrashForUnsampledSession() {
-    #expect(
-      !CrashReportingIntegration.shouldReportPendingCrash(
-        config: ["reportPendingCrash": false]
-      )
+  @Test("returns a structured pending crash and purges it once")
+  func pendingCrash() throws {
+    var purgeCount = 0
+    let integration = CrashReportingIntegration(
+      hasPendingCrashReport: { true },
+      loadPendingCrashReport: { Data([1, 2, 3]) },
+      purgePendingCrashReport: {
+        purgeCount += 1
+        return true
+      },
+      exportCrashReport: { data in
+        #expect(data == Data([1, 2, 3]))
+        return [
+          "type": "SIGSEGV",
+          "value": "Application crash",
+          "stacktrace": [
+            "frames": [["filename": "Runner", "lineno": 42]]
+          ],
+          "timestamp": "2026-08-18T12:00:00.000Z",
+          "fatal": true,
+        ]
+      }
     )
+
+    let reports = integration.takePendingCrashReports()
+    let report = try #require(reports.first)
+    let object = try #require(
+      try JSONSerialization.jsonObject(with: Data(report.utf8))
+        as? [String: Any]
+    )
+    let stacktrace = try #require(object["stacktrace"] as? [String: Any])
+    let frames = try #require(stacktrace["frames"] as? [[String: Any]])
+
+    #expect(reports.count == 1)
+    #expect(object["type"] as? String == "SIGSEGV")
+    #expect(frames.first?["filename"] as? String == "Runner")
+    #expect(purgeCount == 1)
   }
 
-  @Test("ignores malformed sampling configuration")
-  func ignoresMalformedSamplingConfiguration() {
-    #expect(
-      CrashReportingIntegration.shouldReportPendingCrash(
-        config: ["reportPendingCrash": "false"]
-      )
+  @Test("purges a pending crash that cannot be loaded")
+  func malformedPendingCrash() {
+    var purgeCount = 0
+    let integration = CrashReportingIntegration(
+      hasPendingCrashReport: { true },
+      loadPendingCrashReport: { throw TestError() },
+      purgePendingCrashReport: {
+        purgeCount += 1
+        return true
+      },
+      exportCrashReport: { _ in [:] }
     )
+
+    #expect(integration.takePendingCrashReports().isEmpty)
+    #expect(purgeCount == 1)
   }
 }

--- a/example/ios/RunnerTests/CrashReportingIntegrationTests.swift
+++ b/example/ios/RunnerTests/CrashReportingIntegrationTests.swift
@@ -30,7 +30,7 @@ struct CrashReportingIntegrationTests {
     #expect(purgeCount == 0)
   }
 
-  @Test("returns a structured pending crash and purges it once")
+  @Test("returns a structured pending crash and purges it after acknowledgement")
   func pendingCrash() throws {
     var purgeCount = 0
     let integration = CrashReportingIntegration(
@@ -66,6 +66,9 @@ struct CrashReportingIntegrationTests {
     #expect(reports.count == 1)
     #expect(object["type"] as? String == "SIGSEGV")
     #expect(frames.first?["filename"] as? String == "Runner")
+    #expect(purgeCount == 0)
+
+    #expect(integration.purgePendingCrashReport())
     #expect(purgeCount == 1)
   }
 
@@ -80,6 +83,23 @@ struct CrashReportingIntegrationTests {
         return true
       },
       exportCrashReport: { _ in [:] }
+    )
+
+    #expect(integration.takePendingCrashReports().isEmpty)
+    #expect(purgeCount == 1)
+  }
+
+  @Test("purges a pending crash that cannot be encoded as JSON")
+  func unencodablePendingCrash() {
+    var purgeCount = 0
+    let integration = CrashReportingIntegration(
+      hasPendingCrashReport: { true },
+      loadPendingCrashReport: { Data() },
+      purgePendingCrashReport: {
+        purgeCount += 1
+        return true
+      },
+      exportCrashReport: { _ in ["invalid": Date()] }
     )
 
     #expect(integration.takePendingCrashReports().isEmpty)

--- a/ios/faro/Sources/faro/CrashReportingIntegration.swift
+++ b/ios/faro/Sources/faro/CrashReportingIntegration.swift
@@ -4,7 +4,7 @@ import Foundation
 final class CrashReportingIntegration {
     private let hasPendingCrashReport: () -> Bool
     private let loadPendingCrashReport: () throws -> Data
-    private let purgePendingCrashReport: () -> Bool
+    private let purgePendingCrashReportHandler: () -> Bool
     private let exportCrashReport: (Data) throws -> [String: Any]
 
     convenience init() throws {
@@ -40,7 +40,7 @@ final class CrashReportingIntegration {
                 let report = try PLCrashReport(data: data)
                 var crashReport = try CrashReport(from: report)
                 CrashReportMinifier().minify(crashReport: &crashReport)
-                return CrashReportExporter().export(crashReport: crashReport)
+                return try CrashReportExporter().export(crashReport: crashReport)
             }
         )
 
@@ -59,7 +59,7 @@ final class CrashReportingIntegration {
     ) {
         self.hasPendingCrashReport = hasPendingCrashReport
         self.loadPendingCrashReport = loadPendingCrashReport
-        self.purgePendingCrashReport = purgePendingCrashReport
+        self.purgePendingCrashReportHandler = purgePendingCrashReport
         self.exportCrashReport = exportCrashReport
     }
 
@@ -68,14 +68,13 @@ final class CrashReportingIntegration {
             return []
         }
 
-        defer {
-            if !purgePendingCrashReport() {
-                print("Faro: Could not purge the pending iOS crash report.")
-            }
-        }
-
         do {
             let crash = try exportCrashReport(loadPendingCrashReport())
+            guard JSONSerialization.isValidJSONObject(crash) else {
+                throw CrashReportException(
+                    description: "Pending crash report is not valid JSON."
+                )
+            }
             let data = try JSONSerialization.data(withJSONObject: crash)
             guard let json = String(data: data, encoding: .utf8) else {
                 throw CrashReportException(
@@ -85,12 +84,22 @@ final class CrashReportingIntegration {
             return [json]
         } catch {
             // Discard malformed reports so they do not fail every app launch.
+            _ = purgePendingCrashReport()
             print(
                 "Faro: Failed to load pending crash report; discarding it. " +
                 "Error: \(error)"
             )
             return []
         }
+    }
+
+    @discardableResult
+    func purgePendingCrashReport() -> Bool {
+        let purged = purgePendingCrashReportHandler()
+        if !purged {
+            print("Faro: Could not purge the pending iOS crash report.")
+        }
+        return purged
     }
 }
 
@@ -231,14 +240,19 @@ internal struct CrashReportExporter{
         "SIGUSR1": "User defined signal 1",
         "SIGUSR2": "User defined signal 2",
     ]
-    func export(crashReport: CrashReport) -> Dictionary<String,Any>{
+    func export(crashReport: CrashReport) throws -> Dictionary<String,Any>{
+        guard let timestamp = crashReport.systemInfo?.timestamp else {
+            throw CrashReportException(
+                description: "Pending crash report has no timestamp."
+            )
+        }
         let dateFormatter = DateFormatter()
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
 
         return (RumExceptionFormat(type: formattedType(for: crashReport), value: formattedValue(for: crashReport), stacktrace: ["frames":formattedStack(for: crashReport)],
-                           timestamp: dateFormatter.string(from: crashReport.systemInfo?.timestamp ?? Date()),
+                           timestamp: dateFormatter.string(from: timestamp),
                            fatal: true
                            // TODO: add context: binaryImages, ThreadInfo,contextData, Meta,truncation
                            //                           context: [

--- a/ios/faro/Sources/faro/CrashReportingIntegration.swift
+++ b/ios/faro/Sources/faro/CrashReportingIntegration.swift
@@ -1,118 +1,97 @@
 import CrashReporter
+import Foundation
 
-class  CrashReportingIntegration {
-    static func shouldReportPendingCrash(config: [String: Any]) -> Bool {
-        return config["reportPendingCrash"] as? Bool ?? true
-    }
+final class CrashReportingIntegration {
+    private let hasPendingCrashReport: () -> Bool
+    private let loadPendingCrashReport: () throws -> Data
+    private let purgePendingCrashReport: () -> Bool
+    private let exportCrashReport: (Data) throws -> [String: Any]
 
-    init(crashReporterConfig: [String: Any]) throws {
-        //if (!isDebuggerAttached()) {
-        
-        // It is strongly recommended that local symbolication only be enabled for non-release builds.
-        // Use [] for release versions.
-            guard let cache = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-                throw CrashReportException(description: "Cannot obtain `/Library/Caches/` url.")
-            }
+    convenience init() throws {
+        guard let cache = FileManager.default.urls(
+            for: .cachesDirectory,
+            in: .userDomainMask
+        ).first else {
+            throw CrashReportException(
+                description: "Cannot obtain `/Library/Caches/` url."
+            )
+        }
 
-        // Add Cache Directory
-        let directory = cache.appendingPathComponent("com.rumflutter.crash-reporting", isDirectory: true)
-        let config = PLCrashReporterConfig(signalHandlerType: .BSD, symbolicationStrategy:[],basePath: directory.path )
+        let directory = cache.appendingPathComponent(
+            "com.rumflutter.crash-reporting",
+            isDirectory: true
+        )
+        let config = PLCrashReporterConfig(
+            signalHandlerType: .BSD,
+            symbolicationStrategy: [],
+            basePath: directory.path
+        )
         guard let crashReporter = PLCrashReporter(configuration: config) else {
-            print("Could not create an instance of PLCrashReporter")
-            return
+            throw CrashReportException(
+                description: "Could not create an instance of PLCrashReporter."
+            )
         }
-        
-        // Enable the Crash Reporter.
-        do {
-            try crashReporter.enableAndReturnError()
-        } catch let error {
-            print("Warning: Could not enable crash reporter: \(error)")
-        }
-        // Try loading the crash report.
-        let reportPendingCrash = Self.shouldReportPendingCrash(config: crashReporterConfig)
-        if crashReporter.hasPendingCrashReport() && reportPendingCrash {
-            do {
-                let data = try crashReporter.loadPendingCrashReportDataAndReturnError()
-                
-                // Retrieving crash reporter data.
+
+        self.init(
+            hasPendingCrashReport: crashReporter.hasPendingCrashReport,
+            loadPendingCrashReport: crashReporter.loadPendingCrashReportDataAndReturnError,
+            purgePendingCrashReport: crashReporter.purgePendingCrashReport,
+            exportCrashReport: { data in
                 let report = try PLCrashReport(data: data)
                 var crashReport = try CrashReport(from: report)
-                
-                let minifier = CrashReportMinifier()
-                minifier.minify(crashReport: &crashReport)
-                let exporter = CrashReportExporter()
-                // format crash report to send to grafana / send to separate storage
-                sendCrashReport(crash: exporter.export(crashReport: crashReport), config: crashReporterConfig)
-            } catch let error {
-                // The pending report is purged below even on failure, so a
-                // corrupt report cannot cause repeated failures on every
-                // launch — but it also means this crash report is lost.
-                print(
-                    "Faro CrashReportingIntegration: failed to load/parse " +
-                    "pending crash report; discarding it. Error: \(error)"
+                CrashReportMinifier().minify(crashReport: &crashReport)
+                return CrashReportExporter().export(crashReport: crashReport)
+            }
+        )
+
+        do {
+            try crashReporter.enableAndReturnError()
+        } catch {
+            print("Faro: Could not enable crash reporter: \(error)")
+        }
+    }
+
+    init(
+        hasPendingCrashReport: @escaping () -> Bool,
+        loadPendingCrashReport: @escaping () throws -> Data,
+        purgePendingCrashReport: @escaping () -> Bool,
+        exportCrashReport: @escaping (Data) throws -> [String: Any]
+    ) {
+        self.hasPendingCrashReport = hasPendingCrashReport
+        self.loadPendingCrashReport = loadPendingCrashReport
+        self.purgePendingCrashReport = purgePendingCrashReport
+        self.exportCrashReport = exportCrashReport
+    }
+
+    func takePendingCrashReports() -> [String] {
+        guard hasPendingCrashReport() else {
+            return []
+        }
+
+        defer {
+            if !purgePendingCrashReport() {
+                print("Faro: Could not purge the pending iOS crash report.")
+            }
+        }
+
+        do {
+            let crash = try exportCrashReport(loadPendingCrashReport())
+            let data = try JSONSerialization.data(withJSONObject: crash)
+            guard let json = String(data: data, encoding: .utf8) else {
+                throw CrashReportException(
+                    description: "Could not encode pending crash report as UTF-8."
                 )
             }
-        }
-
-        crashReporter.purgePendingCrashReport()
-        
-    }
-    func sendCrashReport(crash:Dictionary<String,Any>, config: Dictionary<String, Any>){
-        let  meta = [
-            "app":config["app"],
-            "session": config["session"],
-        ]
-        var crashPayload:Dictionary<String,Any> = [:]
-        crashPayload["exceptions"] = [crash]
-        crashPayload["meta"] = meta
-        sendPostRequest(collector: config["collectorUrl"] as! String,apiToken: config["apiKey"] as! String, payload: crashPayload) { (error) in
-            if let error = error {
-                print("Error: \(error)")
-            } else {
-                print("Request successful")
-            }
-        }
-    
-        
-    }
-    func sendPostRequest(collector: String, apiToken: String, payload: [String: Any], completion: @escaping (Error?) -> Void) {
-        
-        guard let url = URL(string: collector) else {
-            print("Invalid URL")
-            return
-        }
-
-        // Convert the payload dictionary to JSON data
-        do {
-            let jsonData = try JSONSerialization.data(withJSONObject: payload, options: [])
-            
-            _ = String(data: jsonData, encoding: .utf8)
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            
-            request.addValue(apiToken, forHTTPHeaderField: "x-api-token")
-            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-            
-            request.httpBody = jsonData
-            
-            let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
-                if let error = error {
-                    completion(error)
-                    return
-                }
-
-
-                completion(nil)
-            }
-            
-            task.resume()
-
+            return [json]
         } catch {
-            completion(error)
+            // Discard malformed reports so they do not fail every app launch.
+            print(
+                "Faro: Failed to load pending crash report; discarding it. " +
+                "Error: \(error)"
+            )
+            return []
         }
     }
-    
-    
 }
 
 internal struct RumMeta{
@@ -254,6 +233,7 @@ internal struct CrashReportExporter{
     ]
     func export(crashReport: CrashReport) -> Dictionary<String,Any>{
         let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
 

--- a/ios/faro/Sources/faro/FaroPlugin.swift
+++ b/ios/faro/Sources/faro/FaroPlugin.swift
@@ -8,6 +8,7 @@ public class FaroPlugin: NSObject, FlutterPlugin {
   private static let sessionPersistenceOwnerLock = NSLock()
   private static var sessionPersistenceOwnerClaimed = false
   private var ownsSessionPersistence = false
+  private var crashReportingIntegration: CrashReportingIntegration?
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     // First thing the SDK does. iOS clears the prewarm flag once the app has
@@ -40,11 +41,24 @@ public class FaroPlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "enableCrashReporter":
-            do{
-                _ = try CrashReportingIntegration(crashReporterConfig: call.arguments as! [String: Any])
+            do {
+                crashReportingIntegration = try CrashReportingIntegration()
+                result(nil)
             } catch {
-                print("crash reporter not initialized")
+                result(
+                    FlutterError(
+                        code: "crash_reporter_initialization_failed",
+                        message: "Could not initialize the iOS crash reporter.",
+                        details: error.localizedDescription
+                    )
+                )
             }
+        case "getCrashReport":
+            guard ownsSessionPersistence else {
+                result([String]())
+                return
+            }
+            result(crashReportingIntegration?.takePendingCrashReports() ?? [])
         case "getPlatformVersion":
                 result("iOS " + UIDevice.current.systemVersion);
             case "uptimeUI":

--- a/ios/faro/Sources/faro/FaroPlugin.swift
+++ b/ios/faro/Sources/faro/FaroPlugin.swift
@@ -9,6 +9,10 @@ public class FaroPlugin: NSObject, FlutterPlugin {
   private static var sessionPersistenceOwnerClaimed = false
   private var ownsSessionPersistence = false
   private var crashReportingIntegration: CrashReportingIntegration?
+  private let crashReportQueue = DispatchQueue(
+    label: "com.grafana.faro.crash-report",
+    qos: .utility
+  )
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     // First thing the SDK does. iOS clears the prewarm flag once the app has
@@ -54,11 +58,45 @@ public class FaroPlugin: NSObject, FlutterPlugin {
                 )
             }
         case "getCrashReport":
+            // If runtime discovery failed before claiming an owner, let the
+            // first root engine reaching recovery claim the pending report.
+            claimSessionPersistenceOwnership()
             guard ownsSessionPersistence else {
                 result([String]())
                 return
             }
-            result(crashReportingIntegration?.takePendingCrashReports() ?? [])
+            guard let crashReportingIntegration else {
+                result([String]())
+                return
+            }
+            crashReportQueue.async {
+                let reports = crashReportingIntegration.takePendingCrashReports()
+                DispatchQueue.main.async {
+                    result(reports)
+                }
+            }
+        case "purgeCrashReport":
+            guard ownsSessionPersistence,
+                  let crashReportingIntegration else {
+                result(nil)
+                return
+            }
+            crashReportQueue.async {
+                let purged = crashReportingIntegration.purgePendingCrashReport()
+                DispatchQueue.main.async {
+                    if purged {
+                        result(nil)
+                    } else {
+                        result(
+                            FlutterError(
+                                code: "crash_report_purge_failed",
+                                message: "Could not purge the iOS crash report.",
+                                details: nil
+                            )
+                        )
+                    }
+                }
+            }
         case "getPlatformVersion":
                 result("iOS " + UIDevice.current.systemVersion);
             case "uptimeUI":

--- a/ios/faro/Sources/faro/FaroPlugin.swift
+++ b/ios/faro/Sources/faro/FaroPlugin.swift
@@ -76,6 +76,9 @@ public class FaroPlugin: NSObject, FlutterPlugin {
                 }
             }
         case "purgeCrashReport":
+            // Match getCrashReport's fallback when runtime discovery could not
+            // establish the owner before crash recovery starts.
+            claimSessionPersistenceOwnership()
             guard ownsSessionPersistence,
                   let crashReportingIntegration else {
                 result(nil)

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -1103,17 +1103,24 @@ class Faro {
   Future<void> _enableCrashReporterOnce({
     PersistedSessionRecord? recoveredSession,
   }) async {
+    // Preserve the launch-time consent decision across the native method call.
+    // An app may update the policy while crash reporter setup is in flight.
+    final collectionEnabledAtStart = enableDataCollection;
     try {
       if (_isIOSPlatform()) {
         await _nativeChannel?.enableCrashReporter(const <String, dynamic>{});
-        if (!enableDataCollection) {
-          return;
-        }
-
         final shouldAttemptRecovery =
             _ownsSessionPersistence == true ||
             (_ownsSessionPersistence == null &&
                 RootIsolateToken.instance != null);
+        if (!collectionEnabledAtStart || !enableDataCollection) {
+          if (shouldAttemptRecovery) {
+            // Do not upload a pending crash while collection is disabled.
+            await _nativeChannel?.purgeCrashReport();
+          }
+          return;
+        }
+
         if (shouldAttemptRecovery) {
           final crashReports = await _nativeChannel?.getCrashReport();
           if (crashReports != null && crashReports.isNotEmpty) {
@@ -1213,10 +1220,7 @@ class Faro {
     );
   }
 
-  Meta _metaForRecoveredSession(
-    PersistedSessionRecord recoveredSession, {
-    bool includeCurrentContext = false,
-  }) {
+  Meta _metaForRecoveredSession(PersistedSessionRecord recoveredSession) {
     final attributes = <String, dynamic>{
       'crashedSessionId': recoveredSession.currentSessionId,
       'isSampled': recoveredSession.isSampled,
@@ -1233,10 +1237,6 @@ class Faro {
       ),
       sdk: meta.sdk,
       app: meta.app,
-      view: includeCurrentContext ? meta.view : null,
-      browser: includeCurrentContext ? meta.browser : null,
-      page: includeCurrentContext ? meta.page : null,
-      user: includeCurrentContext ? meta.user : null,
       device: meta.device,
       os: meta.os,
     );
@@ -1367,10 +1367,7 @@ class Faro {
         } else if (recoveredSession.isSampled) {
           final sent = await _sendRecoveredCrash(
             exception,
-            _metaForRecoveredSession(
-              recoveredSession,
-              includeCurrentContext: true,
-            ),
+            _metaForRecoveredSession(recoveredSession),
             nativeRetryAvailable: true,
           );
           accepted = accepted && sent;
@@ -1524,13 +1521,21 @@ class Faro {
         continue;
       }
       hasDirectTransport = true;
-      if (transport is FaroTransport) {
-        final transportAccepted = await transport.sendHistoricalAcknowledged(
-          payloadJson,
+      try {
+        if (transport is FaroTransport) {
+          final transportAccepted = await transport.sendHistoricalAcknowledged(
+            payloadJson,
+          );
+          accepted = accepted && transportAccepted;
+        } else {
+          await transport.send(payloadJson);
+        }
+      } catch (error, stacktrace) {
+        accepted = false;
+        log(
+          'Faro: ${transport.runtimeType} failed for recovered crash: $error',
+          stackTrace: stacktrace,
         );
-        accepted = accepted && transportAccepted;
-      } else {
-        await transport.send(payloadJson);
       }
     }
     return accepted && (!nativeRetryAvailable || hasDirectTransport);

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -1192,7 +1192,10 @@ class Faro {
     );
   }
 
-  Meta _metaForRecoveredSession(PersistedSessionRecord recoveredSession) {
+  Meta _metaForRecoveredSession(
+    PersistedSessionRecord recoveredSession, {
+    bool includeCurrentContext = false,
+  }) {
     final attributes = <String, dynamic>{
       'crashedSessionId': recoveredSession.currentSessionId,
       'isSampled': recoveredSession.isSampled,
@@ -1209,6 +1212,10 @@ class Faro {
       ),
       sdk: meta.sdk,
       app: meta.app,
+      view: includeCurrentContext ? meta.view : null,
+      browser: includeCurrentContext ? meta.browser : null,
+      page: includeCurrentContext ? meta.page : null,
+      user: includeCurrentContext ? meta.user : null,
       device: meta.device,
       os: meta.os,
     );
@@ -1328,13 +1335,18 @@ class Faro {
             // Keep the structured native frames and wait for the transport.
             // pushError would reconstruct a Dart stack and batch delivery would
             // acknowledge the native report before an async send completed.
-            await _sendRecoveredCrash(exception, meta);
+            final sent = await _sendRecoveredCrash(exception, meta);
+            accepted = accepted && sent;
           }
         } else if (recoveredSession.isSampled) {
-          await _sendRecoveredCrash(
+          final sent = await _sendRecoveredCrash(
             exception,
-            _metaForRecoveredSession(recoveredSession),
+            _metaForRecoveredSession(
+              recoveredSession,
+              includeCurrentContext: true,
+            ),
           );
+          accepted = accepted && sent;
         }
       } catch (error, stacktrace) {
         accepted = false;
@@ -1461,23 +1473,28 @@ class Faro {
     return exception;
   }
 
-  Future<void> _sendRecoveredCrash(
+  Future<bool> _sendRecoveredCrash(
     FaroException exception,
     Meta recoveredCrashMeta,
   ) async {
     if (_dataCollectionPolicy?.isEnabled == false) {
-      return;
+      return false;
     }
     // The live batch carries the new session metadata, so recovered crashes
     // must use an isolated payload.
     final payload = Payload(recoveredCrashMeta)..exceptions.add(exception);
     final payloadJson = payload.toJson();
+    var accepted = true;
     for (final transport in List<BaseTransport>.of(_transports)) {
       if (transport is FaroTransport) {
-        await transport.sendHistorical(payloadJson);
+        final transportAccepted = await transport.sendHistoricalAcknowledged(
+          payloadJson,
+        );
+        accepted = accepted && transportAccepted;
       } else {
         await transport.send(payloadJson);
       }
     }
+    return accepted;
   }
 }

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -95,6 +95,7 @@ class Faro {
   List<PersistedSessionRecord> _recoveredSessionHistory =
       const <PersistedSessionRecord>[];
   String? _sessionProcessIdentifier;
+  bool _ownsSessionPersistence = false;
   bool _isSampled = true;
   bool _isInitialized = false;
   FaroWidgetsBindingObserver? _widgetsBindingObserver;
@@ -426,6 +427,7 @@ class Faro {
       return null;
     }
     _sessionProcessIdentifier = runtimeInfo.processIdentifier;
+    _ownsSessionPersistence = runtimeInfo.ownsSessionPersistence;
 
     final session = meta.session;
     if (session != null) {
@@ -507,6 +509,7 @@ class Faro {
   Future<void> _tearDownForReset() async {
     await _sessionPersistence?.flush();
     _sessionPersistence = null;
+    _ownsSessionPersistence = false;
     final widgetsBindingObserver = _widgetsBindingObserver;
     if (widgetsBindingObserver != null) {
       WidgetsBinding.instance.removeObserver(widgetsBindingObserver);
@@ -1065,19 +1068,23 @@ class Faro {
     PersistedSessionRecord? recoveredSession,
   }) async {
     try {
-      final recoveredCrashMeta = recoveredSession == null
-          ? null
-          : _metaForRecoveredSession(recoveredSession);
-      final metadata = (recoveredCrashMeta ?? meta).toFaroJson();
-      metadata['app'] = app.toJson();
-      metadata['apiKey'] = apiKey;
-      metadata['collectorUrl'] = collectorUrl;
-      metadata['reportPendingCrash'] =
-          (_sessionPersistence == null || recoveredSession != null) &&
-          (recoveredSession?.isSampled ?? true) &&
-          enableDataCollection;
       if (_isIOSPlatform()) {
-        _nativeChannel?.enableCrashReporter(metadata);
+        await _nativeChannel?.enableCrashReporter(const <String, dynamic>{});
+        if (_ownsSessionPersistence) {
+          final crashReports = await _nativeChannel?.getCrashReport();
+          if (crashReports != null) {
+            final recoveredSessions = _sessionPersistence != null
+                ? _recoveredSessionHistory
+                : null;
+            // Recovery sends must not hold up the next app launch.
+            unawaited(
+              _reportIOSCrashReports(
+                crashReports,
+                recoveredSessions: recoveredSessions,
+              ),
+            );
+          }
+        }
       }
       if (_isAndroidPlatform()) {
         final crashReports = await _nativeChannel?.getCrashReport();
@@ -1105,6 +1112,22 @@ class Faro {
         stackTrace: stacktrace,
       );
     }
+  }
+
+  @visibleForTesting
+  Future<void> reportIOSCrashesForTesting(
+    List<String> crashReports, {
+    PersistedSessionRecord? recoveredSession,
+    List<PersistedSessionRecord>? recoveredSessions,
+  }) {
+    return _reportIOSCrashReports(
+      crashReports,
+      recoveredSessions:
+          recoveredSessions ??
+          (recoveredSession == null
+              ? null
+              : <PersistedSessionRecord>[recoveredSession]),
+    );
   }
 
   @visibleForTesting
@@ -1208,6 +1231,73 @@ class Faro {
     }
   }
 
+  Future<void> _reportIOSCrashReports(
+    List<String> crashReports, {
+    required List<PersistedSessionRecord>? recoveredSessions,
+  }) async {
+    for (final crashInfo in crashReports) {
+      late final FaroException exception;
+      PersistedSessionRecord? recoveredSession;
+      try {
+        final decoded = json.decode(crashInfo);
+        if (decoded is! Map<String, dynamic>) {
+          throw const FormatException('Crash report must be an object');
+        }
+
+        final timestamp = DateTime.tryParse(
+          decoded['timestamp']?.toString() ?? '',
+        )?.toUtc();
+        if (recoveredSessions != null) {
+          if (timestamp != null) {
+            recoveredSession = _matchRecoveredSessionAt(
+              timestamp,
+              recoveredSessions,
+            );
+          }
+          if (recoveredSession == null) {
+            log('Faro: Ignoring iOS crash without a matching session');
+            continue;
+          }
+        }
+
+        exception = _iosCrashException(
+          decoded,
+          timestamp: timestamp,
+          crashedSessionId: recoveredSession?.currentSessionId,
+        );
+      } catch (error, stacktrace) {
+        log(
+          'Faro: Ignoring malformed iOS crash report: $error',
+          stackTrace: stacktrace,
+        );
+        continue;
+      }
+
+      try {
+        if (_dataCollectionPolicy?.isEnabled == false) {
+          continue;
+        }
+        if (recoveredSession == null) {
+          _telemetryRouter.ingest(
+            TelemetryItem.fromException(exception),
+            activity: SessionActivityKind.passive,
+            skipBuffer: true,
+          );
+        } else if (recoveredSession.isSampled) {
+          await _sendRecoveredCrash(
+            exception,
+            _metaForRecoveredSession(recoveredSession),
+          );
+        }
+      } catch (error, stacktrace) {
+        log(
+          'Faro: Failed to report recovered iOS crash: $error',
+          stackTrace: stacktrace,
+        );
+      }
+    }
+  }
+
   PersistedSessionRecord? _matchRecoveredSession(
     Map<String, dynamic> crashInfo,
     List<PersistedSessionRecord> recoveredSessions, {
@@ -1230,6 +1320,13 @@ class Faro {
       isUtc: true,
     );
 
+    return _matchRecoveredSessionAt(crashTime, recoveredSessions);
+  }
+
+  PersistedSessionRecord? _matchRecoveredSessionAt(
+    DateTime crashTime,
+    List<PersistedSessionRecord> recoveredSessions,
+  ) {
     PersistedSessionRecord? match;
     for (final session in recoveredSessions) {
       if (session.startedAt.isAfter(crashTime)) {
@@ -1242,6 +1339,37 @@ class Faro {
       }
     }
     return match;
+  }
+
+  FaroException _iosCrashException(
+    Map<String, dynamic> crashInfo, {
+    required DateTime? timestamp,
+    String? crashedSessionId,
+  }) {
+    final nativeType = crashInfo['type']?.toString();
+    final context = <String, String>{};
+    if (nativeType != null && nativeType.isNotEmpty) {
+      context['nativeType'] = nativeType;
+    }
+    if (crashedSessionId != null) {
+      context['crashedSessionId'] = crashedSessionId;
+    }
+
+    final rawStacktrace = crashInfo['stacktrace'];
+    final stacktrace = rawStacktrace is Map
+        ? Map<String, dynamic>.from(rawStacktrace)
+        : <String, dynamic>{};
+    final exception = FaroException(
+      'crash',
+      crashInfo['value']?.toString() ?? 'Application crash',
+      stacktrace,
+      fatal: true,
+      context: context.isEmpty ? null : context,
+    );
+    if (timestamp != null) {
+      exception.timestamp = timestamp.toIso8601String();
+    }
+    return exception;
   }
 
   FaroException _androidCrashException(

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
+import 'dart:ui' show RootIsolateToken;
 
 import 'package:faro/src/configurations/batch_config.dart';
 import 'package:faro/src/configurations/faro_config.dart';
@@ -95,7 +96,7 @@ class Faro {
   List<PersistedSessionRecord> _recoveredSessionHistory =
       const <PersistedSessionRecord>[];
   String? _sessionProcessIdentifier;
-  bool _ownsSessionPersistence = false;
+  bool? _ownsSessionPersistence;
   bool _isSampled = true;
   bool _isInitialized = false;
   FaroWidgetsBindingObserver? _widgetsBindingObserver;
@@ -277,11 +278,10 @@ class Faro {
       ignoreUrls: optionsConfiguration.ignoreUrls,
     );
     if (config?.enableCrashReporting == true) {
-      _instance.enableCrashReporter(
-        app: _instance.meta.app!,
-        apiKey: optionsConfiguration.apiKey,
-        collectorUrl: optionsConfiguration.collectorUrl ?? '',
-        recoveredSession: persistedPreviousSession,
+      unawaited(
+        _instance._enableCrashReporter(
+          recoveredSession: persistedPreviousSession,
+        ),
       );
     }
     if (Platform.isAndroid || Platform.isIOS) {
@@ -509,7 +509,7 @@ class Faro {
   Future<void> _tearDownForReset() async {
     await _sessionPersistence?.flush();
     _sessionPersistence = null;
-    _ownsSessionPersistence = false;
+    _ownsSessionPersistence = null;
     final widgetsBindingObserver = _widgetsBindingObserver;
     if (widgetsBindingObserver != null) {
       WidgetsBinding.instance.removeObserver(widgetsBindingObserver);
@@ -1061,24 +1061,47 @@ class Faro {
     eventMark.remove(key);
   }
 
+  /// Deprecated. Enable crash reporting and configure transports through
+  /// [FaroConfig] instead.
+  @Deprecated(
+    'Use FaroConfig.enableCrashReporting and FaroConfig transports instead.',
+  )
   Future<void>? enableCrashReporter({
     required App app,
     required String apiKey,
     required String collectorUrl,
     PersistedSessionRecord? recoveredSession,
+  }) {
+    log(
+      'Faro: enableCrashReporter() is deprecated. Its app, apiKey, and '
+      'collectorUrl arguments no longer override FaroConfig.',
+    );
+    return _enableCrashReporter(recoveredSession: recoveredSession);
+  }
+
+  Future<void> _enableCrashReporter({
+    PersistedSessionRecord? recoveredSession,
   }) async {
     try {
       if (_isIOSPlatform()) {
         await _nativeChannel?.enableCrashReporter(const <String, dynamic>{});
-        if (_ownsSessionPersistence) {
+        if (!enableDataCollection) {
+          return;
+        }
+
+        final shouldAttemptRecovery =
+            _ownsSessionPersistence == true ||
+            (_ownsSessionPersistence == null &&
+                RootIsolateToken.instance != null);
+        if (shouldAttemptRecovery) {
           final crashReports = await _nativeChannel?.getCrashReport();
-          if (crashReports != null) {
+          if (crashReports != null && crashReports.isNotEmpty) {
             final recoveredSessions = _sessionPersistence != null
                 ? _recoveredSessionHistory
                 : null;
             // Recovery sends must not hold up the next app launch.
             unawaited(
-              _reportIOSCrashReports(
+              _reportAndPurgeIOSCrashReports(
                 crashReports,
                 recoveredSessions: recoveredSessions,
               ),
@@ -1114,8 +1137,29 @@ class Faro {
     }
   }
 
+  Future<void> _reportAndPurgeIOSCrashReports(
+    List<String> crashReports, {
+    required List<PersistedSessionRecord>? recoveredSessions,
+  }) async {
+    try {
+      final accepted = await _reportIOSCrashReports(
+        crashReports,
+        recoveredSessions: recoveredSessions,
+      );
+      if (accepted) {
+        await _nativeChannel?.purgeCrashReport();
+      }
+    } catch (error, stacktrace) {
+      // Keep the native report so the next launch can retry it.
+      log(
+        'Faro: Failed to acknowledge recovered iOS crash: $error',
+        stackTrace: stacktrace,
+      );
+    }
+  }
+
   @visibleForTesting
-  Future<void> reportIOSCrashesForTesting(
+  Future<bool> reportIOSCrashesForTesting(
     List<String> crashReports, {
     PersistedSessionRecord? recoveredSession,
     List<PersistedSessionRecord>? recoveredSessions,
@@ -1231,10 +1275,11 @@ class Faro {
     }
   }
 
-  Future<void> _reportIOSCrashReports(
+  Future<bool> _reportIOSCrashReports(
     List<String> crashReports, {
     required List<PersistedSessionRecord>? recoveredSessions,
   }) async {
+    var accepted = true;
     for (final crashInfo in crashReports) {
       late final FaroException exception;
       PersistedSessionRecord? recoveredSession;
@@ -1247,13 +1292,14 @@ class Faro {
         final timestamp = DateTime.tryParse(
           decoded['timestamp']?.toString() ?? '',
         )?.toUtc();
+        if (timestamp == null) {
+          throw const FormatException('Crash report must include a timestamp');
+        }
         if (recoveredSessions != null) {
-          if (timestamp != null) {
-            recoveredSession = _matchRecoveredSessionAt(
-              timestamp,
-              recoveredSessions,
-            );
-          }
+          recoveredSession = _matchRecoveredSessionAt(
+            timestamp,
+            recoveredSessions,
+          );
           if (recoveredSession == null) {
             log('Faro: Ignoring iOS crash without a matching session');
             continue;
@@ -1275,14 +1321,15 @@ class Faro {
 
       try {
         if (_dataCollectionPolicy?.isEnabled == false) {
-          continue;
+          return false;
         }
         if (recoveredSession == null) {
-          _telemetryRouter.ingest(
-            TelemetryItem.fromException(exception),
-            activity: SessionActivityKind.passive,
-            skipBuffer: true,
-          );
+          if (_isSampled) {
+            // Keep the structured native frames and wait for the transport.
+            // pushError would reconstruct a Dart stack and batch delivery would
+            // acknowledge the native report before an async send completed.
+            await _sendRecoveredCrash(exception, meta);
+          }
         } else if (recoveredSession.isSampled) {
           await _sendRecoveredCrash(
             exception,
@@ -1290,12 +1337,14 @@ class Faro {
           );
         }
       } catch (error, stacktrace) {
+        accepted = false;
         log(
           'Faro: Failed to report recovered iOS crash: $error',
           stackTrace: stacktrace,
         );
       }
     }
+    return accepted;
   }
 
   PersistedSessionRecord? _matchRecoveredSession(

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -100,6 +100,7 @@ class Faro {
   bool? _ownsSessionPersistence;
   bool _isSampled = true;
   bool _isInitialized = false;
+  Future<void>? _iosCrashReporterEnablement;
   FaroWidgetsBindingObserver? _widgetsBindingObserver;
   bool _didAttachUiActivityMonitor = false;
 
@@ -1089,6 +1090,17 @@ class Faro {
   }
 
   Future<void> _enableCrashReporter({
+    PersistedSessionRecord? recoveredSession,
+  }) {
+    if (!_isIOSPlatform() || _nativeChannel == null) {
+      return _enableCrashReporterOnce(recoveredSession: recoveredSession);
+    }
+    return _iosCrashReporterEnablement ??= _enableCrashReporterOnce(
+      recoveredSession: recoveredSession,
+    );
+  }
+
+  Future<void> _enableCrashReporterOnce({
     PersistedSessionRecord? recoveredSession,
   }) async {
     try {

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -18,6 +18,7 @@ import 'package:faro/src/integrations/native_integration.dart';
 import 'package:faro/src/integrations/on_error_integration.dart';
 import 'package:faro/src/models/models.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
+import 'package:faro/src/offline_transport/offline_transport.dart';
 import 'package:faro/src/session/session_activity_kind.dart';
 import 'package:faro/src/session/session_id_provider.dart';
 import 'package:faro/src/session/session_manager.dart';
@@ -1485,7 +1486,15 @@ class Faro {
     final payload = Payload(recoveredCrashMeta)..exceptions.add(exception);
     final payloadJson = payload.toJson();
     var accepted = true;
+    var hasDirectTransport = false;
     for (final transport in List<BaseTransport>.of(_transports)) {
+      // The native crash report is already the durable retry copy. Sending it
+      // to OfflineTransport as well would create a second retry owner and can
+      // deliver the same crash twice after connectivity returns.
+      if (transport is OfflineTransport) {
+        continue;
+      }
+      hasDirectTransport = true;
       if (transport is FaroTransport) {
         final transportAccepted = await transport.sendHistoricalAcknowledged(
           payloadJson,
@@ -1495,6 +1504,6 @@ class Faro {
         await transport.send(payloadJson);
       }
     }
-    return accepted;
+    return hasDirectTransport && accepted;
   }
 }

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -1272,6 +1272,7 @@ class Faro {
           await _sendRecoveredCrash(
             exception,
             _metaForRecoveredSession(recoveredSession),
+            nativeRetryAvailable: false,
           );
         }
       } catch (error, stacktrace) {
@@ -1336,7 +1337,11 @@ class Faro {
             // Keep the structured native frames and wait for the transport.
             // pushError would reconstruct a Dart stack and batch delivery would
             // acknowledge the native report before an async send completed.
-            final sent = await _sendRecoveredCrash(exception, meta);
+            final sent = await _sendRecoveredCrash(
+              exception,
+              meta,
+              nativeRetryAvailable: true,
+            );
             accepted = accepted && sent;
           }
         } else if (recoveredSession.isSampled) {
@@ -1346,6 +1351,7 @@ class Faro {
               recoveredSession,
               includeCurrentContext: true,
             ),
+            nativeRetryAvailable: true,
           );
           accepted = accepted && sent;
         }
@@ -1476,8 +1482,9 @@ class Faro {
 
   Future<bool> _sendRecoveredCrash(
     FaroException exception,
-    Meta recoveredCrashMeta,
-  ) async {
+    Meta recoveredCrashMeta, {
+    required bool nativeRetryAvailable,
+  }) async {
     if (_dataCollectionPolicy?.isEnabled == false) {
       return false;
     }
@@ -1488,10 +1495,12 @@ class Faro {
     var accepted = true;
     var hasDirectTransport = false;
     for (final transport in List<BaseTransport>.of(_transports)) {
-      // The native crash report is already the durable retry copy. Sending it
-      // to OfflineTransport as well would create a second retry owner and can
-      // deliver the same crash twice after connectivity returns.
-      if (transport is OfflineTransport) {
+      // PLCrashReporter keeps the iOS report until this handoff succeeds.
+      // Sending it to OfflineTransport as well would create a second retry
+      // owner and can deliver the same crash twice after connectivity returns.
+      // Android ApplicationExitInfo has no retained native copy, so Android
+      // must continue using OfflineTransport when it is configured.
+      if (nativeRetryAvailable && transport is OfflineTransport) {
         continue;
       }
       hasDirectTransport = true;
@@ -1504,6 +1513,6 @@ class Faro {
         await transport.send(payloadJson);
       }
     }
-    return hasDirectTransport && accepted;
+    return accepted && (!nativeRetryAvailable || hasDirectTransport);
   }
 }

--- a/lib/src/native_platform_interaction/faro_native_methods.dart
+++ b/lib/src/native_platform_interaction/faro_native_methods.dart
@@ -45,6 +45,10 @@ class FaroNativeMethods {
     return FaroSdkPlatform.instance.getCrashReport();
   }
 
+  Future<void> purgeCrashReport() {
+    return FaroSdkPlatform.instance.purgeCrashReport();
+  }
+
   Future<Map<String, dynamic>?> getSessionRuntimeInfo({
     required bool claimSessionPersistence,
   }) {

--- a/lib/src/native_platform_interaction/faro_sdk_method_channel.dart
+++ b/lib/src/native_platform_interaction/faro_sdk_method_channel.dart
@@ -79,6 +79,11 @@ class MethodChannelFaroSdk extends FaroSdkPlatform {
   }
 
   @override
+  Future<void> purgeCrashReport() async {
+    await methodChannel.invokeMethod<void>('purgeCrashReport');
+  }
+
+  @override
   Future<Map<String, dynamic>?> getSessionRuntimeInfo({
     required bool claimSessionPersistence,
   }) {

--- a/lib/src/native_platform_interaction/faro_sdk_platform_interface.dart
+++ b/lib/src/native_platform_interaction/faro_sdk_platform_interface.dart
@@ -71,6 +71,10 @@ abstract class FaroSdkPlatform extends PlatformInterface {
     throw UnimplementedError('getCrashReport() has not been implemented');
   }
 
+  Future<void> purgeCrashReport() {
+    throw UnimplementedError('purgeCrashReport() has not been implemented');
+  }
+
   Future<Map<String, dynamic>?> getSessionRuntimeInfo({
     required bool claimSessionPersistence,
   }) {

--- a/lib/src/transport/faro_transport.dart
+++ b/lib/src/transport/faro_transport.dart
@@ -67,13 +67,21 @@ class FaroTransport extends BaseTransport {
     await _send(payloadJson, processSessionInvalidation: false);
   }
 
-  Future<void> _send(
+  /// Sends historical telemetry and reports whether the collector accepted it.
+  ///
+  /// This is used when the caller owns the only durable copy and must not
+  /// discard it until the collector returns a successful response.
+  Future<bool> sendHistoricalAcknowledged(Map<String, dynamic> payloadJson) {
+    return _send(payloadJson, processSessionInvalidation: false);
+  }
+
+  Future<bool> _send(
     Map<String, dynamic> payloadJson, {
     required bool processSessionInvalidation,
   }) async {
     if (Faro().enableDataCollection == false) {
       log('Data collection is disabled. Skipping sending data.');
-      return;
+      return false;
     }
 
     try {
@@ -103,6 +111,11 @@ class FaroTransport extends BaseTransport {
           'Error sending payload: ${response.statusCode}, '
           'body: ${response.body} payload:$encodedPayload',
         );
+        return false;
+      }
+
+      if (response == null) {
+        return false;
       }
 
       if (response != null &&
@@ -114,8 +127,10 @@ class FaroTransport extends BaseTransport {
         log('Faro: Receiver reported the submitted session as invalid.');
         _onSessionInvalidated?.call(sentSessionId);
       }
+      return true;
     } catch (error) {
       log('Error sending payload: $error');
+      return false;
     }
   }
 

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -814,6 +814,9 @@ java.lang.NullPointerException: test crash
     });
 
     test('recovered crash is sent with the crashed session metadata', () async {
+      final offlineTransport = MockOfflineTransport();
+      when(() => offlineTransport.send(any())).thenAnswer((_) async {});
+      Faro().transports = <BaseTransport>[offlineTransport, mockFaroTransport];
       final currentSessionId = Faro().meta.session?.id;
       final recoveredSession = PersistedSessionRecord(
         currentSessionId: 'crashed-session',
@@ -857,6 +860,7 @@ java.lang.NullPointerException: test crash
       expect(payload['meta'], isNot(contains('view')));
       expect(payload['meta'], isNot(contains('user')));
       expect(payload['meta'], isNot(contains('page')));
+      verify(() => offlineTransport.send(any())).called(1);
       expect(
         payload['exceptions'][0]['context']['crashedSessionId'],
         'crashed-session',

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -334,6 +334,57 @@ void main() {
         },
       );
 
+      test('iOS enables crash recovery only once', () async {
+        stubRuntimeInfo(ownsPersistence: true);
+        Faro().iosPlatformResolver = () => true;
+        Faro().androidPlatformResolver = () => false;
+
+        await Faro().init(
+          optionsConfiguration: createConfig(enableCrashReporting: true),
+        );
+        await Faro().enableCrashReporter(
+          app: App(name: appName, version: appVersion, environment: appEnv),
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+        );
+        await Faro().enableCrashReporter(
+          app: App(name: appName, version: appVersion, environment: appEnv),
+          apiKey: apiKey,
+          collectorUrl: 'https://some-url.com',
+        );
+
+        verify(
+          () => mockFaroNativeMethods.enableCrashReporter(any()),
+        ).called(1);
+        verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
+      });
+
+      test(
+        'an iOS pre-init call does not suppress configured recovery',
+        () async {
+          stubRuntimeInfo(ownsPersistence: true);
+          Faro().iosPlatformResolver = () => true;
+          Faro().androidPlatformResolver = () => false;
+          Faro().nativeChannel = null;
+
+          await Faro().enableCrashReporter(
+            app: App(name: appName, version: appVersion, environment: appEnv),
+            apiKey: apiKey,
+            collectorUrl: 'https://some-url.com',
+          );
+          Faro().nativeChannel = mockFaroNativeMethods;
+          await Faro().init(
+            optionsConfiguration: createConfig(enableCrashReporting: true),
+          );
+          await untilCalled(() => mockFaroNativeMethods.getCrashReport());
+
+          verify(
+            () => mockFaroNativeMethods.enableCrashReporter(any()),
+          ).called(1);
+          verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
+        },
+      );
+
       test(
         'iOS keeps the crash fallback when persistence is disabled',
         () async {

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -13,6 +13,7 @@ import 'package:faro/src/session/session_persistence.dart';
 import 'package:faro/src/tracing/faro_span_context.dart';
 import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/transport/batch_transport.dart';
+import 'package:faro/src/transport/faro_base_transport.dart';
 import 'package:faro/src/transport/faro_transport.dart';
 import 'package:faro/src/util/constants.dart';
 import 'package:flutter/foundation.dart';
@@ -24,6 +25,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 class MockFaroTransport extends Mock implements FaroTransport {}
 
 class MockBatchTransport extends Mock implements BatchTransport {}
+
+class MockBaseTransport extends Mock implements BaseTransport {}
 
 class MockFaroNativeMethods extends Mock implements FaroNativeMethods {}
 
@@ -39,6 +42,7 @@ void main() {
 
     late MockFaroTransport mockFaroTransport;
     late MockBatchTransport mockBatchTransport;
+    late MockBaseTransport mockBaseTransport;
     late MockFaroNativeMethods mockFaroNativeMethods;
     late MockDataCollectionPolicy mockDataCollectionPolicy;
 
@@ -80,6 +84,7 @@ void main() {
 
       mockFaroTransport = MockFaroTransport();
       mockBatchTransport = MockBatchTransport();
+      mockBaseTransport = MockBaseTransport();
       mockFaroNativeMethods = MockFaroNativeMethods();
 
       BatchTransportFactory().setInstance(mockBatchTransport);
@@ -92,6 +97,9 @@ void main() {
         () => mockFaroNativeMethods.enableCrashReporter(any()),
       ).thenAnswer((_) async {});
       when(
+        () => mockFaroNativeMethods.getCrashReport(),
+      ).thenAnswer((_) async => null);
+      when(
         () => mockBatchTransport.addExceptions(any()),
       ).thenAnswer((_) async {});
       when(() => mockBatchTransport.addLog(any())).thenAnswer((_) async {});
@@ -103,6 +111,7 @@ void main() {
         () => mockBatchTransport.updatePayloadMeta(any()),
       ).thenAnswer((_) async {});
       when(() => mockFaroTransport.send(any())).thenAnswer((_) async {});
+      when(() => mockBaseTransport.send(any())).thenAnswer((_) async {});
       when(
         () => mockFaroTransport.sendHistorical(any()),
       ).thenAnswer((_) async {});
@@ -289,18 +298,27 @@ void main() {
           stubRuntimeInfo(ownsPersistence: true);
           Faro().iosPlatformResolver = () => true;
           Faro().androidPlatformResolver = () => false;
+          when(() => mockFaroNativeMethods.getCrashReport()).thenAnswer(
+            (_) async => <String>[
+              json.encode({
+                'type': 'SIGSEGV',
+                'value': 'Application crash',
+                'timestamp': '2026-08-14T12:03:00.000Z',
+              }),
+            ],
+          );
 
           await Faro().init(
             optionsConfiguration: createConfig(enableCrashReporting: true),
           );
 
-          final config =
-              verify(
-                    () =>
-                        mockFaroNativeMethods.enableCrashReporter(captureAny()),
-                  ).captured.single
-                  as Map<String, dynamic>;
-          expect(config['reportPendingCrash'], isFalse);
+          final config = verify(
+            () => mockFaroNativeMethods.enableCrashReporter(captureAny()),
+          ).captured.single;
+          expect(config, isEmpty);
+          verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
+          verifyNever(() => mockFaroTransport.sendHistorical(any()));
+          verifyNever(() => mockBatchTransport.addExceptions(any()));
         },
       );
 
@@ -310,6 +328,15 @@ void main() {
           stubRuntimeInfo(ownsPersistence: true);
           Faro().iosPlatformResolver = () => true;
           Faro().androidPlatformResolver = () => false;
+          when(() => mockFaroNativeMethods.getCrashReport()).thenAnswer(
+            (_) async => <String>[
+              json.encode({
+                'type': 'SIGABRT',
+                'value': 'Application crash',
+                'timestamp': '2026-08-14T12:03:00.000Z',
+              }),
+            ],
+          );
 
           await Faro().init(
             optionsConfiguration: createConfig(
@@ -318,15 +345,29 @@ void main() {
             ),
           );
 
-          final config =
-              verify(
-                    () =>
-                        mockFaroNativeMethods.enableCrashReporter(captureAny()),
-                  ).captured.single
-                  as Map<String, dynamic>;
-          expect(config['reportPendingCrash'], isTrue);
+          final config = verify(
+            () => mockFaroNativeMethods.enableCrashReporter(captureAny()),
+          ).captured.single;
+          expect(config, isEmpty);
+          verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
+          verify(() => mockBatchTransport.addExceptions(any())).called(1);
         },
       );
+
+      test('iOS non-owner does not consume the pending crash', () async {
+        stubRuntimeInfo(ownsPersistence: false);
+        Faro().iosPlatformResolver = () => true;
+        Faro().androidPlatformResolver = () => false;
+
+        await Faro().init(
+          optionsConfiguration: createConfig(enableCrashReporting: true),
+        );
+
+        verify(
+          () => mockFaroNativeMethods.enableCrashReporter(any()),
+        ).called(1);
+        verifyNever(() => mockFaroNativeMethods.getCrashReport());
+      });
 
       test(
         'a non-owner stays in memory and preserves the owned record',
@@ -368,12 +409,10 @@ void main() {
           Faro().meta.session?.attributes?.containsKey('previousSession'),
           isFalse,
         );
-        final config =
-            verify(
-                  () => mockFaroNativeMethods.enableCrashReporter(captureAny()),
-                ).captured.single
-                as Map<String, dynamic>;
-        expect(config['reportPendingCrash'], isTrue);
+        verify(
+          () => mockFaroNativeMethods.enableCrashReporter(any()),
+        ).called(1);
+        verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
       });
     });
 
@@ -727,34 +766,147 @@ java.lang.NullPointerException: test crash
       verifyNever(() => mockBatchTransport.addExceptions(any()));
     });
 
-    test('iOS crash metadata uses Faro session attribute values', () async {
-      Faro().iosPlatformResolver = () => true;
-      Faro().androidPlatformResolver = () => false;
+    test(
+      'recovered iOS crash uses the original session and normal type',
+      () async {
+        final recoveredSession = PersistedSessionRecord(
+          currentSessionId: 'crashed-session',
+          previousSessionId: 'older-session',
+          startedAt: DateTime.utc(2026, 8, 14, 12),
+          lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
+          isSampled: true,
+        );
+        final crashReport = json.encode({
+          'type': 'SIGSEGV (SEGV_MAPERR)',
+          'value': 'Application crash: SIGSEGV',
+          'stacktrace': {
+            'frames': [
+              {'filename': 'Runner', 'function': 'crash', 'lineno': 42},
+            ],
+          },
+          'timestamp': '2026-08-14T12:03:00.000Z',
+          'fatal': true,
+        });
+
+        await Faro().reportIOSCrashesForTesting([
+          crashReport,
+        ], recoveredSession: recoveredSession);
+
+        final payload =
+            verify(
+                  () => mockFaroTransport.sendHistorical(captureAny()),
+                ).captured.single
+                as Map<String, dynamic>;
+        final exception = payload['exceptions'][0] as Map<String, dynamic>;
+        expect(payload['meta']['session']['id'], 'crashed-session');
+        expect(
+          payload['meta']['session']['attributes'],
+          containsPair('isSampled', 'true'),
+        );
+        expect(exception['type'], 'crash');
+        expect(exception['fatal'], isTrue);
+        expect(exception['context']['nativeType'], 'SIGSEGV (SEGV_MAPERR)');
+        expect(exception['context']['crashedSessionId'], 'crashed-session');
+        expect(exception['stacktrace']['frames'], hasLength(1));
+        verifyNever(() => mockBatchTransport.addExceptions(any()));
+      },
+    );
+
+    test('recovered iOS crash reaches custom transports', () async {
+      Faro().transports = <BaseTransport>[mockFaroTransport, mockBaseTransport];
       final recoveredSession = PersistedSessionRecord(
         currentSessionId: 'crashed-session',
-        previousSessionId: 'older-session',
+        previousSessionId: null,
         startedAt: DateTime.utc(2026, 8, 14, 12),
         lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
         isSampled: true,
       );
+      final crashReport = json.encode({
+        'type': 'SIGSEGV',
+        'value': 'Application crash',
+        'timestamp': '2026-08-14T12:03:00.000Z',
+      });
 
-      await Faro().enableCrashReporter(
-        app: App(name: appName, version: appVersion, environment: appEnv),
-        apiKey: apiKey,
-        collectorUrl: 'https://some-url.com',
-        recoveredSession: recoveredSession,
-      );
+      await Faro().reportIOSCrashesForTesting([
+        crashReport,
+      ], recoveredSession: recoveredSession);
 
-      final config =
+      verify(() => mockFaroTransport.sendHistorical(any())).called(1);
+      verify(() => mockBaseTransport.send(any())).called(1);
+    });
+
+    test('iOS live-session fallback preserves the structured stack', () async {
+      final crashReport = json.encode({
+        'type': 'SIGABRT',
+        'value': 'Application crash: SIGABRT',
+        'stacktrace': {
+          'frames': [
+            {'filename': 'Runner', 'function': 'abort'},
+          ],
+        },
+        'timestamp': '2026-08-14T12:03:00.000Z',
+      });
+
+      await Faro().reportIOSCrashesForTesting([crashReport]);
+
+      final exception =
           verify(
-                () => mockFaroNativeMethods.enableCrashReporter(captureAny()),
+                () => mockBatchTransport.addExceptions(captureAny()),
               ).captured.single
-              as Map<String, dynamic>;
-      expect(
-        config['session']['attributes'],
-        containsPair('isSampled', 'true'),
+              as FaroException;
+      expect(exception.type, 'crash');
+      expect(exception.fatal, isTrue);
+      expect(exception.context?['nativeType'], 'SIGABRT');
+      expect(exception.stacktrace?['frames'], hasLength(1));
+    });
+
+    test('malformed iOS crash does not block the next report', () async {
+      final validCrash = json.encode({
+        'type': 'SIGABRT',
+        'value': 'Application crash',
+        'timestamp': '2026-08-14T12:03:00.000Z',
+      });
+
+      await Faro().reportIOSCrashesForTesting(['[]', validCrash]);
+
+      verify(() => mockBatchTransport.addExceptions(any())).called(1);
+    });
+
+    test('recovered iOS crash from an unsampled session is not sent', () async {
+      final recoveredSession = PersistedSessionRecord(
+        currentSessionId: 'unsampled-session',
+        previousSessionId: null,
+        startedAt: DateTime.utc(2026, 8, 14, 12),
+        lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
+        isSampled: false,
       );
-      expect(config['reportPendingCrash'], isTrue);
+      final crashReport = json.encode({
+        'type': 'SIGSEGV',
+        'value': 'Application crash',
+        'timestamp': '2026-08-14T12:03:00.000Z',
+      });
+
+      await Faro().reportIOSCrashesForTesting([
+        crashReport,
+      ], recoveredSession: recoveredSession);
+
+      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockBatchTransport.addExceptions(any()));
+    });
+
+    test('recovered iOS crash respects disabled data collection', () async {
+      Faro().dataCollectionPolicy = mockDataCollectionPolicy;
+      when(() => mockDataCollectionPolicy.isEnabled).thenReturn(false);
+      final crashReport = json.encode({
+        'type': 'SIGSEGV',
+        'value': 'Application crash',
+        'timestamp': '2026-08-14T12:03:00.000Z',
+      });
+
+      await Faro().reportIOSCrashesForTesting([crashReport]);
+
+      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockBatchTransport.addExceptions(any()));
     });
 
     test('recovered crash from an unsampled session is not sent', () async {

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -509,20 +509,97 @@ void main() {
         },
       );
 
-      test('iOS leaves a pending crash while collection is disabled', () async {
-        SharedPreferences.setMockInitialValues({
-          'faro_enable_data_collection': false,
-        });
+      test(
+        'iOS discards an opted-out crash when collection is re-enabled',
+        () async {
+          final enableStarted = Completer<void>();
+          final enableResult = Completer<void>();
+          when(
+            () => mockFaroNativeMethods.enableCrashReporter(any()),
+          ).thenAnswer((_) {
+            enableStarted.complete();
+            return enableResult.future;
+          });
+          SharedPreferences.setMockInitialValues({
+            'faro_enable_data_collection': false,
+          });
+          stubRuntimeInfo(ownsPersistence: true);
+          Faro().iosPlatformResolver = () => true;
+          Faro().androidPlatformResolver = () => false;
+
+          await Faro().init(
+            optionsConfiguration: createConfig(enableCrashReporting: true),
+          );
+
+          await enableStarted.future;
+          Faro().enableDataCollection = true;
+          enableResult.complete();
+          await untilCalled(() => mockFaroNativeMethods.purgeCrashReport());
+
+          verifyNever(() => mockFaroNativeMethods.getCrashReport());
+          verify(() => mockFaroNativeMethods.purgeCrashReport()).called(1);
+        },
+      );
+
+      test(
+        'iOS discards a crash when collection is disabled during setup',
+        () async {
+          final enableStarted = Completer<void>();
+          final enableResult = Completer<void>();
+          when(
+            () => mockFaroNativeMethods.enableCrashReporter(any()),
+          ).thenAnswer((_) {
+            enableStarted.complete();
+            return enableResult.future;
+          });
+          stubRuntimeInfo(ownsPersistence: true);
+          Faro().iosPlatformResolver = () => true;
+          Faro().androidPlatformResolver = () => false;
+
+          await Faro().init(
+            optionsConfiguration: createConfig(enableCrashReporting: true),
+          );
+
+          await enableStarted.future;
+          Faro().enableDataCollection = false;
+          enableResult.complete();
+          await untilCalled(() => mockFaroNativeMethods.purgeCrashReport());
+
+          verifyNever(() => mockFaroNativeMethods.getCrashReport());
+          verify(() => mockFaroNativeMethods.purgeCrashReport()).called(1);
+        },
+      );
+
+      test('iOS retains the pending crash when purge fails', () async {
         stubRuntimeInfo(ownsPersistence: true);
         Faro().iosPlatformResolver = () => true;
         Faro().androidPlatformResolver = () => false;
+        when(() => mockFaroNativeMethods.getCrashReport()).thenAnswer(
+          (_) async => <String>[
+            json.encode({
+              'type': 'SIGABRT',
+              'value': 'Application crash',
+              'timestamp': '2026-08-14T12:03:00.000Z',
+            }),
+          ],
+        );
+        when(
+          () => mockFaroNativeMethods.purgeCrashReport(),
+        ).thenThrow(StateError('purge failed'));
 
         await Faro().init(
-          optionsConfiguration: createConfig(enableCrashReporting: true),
+          optionsConfiguration: createConfig(
+            persistSession: false,
+            enableCrashReporting: true,
+          ),
         );
 
-        verifyNever(() => mockFaroNativeMethods.getCrashReport());
-        verifyNever(() => mockFaroNativeMethods.purgeCrashReport());
+        await untilCalled(() => mockFaroNativeMethods.purgeCrashReport());
+        await Future<void>.delayed(Duration.zero);
+        verify(
+          () => mockFaroTransport.sendHistoricalAcknowledged(any()),
+        ).called(1);
+        verify(() => mockFaroNativeMethods.purgeCrashReport()).called(1);
       });
 
       test(
@@ -969,9 +1046,9 @@ java.lang.NullPointerException: test crash
           payload['meta']['session']['attributes'],
           containsPair('isSampled', 'true'),
         );
-        expect(payload['meta']['user']['id'], 'current-user');
-        expect(payload['meta']['view']['name'], 'current-view');
-        expect(payload['meta']['page']['url'], 'https://example.com/current');
+        expect(payload['meta'], isNot(contains('user')));
+        expect(payload['meta'], isNot(contains('view')));
+        expect(payload['meta'], isNot(contains('page')));
         expect(exception['type'], 'crash');
         expect(exception['fatal'], isTrue);
         expect(exception['context']['nativeType'], 'SIGSEGV (SEGV_MAPERR)');
@@ -1005,6 +1082,40 @@ java.lang.NullPointerException: test crash
       ).called(1);
       verify(() => mockBaseTransport.send(any())).called(1);
     });
+
+    test(
+      'recovered iOS crash continues after a custom transport throws',
+      () async {
+        Faro().transports = <BaseTransport>[
+          mockBaseTransport,
+          mockFaroTransport,
+        ];
+        when(
+          () => mockBaseTransport.send(any()),
+        ).thenThrow(StateError('transport unavailable'));
+        final recoveredSession = PersistedSessionRecord(
+          currentSessionId: 'crashed-session',
+          previousSessionId: null,
+          startedAt: DateTime.utc(2026, 8, 14, 12),
+          lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
+          isSampled: true,
+        );
+        final crashReport = json.encode({
+          'type': 'SIGSEGV',
+          'value': 'Application crash',
+          'timestamp': '2026-08-14T12:03:00.000Z',
+        });
+
+        final accepted = await Faro().reportIOSCrashesForTesting([
+          crashReport,
+        ], recoveredSession: recoveredSession);
+
+        expect(accepted, isFalse);
+        verify(
+          () => mockFaroTransport.sendHistoricalAcknowledged(any()),
+        ).called(1);
+      },
+    );
 
     test('iOS live-session fallback preserves the structured stack', () async {
       final crashReport = json.encode({

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -116,8 +117,8 @@ void main() {
       when(() => mockFaroTransport.send(any())).thenAnswer((_) async {});
       when(() => mockBaseTransport.send(any())).thenAnswer((_) async {});
       when(
-        () => mockFaroTransport.sendHistorical(any()),
-      ).thenAnswer((_) async {});
+        () => mockFaroTransport.sendHistoricalAcknowledged(any()),
+      ).thenAnswer((_) async => true);
     });
 
     tearDown(() async {
@@ -181,6 +182,7 @@ void main() {
           collectorUrl: 'https://some-url.com',
           persistSession: persistSession,
           enableCrashReporting: enableCrashReporting,
+          transports: const <FaroTransport>[],
         );
       }
 
@@ -322,7 +324,9 @@ void main() {
           verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
           await untilCalled(() => mockFaroNativeMethods.purgeCrashReport());
           verify(() => mockFaroNativeMethods.purgeCrashReport()).called(1);
-          verifyNever(() => mockFaroTransport.sendHistorical(any()));
+          verifyNever(
+            () => mockFaroTransport.sendHistoricalAcknowledged(any()),
+          );
           verifyNever(() => mockBatchTransport.addExceptions(any()));
         },
       );
@@ -355,12 +359,49 @@ void main() {
           ).captured.single;
           expect(config, isEmpty);
           verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
-          verify(() => mockFaroTransport.sendHistorical(any())).called(1);
+          verify(
+            () => mockFaroTransport.sendHistoricalAcknowledged(any()),
+          ).called(1);
           verifyNever(() => mockBatchTransport.addExceptions(any()));
           await untilCalled(() => mockFaroNativeMethods.purgeCrashReport());
           verify(() => mockFaroNativeMethods.purgeCrashReport()).called(1);
         },
       );
+
+      test('iOS retains the pending crash when delivery is rejected', () async {
+        final deliveryStarted = Completer<void>();
+        final deliveryResult = Completer<bool>();
+        stubRuntimeInfo(ownsPersistence: true);
+        Faro().iosPlatformResolver = () => true;
+        Faro().androidPlatformResolver = () => false;
+        when(() => mockFaroNativeMethods.getCrashReport()).thenAnswer(
+          (_) async => <String>[
+            json.encode({
+              'type': 'SIGABRT',
+              'value': 'Application crash',
+              'timestamp': '2026-08-14T12:03:00.000Z',
+            }),
+          ],
+        );
+        when(
+          () => mockFaroTransport.sendHistoricalAcknowledged(any()),
+        ).thenAnswer((_) {
+          deliveryStarted.complete();
+          return deliveryResult.future;
+        });
+
+        await Faro().init(
+          optionsConfiguration: createConfig(
+            persistSession: false,
+            enableCrashReporting: true,
+          ),
+        );
+
+        await deliveryStarted.future;
+        deliveryResult.complete(false);
+        await Future<void>.delayed(Duration.zero);
+        verifyNever(() => mockFaroNativeMethods.purgeCrashReport());
+      });
 
       test('iOS non-owner does not consume the pending crash', () async {
         stubRuntimeInfo(ownsPersistence: false);
@@ -787,7 +828,8 @@ java.lang.NullPointerException: test crash
 
       final payload =
           verify(
-                () => mockFaroTransport.sendHistorical(captureAny()),
+                () =>
+                    mockFaroTransport.sendHistoricalAcknowledged(captureAny()),
               ).captured.single
               as Map<String, dynamic>;
       expect(payload['meta']['session']['id'], 'crashed-session');
@@ -824,6 +866,9 @@ java.lang.NullPointerException: test crash
     test(
       'recovered iOS crash uses the original session and normal type',
       () async {
+        Faro().meta.user = const FaroUser(id: 'current-user');
+        Faro().meta.view = ViewMeta('current-view');
+        Faro().meta.page = Page('https://example.com/current');
         final recoveredSession = PersistedSessionRecord(
           currentSessionId: 'crashed-session',
           previousSessionId: 'older-session',
@@ -849,7 +894,9 @@ java.lang.NullPointerException: test crash
 
         final payload =
             verify(
-                  () => mockFaroTransport.sendHistorical(captureAny()),
+                  () => mockFaroTransport.sendHistoricalAcknowledged(
+                    captureAny(),
+                  ),
                 ).captured.single
                 as Map<String, dynamic>;
         final exception = payload['exceptions'][0] as Map<String, dynamic>;
@@ -858,6 +905,9 @@ java.lang.NullPointerException: test crash
           payload['meta']['session']['attributes'],
           containsPair('isSampled', 'true'),
         );
+        expect(payload['meta']['user']['id'], 'current-user');
+        expect(payload['meta']['view']['name'], 'current-view');
+        expect(payload['meta']['page']['url'], 'https://example.com/current');
         expect(exception['type'], 'crash');
         expect(exception['fatal'], isTrue);
         expect(exception['context']['nativeType'], 'SIGSEGV (SEGV_MAPERR)');
@@ -886,7 +936,9 @@ java.lang.NullPointerException: test crash
         crashReport,
       ], recoveredSession: recoveredSession);
 
-      verify(() => mockFaroTransport.sendHistorical(any())).called(1);
+      verify(
+        () => mockFaroTransport.sendHistoricalAcknowledged(any()),
+      ).called(1);
       verify(() => mockBaseTransport.send(any())).called(1);
     });
 
@@ -906,7 +958,8 @@ java.lang.NullPointerException: test crash
 
       final payload =
           verify(
-                () => mockFaroTransport.sendHistorical(captureAny()),
+                () =>
+                    mockFaroTransport.sendHistoricalAcknowledged(captureAny()),
               ).captured.single
               as Map<String, dynamic>;
       final exception = payload['exceptions'][0] as Map<String, dynamic>;
@@ -926,7 +979,9 @@ java.lang.NullPointerException: test crash
 
       await Faro().reportIOSCrashesForTesting(['[]', validCrash]);
 
-      verify(() => mockFaroTransport.sendHistorical(any())).called(1);
+      verify(
+        () => mockFaroTransport.sendHistoricalAcknowledged(any()),
+      ).called(1);
     });
 
     test('iOS crash without a timestamp is ignored', () async {
@@ -947,7 +1002,7 @@ java.lang.NullPointerException: test crash
       ], recoveredSession: recoveredSession);
 
       expect(accepted, isTrue);
-      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockFaroTransport.sendHistoricalAcknowledged(any()));
       verifyNever(() => mockBatchTransport.addExceptions(any()));
     });
 
@@ -970,6 +1025,21 @@ java.lang.NullPointerException: test crash
       },
     );
 
+    test('iOS keeps the native report when the collector rejects it', () async {
+      when(
+        () => mockFaroTransport.sendHistoricalAcknowledged(any()),
+      ).thenAnswer((_) async => false);
+      final crashReport = json.encode({
+        'type': 'SIGSEGV',
+        'value': 'Application crash',
+        'timestamp': '2026-08-14T12:03:00.000Z',
+      });
+
+      final accepted = await Faro().reportIOSCrashesForTesting([crashReport]);
+
+      expect(accepted, isFalse);
+    });
+
     test('recovered iOS crash from an unsampled session is not sent', () async {
       final recoveredSession = PersistedSessionRecord(
         currentSessionId: 'unsampled-session',
@@ -988,7 +1058,7 @@ java.lang.NullPointerException: test crash
         crashReport,
       ], recoveredSession: recoveredSession);
 
-      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockFaroTransport.sendHistoricalAcknowledged(any()));
       verifyNever(() => mockBatchTransport.addExceptions(any()));
     });
 
@@ -1004,7 +1074,7 @@ java.lang.NullPointerException: test crash
       final accepted = await Faro().reportIOSCrashesForTesting([crashReport]);
 
       expect(accepted, isFalse);
-      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockFaroTransport.sendHistoricalAcknowledged(any()));
       verifyNever(() => mockBatchTransport.addExceptions(any()));
     });
 
@@ -1026,7 +1096,7 @@ java.lang.NullPointerException: test crash
         crashReport,
       ], recoveredSession: recoveredSession);
 
-      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockFaroTransport.sendHistoricalAcknowledged(any()));
       verifyNever(() => mockBatchTransport.addExceptions(any()));
     });
 
@@ -1049,7 +1119,7 @@ java.lang.NullPointerException: test crash
         }),
       ], recoveredSession: recoveredSession);
 
-      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockFaroTransport.sendHistoricalAcknowledged(any()));
     });
 
     test('multiple recovered crashes use their matching sessions', () async {
@@ -1103,7 +1173,7 @@ java.lang.NullPointerException: test crash
       );
 
       final payloads = verify(
-        () => mockFaroTransport.sendHistorical(captureAny()),
+        () => mockFaroTransport.sendHistoricalAcknowledged(captureAny()),
       ).captured;
       expect(payloads, hasLength(2));
       expect(
@@ -1143,7 +1213,7 @@ java.lang.NullPointerException: test crash
         processIdentifier: 'com.example.app',
       );
 
-      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockFaroTransport.sendHistoricalAcknowledged(any()));
       verifyNever(() => mockBatchTransport.addExceptions(any()));
     });
 
@@ -1169,7 +1239,7 @@ java.lang.NullPointerException: test crash
           processIdentifier: 'com.example.app',
         );
 
-        verifyNever(() => mockFaroTransport.sendHistorical(any()));
+        verifyNever(() => mockFaroTransport.sendHistoricalAcknowledged(any()));
         verifyNever(() => mockBatchTransport.addExceptions(any()));
       },
     );

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -9,6 +9,7 @@ import 'package:faro/src/data_collection_policy.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/models/models.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
+import 'package:faro/src/offline_transport/offline_transport.dart';
 import 'package:faro/src/session/session_manager.dart';
 import 'package:faro/src/session/session_persistence.dart';
 import 'package:faro/src/tracing/faro_span_context.dart';
@@ -28,6 +29,8 @@ class MockFaroTransport extends Mock implements FaroTransport {}
 class MockBatchTransport extends Mock implements BatchTransport {}
 
 class MockBaseTransport extends Mock implements BaseTransport {}
+
+class MockOfflineTransport extends Mock implements OfflineTransport {}
 
 class MockFaroNativeMethods extends Mock implements FaroNativeMethods {}
 
@@ -371,6 +374,7 @@ void main() {
       test('iOS retains the pending crash when delivery is rejected', () async {
         final deliveryStarted = Completer<void>();
         final deliveryResult = Completer<bool>();
+        final offlineTransport = MockOfflineTransport();
         stubRuntimeInfo(ownsPersistence: true);
         Faro().iosPlatformResolver = () => true;
         Faro().androidPlatformResolver = () => false;
@@ -389,6 +393,10 @@ void main() {
           deliveryStarted.complete();
           return deliveryResult.future;
         });
+        Faro().transports = <BaseTransport>[
+          offlineTransport,
+          mockFaroTransport,
+        ];
 
         await Faro().init(
           optionsConfiguration: createConfig(
@@ -400,6 +408,7 @@ void main() {
         await deliveryStarted.future;
         deliveryResult.complete(false);
         await Future<void>.delayed(Duration.zero);
+        verifyNever(() => offlineTransport.send(any()));
         verifyNever(() => mockFaroNativeMethods.purgeCrashReport());
       });
 
@@ -1039,6 +1048,24 @@ java.lang.NullPointerException: test crash
 
       expect(accepted, isFalse);
     });
+
+    test(
+      'iOS keeps the native report when only offline retry is configured',
+      () async {
+        final offlineTransport = MockOfflineTransport();
+        Faro().transports = <BaseTransport>[offlineTransport];
+        final crashReport = json.encode({
+          'type': 'SIGSEGV',
+          'value': 'Application crash',
+          'timestamp': '2026-08-14T12:03:00.000Z',
+        });
+
+        final accepted = await Faro().reportIOSCrashesForTesting([crashReport]);
+
+        expect(accepted, isFalse);
+        verifyNever(() => offlineTransport.send(any()));
+      },
+    );
 
     test('recovered iOS crash from an unsampled session is not sent', () async {
       final recoveredSession = PersistedSessionRecord(

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -100,6 +100,9 @@ void main() {
         () => mockFaroNativeMethods.getCrashReport(),
       ).thenAnswer((_) async => null);
       when(
+        () => mockFaroNativeMethods.purgeCrashReport(),
+      ).thenAnswer((_) async {});
+      when(
         () => mockBatchTransport.addExceptions(any()),
       ).thenAnswer((_) async {});
       when(() => mockBatchTransport.addLog(any())).thenAnswer((_) async {});
@@ -317,6 +320,8 @@ void main() {
           ).captured.single;
           expect(config, isEmpty);
           verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
+          await untilCalled(() => mockFaroNativeMethods.purgeCrashReport());
+          verify(() => mockFaroNativeMethods.purgeCrashReport()).called(1);
           verifyNever(() => mockFaroTransport.sendHistorical(any()));
           verifyNever(() => mockBatchTransport.addExceptions(any()));
         },
@@ -350,7 +355,10 @@ void main() {
           ).captured.single;
           expect(config, isEmpty);
           verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
-          verify(() => mockBatchTransport.addExceptions(any())).called(1);
+          verify(() => mockFaroTransport.sendHistorical(any())).called(1);
+          verifyNever(() => mockBatchTransport.addExceptions(any()));
+          await untilCalled(() => mockFaroNativeMethods.purgeCrashReport());
+          verify(() => mockFaroNativeMethods.purgeCrashReport()).called(1);
         },
       );
 
@@ -367,6 +375,53 @@ void main() {
           () => mockFaroNativeMethods.enableCrashReporter(any()),
         ).called(1);
         verifyNever(() => mockFaroNativeMethods.getCrashReport());
+        verifyNever(() => mockFaroNativeMethods.purgeCrashReport());
+      });
+
+      test(
+        'iOS recovery falls back when runtime info is unavailable',
+        () async {
+          when(
+            () => mockFaroNativeMethods.getSessionRuntimeInfo(
+              claimSessionPersistence: true,
+            ),
+          ).thenAnswer((_) async => null);
+          Faro().iosPlatformResolver = () => true;
+          Faro().androidPlatformResolver = () => false;
+          when(() => mockFaroNativeMethods.getCrashReport()).thenAnswer(
+            (_) async => <String>[
+              json.encode({
+                'type': 'SIGABRT',
+                'value': 'Application crash',
+                'timestamp': '2026-08-14T12:03:00.000Z',
+              }),
+            ],
+          );
+
+          await Faro().init(
+            optionsConfiguration: createConfig(enableCrashReporting: true),
+          );
+
+          verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
+          await untilCalled(() => mockFaroNativeMethods.purgeCrashReport());
+          verify(() => mockFaroNativeMethods.purgeCrashReport()).called(1);
+        },
+      );
+
+      test('iOS leaves a pending crash while collection is disabled', () async {
+        SharedPreferences.setMockInitialValues({
+          'faro_enable_data_collection': false,
+        });
+        stubRuntimeInfo(ownsPersistence: true);
+        Faro().iosPlatformResolver = () => true;
+        Faro().androidPlatformResolver = () => false;
+
+        await Faro().init(
+          optionsConfiguration: createConfig(enableCrashReporting: true),
+        );
+
+        verifyNever(() => mockFaroNativeMethods.getCrashReport());
+        verifyNever(() => mockFaroNativeMethods.purgeCrashReport());
       });
 
       test(
@@ -849,15 +904,17 @@ java.lang.NullPointerException: test crash
 
       await Faro().reportIOSCrashesForTesting([crashReport]);
 
-      final exception =
+      final payload =
           verify(
-                () => mockBatchTransport.addExceptions(captureAny()),
+                () => mockFaroTransport.sendHistorical(captureAny()),
               ).captured.single
-              as FaroException;
-      expect(exception.type, 'crash');
-      expect(exception.fatal, isTrue);
-      expect(exception.context?['nativeType'], 'SIGABRT');
-      expect(exception.stacktrace?['frames'], hasLength(1));
+              as Map<String, dynamic>;
+      final exception = payload['exceptions'][0] as Map<String, dynamic>;
+      expect(exception['type'], 'crash');
+      expect(exception['fatal'], isTrue);
+      expect(exception['context']['nativeType'], 'SIGABRT');
+      expect(exception['stacktrace']['frames'], hasLength(1));
+      verifyNever(() => mockBatchTransport.addExceptions(any()));
     });
 
     test('malformed iOS crash does not block the next report', () async {
@@ -869,8 +926,49 @@ java.lang.NullPointerException: test crash
 
       await Faro().reportIOSCrashesForTesting(['[]', validCrash]);
 
-      verify(() => mockBatchTransport.addExceptions(any())).called(1);
+      verify(() => mockFaroTransport.sendHistorical(any())).called(1);
     });
+
+    test('iOS crash without a timestamp is ignored', () async {
+      final recoveredSession = PersistedSessionRecord(
+        currentSessionId: 'crashed-session',
+        previousSessionId: null,
+        startedAt: DateTime.utc(2026, 8, 14, 12),
+        lastActivityAt: DateTime.utc(2026, 8, 14, 12, 5),
+        isSampled: true,
+      );
+      final crashReport = json.encode({
+        'type': 'SIGSEGV',
+        'value': 'Application crash',
+      });
+
+      final accepted = await Faro().reportIOSCrashesForTesting([
+        crashReport,
+      ], recoveredSession: recoveredSession);
+
+      expect(accepted, isTrue);
+      verifyNever(() => mockFaroTransport.sendHistorical(any()));
+      verifyNever(() => mockBatchTransport.addExceptions(any()));
+    });
+
+    test(
+      'iOS keeps the native report when a live-session transport throws',
+      () async {
+        Faro().transports = <BaseTransport>[mockBaseTransport];
+        when(
+          () => mockBaseTransport.send(any()),
+        ).thenThrow(StateError('transport unavailable'));
+        final crashReport = json.encode({
+          'type': 'SIGSEGV',
+          'value': 'Application crash',
+          'timestamp': '2026-08-14T12:03:00.000Z',
+        });
+
+        final accepted = await Faro().reportIOSCrashesForTesting([crashReport]);
+
+        expect(accepted, isFalse);
+      },
+    );
 
     test('recovered iOS crash from an unsampled session is not sent', () async {
       final recoveredSession = PersistedSessionRecord(
@@ -903,8 +1001,9 @@ java.lang.NullPointerException: test crash
         'timestamp': '2026-08-14T12:03:00.000Z',
       });
 
-      await Faro().reportIOSCrashesForTesting([crashReport]);
+      final accepted = await Faro().reportIOSCrashesForTesting([crashReport]);
 
+      expect(accepted, isFalse);
       verifyNever(() => mockFaroTransport.sendHistorical(any()));
       verifyNever(() => mockBatchTransport.addExceptions(any()));
     });

--- a/test/src/transport/faro_transport_test.dart
+++ b/test/src/transport/faro_transport_test.dart
@@ -31,12 +31,14 @@ void main() {
       SessionIdResolver? sessionIdResolver,
       SessionInvalidatedHandler? onSessionInvalidated,
       Map<String, String>? headers,
+      int? maxBufferLimit,
     }) {
       final transport = FaroTransport(
         collectorUrl: 'https://collector.example/collect',
         apiKey: 'test-key',
         sessionIdResolver: sessionIdResolver ?? () => 'session-id',
         headers: headers,
+        maxBufferLimit: maxBufferLimit,
         httpClient: client,
       );
       if (onSessionInvalidated != null) {
@@ -74,6 +76,51 @@ void main() {
         expect(headers['x-api-key'], 'test-key');
         expect(headers['content-type'], contains('application/json'));
         expect(headers['x-custom'], 'custom-value');
+      });
+    });
+
+    group('historical acknowledgement:', () {
+      test('returns true for a successful collector response', () async {
+        final accepted = await buildTransport().sendHistoricalAcknowledged(
+          payload(),
+        );
+
+        expect(accepted, isTrue);
+      });
+
+      test('returns false for a rejected collector response', () async {
+        client = MockClient((request) async {
+          captured.add(request);
+          return http.Response('rejected', 500);
+        });
+
+        final accepted = await buildTransport().sendHistoricalAcknowledged(
+          payload(),
+        );
+
+        expect(accepted, isFalse);
+      });
+
+      test('returns false when the request fails', () async {
+        client = MockClient((request) async {
+          captured.add(request);
+          throw http.ClientException('collector unavailable');
+        });
+
+        final accepted = await buildTransport().sendHistoricalAcknowledged(
+          payload(),
+        );
+
+        expect(accepted, isFalse);
+      });
+
+      test('returns false when the transport buffer is full', () async {
+        final accepted = await buildTransport(
+          maxBufferLimit: 0,
+        ).sendHistoricalAcknowledged(payload());
+
+        expect(accepted, isFalse);
+        expect(captured, isEmpty);
       });
     });
 


### PR DESCRIPTION
iOS crash reports currently bypass Faro's configured transports and send their own HTTP request. This moves recovered crashes through Faro on the next app launch, so sampling, data collection settings, headers, and custom transports are respected. When session history is available, the crash stays linked to the session that crashed.

Fixes #269

No screenshots needed. This is an SDK-only change.
