### PR TITLE
docs(transport): clarify custom failure signaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,11 +94,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **iOS crash reports now use the configured SDK transports.** Pending
   PLCrashReporter data returns to Dart on the next launch and follows the
   configured collector and custom transport paths, sampling, data collection
-  policy, and collector headers. Successfully handed-off reports are purged.
-  Collector rejections and thrown transport failures remain pending. Reports
-  are discarded when data collection is disabled during launch recovery.
-  Pending native reports do not also enter `OfflineTransport`, because the
-  native report is already the durable retry copy
+  policy, and collector headers. Accepted reports are purged; collector
+  rejections and transport errors remain pending. Custom transports must
+  complete with an error when handoff fails because returning normally counts
+  as acceptance. Reports are discarded when data collection is disabled.
+  Pending native reports skip `OfflineTransport` because the native report is
+  already the durable retry copy
   ([#269](https://github.com/grafana/faro-flutter-sdk/issues/269)).
 - **Recovered native crashes retain their original session.** Android and iOS
   crash metadata includes `crashedSessionId` and preserves the persisted

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -453,13 +453,16 @@ deduplicate historical `ApplicationExitInfo` records, while iOS purges the
 pending PLCrashReporter record after Dart accepts it for transport. The report
 uses the configured collector and custom transports, sampling decision, data
 collection policy, collector headers, and `type: crash`; its native signal and
-code are preserved in `context.nativeType`. A pending iOS report is discarded
-without being sent when data collection was disabled at launch. If persistence
-is active
-but a recovered crash cannot be matched to a persisted session, the SDK
-discards that crash rather than attributing it to the new live session. If
-persistence is disabled or unavailable, the SDK cannot recover the prior
-session identity and retains the legacy live-session fallback.
+code are preserved in `context.nativeType`. `FaroTransport` uses the collector
+response to confirm the handoff. For a custom `BaseTransport`, a completed
+`send` call counts as acceptance. Custom transports must complete with an error
+when they cannot accept or durably queue the payload; hiding that failure can
+cause the SDK to purge the retained native report. A pending iOS report is
+discarded without being sent when data collection was disabled at launch. If
+persistence is active but a recovered crash cannot be matched to a persisted
+session, the SDK discards that crash rather than attributing it to the new live
+session. If persistence is disabled or unavailable, the SDK cannot recover the
+prior session identity and retains the legacy live-session fallback.
 
 **What counts as activity.** Faro classifies telemetry as meaningful work or
 passive telemetry. Every item checks session expiry before it is attributed,

--- a/lib/src/transport/faro_base_transport.dart
+++ b/lib/src/transport/faro_base_transport.dart
@@ -1,5 +1,12 @@
 import 'dart:async';
 
 abstract class BaseTransport {
+  /// Accepts a payload for delivery.
+  ///
+  /// Completing normally tells the SDK that the payload was accepted or
+  /// durably queued. Implementations must complete with an error when that
+  /// handoff fails. This is especially important for recovered iOS crashes,
+  /// because the SDK may purge the retained native report after a successful
+  /// handoff.
   Future<void> send(Map<String, dynamic> payloadJson) async {}
 }


### PR DESCRIPTION
## Description

Clarifies how custom transports signal a failed recovered-crash handoff. A completed `send()` counts as acceptance, so transports need to complete with an error when they cannot accept or durably queue the payload. This documents the existing behavior without changing runtime code.

## Related Issue(s)

Related to #269

## Type of Change

- [x] 📝 Documentation

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Additional Notes

No screenshots needed. `flutter analyze` and the Flutter test suite passed.