### PR TITLE
fix(session): scope Android crash recovery to the persistence owner

### DIFF
--- a/.github/workflows/flutter_checks.yml
+++ b/.github/workflows/flutter_checks.yml
@@ -77,6 +77,10 @@ jobs:
         working-directory: example/android
         run: ./gradlew :faro:testDebugUnitTest
 
+      - name: Compile Android instrumentation tests
+        working-directory: example/android
+        run: ./gradlew :app:assembleDebugAndroidTest
+
   test-ios:
     name: build & test iOS
     runs-on: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,9 +95,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Only the root Flutter engine that owns the durable session chain reads
   historical application exits. Other engines, including those whose native
   process identity cannot be resolved, skip recovery instead of emitting an
-  old crash with an unrelated live session. **This can reduce recovered-crash
-  volume when runtime identity is unavailable.** Enable crash reporting on
-  every root-engine entrypoint that may initialize Faro first
+  old crash with an unrelated live session. If ownership cannot be established
+  during startup, recovery is deferred to a later launch. Enable crash
+  reporting on every root-engine entrypoint that may initialize Faro first
   ([#340](https://github.com/grafana/faro-flutter-sdk/issues/340)).
 - **iOS crash reports now use the configured SDK transports.** Pending
   PLCrashReporter data returns to Dart on the next launch and follows the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Android crash recovery is now limited to the Flutter engine that owns the
-  process-scoped session record, preventing a secondary engine from replaying
-  a recovered crash with unrelated session metadata.
 - **BREAKING (behavioral): iOS recovered crashes now use `type: crash`.**
   The native signal and code remain available in `context.nativeType`.
   Dashboards and alerts matching signal names in `exception.type` should match
@@ -94,6 +91,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Recovered Android crashes now respect process-scoped session ownership.**
+  When ownership is known, only the root Flutter engine that owns the durable
+  session chain reads historical application exits. Other engines skip
+  recovery instead of emitting an old crash with an unrelated live session.
+  Enable crash reporting on every root-engine entrypoint that may initialize
+  Faro first
+  ([#340](https://github.com/grafana/faro-flutter-sdk/issues/340)).
 - **iOS crash reports now use the configured SDK transports.** Pending
   PLCrashReporter data returns to Dart on the next launch and follows the
   configured collector and custom transport paths, sampling, data collection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,11 +92,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Recovered Android crashes now respect process-scoped session ownership.**
-  When ownership is known, only the root Flutter engine that owns the durable
-  session chain reads historical application exits. Other engines skip
-  recovery instead of emitting an old crash with an unrelated live session.
-  Enable crash reporting on every root-engine entrypoint that may initialize
-  Faro first
+  Only the root Flutter engine that owns the durable session chain reads
+  historical application exits. Other engines, including those whose native
+  process identity cannot be resolved, skip recovery instead of emitting an
+  old crash with an unrelated live session. **This can reduce recovered-crash
+  volume when runtime identity is unavailable.** Enable crash reporting on
+  every root-engine entrypoint that may initialize Faro first
   ([#340](https://github.com/grafana/faro-flutter-sdk/issues/340)).
 - **iOS crash reports now use the configured SDK transports.** Pending
   PLCrashReporter data returns to Dart on the next launch and follows the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Android crash recovery is now limited to the Flutter engine that owns the
+  process-scoped session record, preventing a secondary engine from replaying
+  a recovered crash with unrelated session metadata.
 - **BREAKING (behavioral): iOS recovered crashes now use `type: crash`.**
   The native signal and code remain available in `context.nativeType`.
   Dashboards and alerts matching signal names in `exception.type` should match

--- a/android/src/main/java/com/grafana/faro/FaroPlugin.java
+++ b/android/src/main/java/com/grafana/faro/FaroPlugin.java
@@ -367,6 +367,13 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
                         }
                         break;
                     case "getCrashReport":
+                        // Runtime discovery normally claims the owner first. Keep
+                        // this fallback for callers that could not discover it.
+                        claimSessionPersistenceOwnership();
+                        if (!ownsSessionPersistence) {
+                            result.success(new ArrayList<>());
+                            break;
+                        }
                         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
                             // Check if exitInfoHelper is initialized
                             if (exitInfoHelper == null) {

--- a/android/src/main/java/com/grafana/faro/FaroPlugin.java
+++ b/android/src/main/java/com/grafana/faro/FaroPlugin.java
@@ -51,6 +51,7 @@ import io.flutter.plugin.common.MethodChannel.Result;
  */
 public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAware {
     private static final AtomicBoolean SESSION_PERSISTENCE_OWNER_CLAIMED = new AtomicBoolean(false);
+    private static final AtomicBoolean CRASH_RECOVERY_OWNER_CLAIMED = new AtomicBoolean(false);
 
     /// The MethodChannel that will the communication between Flutter and native Android
     /// This local reference serves to register the plugin with the Flutter Engine and unregister it
@@ -63,6 +64,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
     private @Nullable Window window;
     private @Nullable Application application;
     private boolean ownsSessionPersistence = false;
+    private boolean ownsCrashRecovery = false;
     // Once attached, this engine remains the main engine across Activity detaches.
     private final EngineRoleTracker engineRoleTracker = new EngineRoleTracker();
 
@@ -337,10 +339,8 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
         Log.d(TAG, "onDetachedFromEngine");
         channel.setMethodCallHandler(null);
         channel = null;
-        if (ownsSessionPersistence) {
-            SESSION_PERSISTENCE_OWNER_CLAIMED.set(false);
-            ownsSessionPersistence = false;
-        }
+        releaseCrashRecoveryOwnership();
+        releaseSessionPersistenceOwnership();
     }
 
     // test
@@ -367,10 +367,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
                         }
                         break;
                     case "getCrashReport":
-                        // Runtime discovery normally claims the owner first. Keep
-                        // this fallback for callers that could not discover it.
-                        claimSessionPersistenceOwnership();
-                        if (!ownsSessionPersistence) {
+                        if (!claimCrashRecoveryOwnership()) {
                             result.success(new ArrayList<>());
                             break;
                         }
@@ -566,12 +563,43 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
         return null;
     }
 
-    private void claimSessionPersistenceOwnership() {
+    boolean claimSessionPersistenceOwnership() {
         // Registration also runs for pre-warmed engines. Claim only when a
         // root Dart runtime actually initializes Faro.
         if (!ownsSessionPersistence
             && SESSION_PERSISTENCE_OWNER_CLAIMED.compareAndSet(false, true)) {
             ownsSessionPersistence = true;
+        }
+        return ownsSessionPersistence;
+    }
+
+    void releaseSessionPersistenceOwnership() {
+        if (ownsSessionPersistence) {
+            SESSION_PERSISTENCE_OWNER_CLAIMED.set(false);
+            ownsSessionPersistence = false;
+        }
+    }
+
+    boolean claimCrashRecoveryOwnership() {
+        if (ownsCrashRecovery) {
+            return true;
+        }
+        // A known secondary engine must not recover a crash with its unrelated
+        // live session. Runtime-discovery fallbacks use a separate claim so
+        // they cannot take session-persistence ownership as a side effect.
+        if (!ownsSessionPersistence && SESSION_PERSISTENCE_OWNER_CLAIMED.get()) {
+            return false;
+        }
+        if (CRASH_RECOVERY_OWNER_CLAIMED.compareAndSet(false, true)) {
+            ownsCrashRecovery = true;
+        }
+        return ownsCrashRecovery;
+    }
+
+    void releaseCrashRecoveryOwnership() {
+        if (ownsCrashRecovery) {
+            CRASH_RECOVERY_OWNER_CLAIMED.set(false);
+            ownsCrashRecovery = false;
         }
     }
 

--- a/android/src/main/java/com/grafana/faro/FaroPlugin.java
+++ b/android/src/main/java/com/grafana/faro/FaroPlugin.java
@@ -51,7 +51,6 @@ import io.flutter.plugin.common.MethodChannel.Result;
  */
 public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAware {
     private static final AtomicBoolean SESSION_PERSISTENCE_OWNER_CLAIMED = new AtomicBoolean(false);
-    private static final AtomicBoolean CRASH_RECOVERY_OWNER_CLAIMED = new AtomicBoolean(false);
 
     /// The MethodChannel that will the communication between Flutter and native Android
     /// This local reference serves to register the plugin with the Flutter Engine and unregister it
@@ -64,7 +63,6 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
     private @Nullable Window window;
     private @Nullable Application application;
     private boolean ownsSessionPersistence = false;
-    private boolean ownsCrashRecovery = false;
     // Once attached, this engine remains the main engine across Activity detaches.
     private final EngineRoleTracker engineRoleTracker = new EngineRoleTracker();
 
@@ -339,7 +337,6 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
         Log.d(TAG, "onDetachedFromEngine");
         channel.setMethodCallHandler(null);
         channel = null;
-        releaseCrashRecoveryOwnership();
         releaseSessionPersistenceOwnership();
     }
 
@@ -367,7 +364,7 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
                         }
                         break;
                     case "getCrashReport":
-                        if (!claimCrashRecoveryOwnership()) {
+                        if (!canRecoverCrashReports()) {
                             result.success(new ArrayList<>());
                             break;
                         }
@@ -580,27 +577,11 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
         }
     }
 
-    boolean claimCrashRecoveryOwnership() {
-        if (ownsCrashRecovery) {
-            return true;
-        }
-        // A known secondary engine must not recover a crash with its unrelated
-        // live session. Runtime-discovery fallbacks use a separate claim so
-        // they cannot take session-persistence ownership as a side effect.
-        if (!ownsSessionPersistence && SESSION_PERSISTENCE_OWNER_CLAIMED.get()) {
-            return false;
-        }
-        if (CRASH_RECOVERY_OWNER_CLAIMED.compareAndSet(false, true)) {
-            ownsCrashRecovery = true;
-        }
-        return ownsCrashRecovery;
-    }
-
-    void releaseCrashRecoveryOwnership() {
-        if (ownsCrashRecovery) {
-            CRASH_RECOVERY_OWNER_CLAIMED.set(false);
-            ownsCrashRecovery = false;
-        }
+    boolean canRecoverCrashReports() {
+        // Fail closed when process discovery did not establish ownership. A
+        // non-owner must never consume an exit before the durable-session
+        // owner starts and attributes it correctly.
+        return ownsSessionPersistence;
     }
 
     /** Tracks whether this Flutter engine has ever been attached to an Activity. */

--- a/android/src/main/java/com/grafana/faro/FaroPlugin.java
+++ b/android/src/main/java/com/grafana/faro/FaroPlugin.java
@@ -578,9 +578,8 @@ public class FaroPlugin implements FlutterPlugin, MethodCallHandler, ActivityAwa
     }
 
     boolean canRecoverCrashReports() {
-        // Fail closed when process discovery did not establish ownership. A
-        // non-owner must never consume an exit before the durable-session
-        // owner starts and attributes it correctly.
+        // Dart checks the same ownership before invoking this method. Keep the
+        // native guard for direct channel callers and future call-site changes.
         return ownsSessionPersistence;
     }
 

--- a/android/src/test/java/com/grafana/faro/FaroPluginTest.java
+++ b/android/src/test/java/com/grafana/faro/FaroPluginTest.java
@@ -1,6 +1,8 @@
 package com.grafana.faro;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -13,5 +15,39 @@ public class FaroPluginTest {
 
         tracker.onActivityAttached();
         assertEquals("main", tracker.getEngineRole());
+    }
+
+    @Test
+    public void crashRecoveryClaimDoesNotTakeSessionPersistenceOwnership() {
+        FaroPlugin crashOwner = new FaroPlugin();
+        FaroPlugin persistenceOwner = new FaroPlugin();
+
+        try {
+            assertTrue(crashOwner.claimCrashRecoveryOwnership());
+            assertTrue(persistenceOwner.claimSessionPersistenceOwnership());
+            assertFalse(crashOwner.claimSessionPersistenceOwnership());
+        } finally {
+            crashOwner.releaseCrashRecoveryOwnership();
+            crashOwner.releaseSessionPersistenceOwnership();
+            persistenceOwner.releaseCrashRecoveryOwnership();
+            persistenceOwner.releaseSessionPersistenceOwnership();
+        }
+    }
+
+    @Test
+    public void persistenceOwnerExcludesSecondaryCrashRecovery() {
+        FaroPlugin owner = new FaroPlugin();
+        FaroPlugin secondary = new FaroPlugin();
+
+        try {
+            assertTrue(owner.claimSessionPersistenceOwnership());
+            assertTrue(owner.claimCrashRecoveryOwnership());
+            assertFalse(secondary.claimCrashRecoveryOwnership());
+        } finally {
+            owner.releaseCrashRecoveryOwnership();
+            owner.releaseSessionPersistenceOwnership();
+            secondary.releaseCrashRecoveryOwnership();
+            secondary.releaseSessionPersistenceOwnership();
+        }
     }
 }

--- a/android/src/test/java/com/grafana/faro/FaroPluginTest.java
+++ b/android/src/test/java/com/grafana/faro/FaroPluginTest.java
@@ -18,36 +18,40 @@ public class FaroPluginTest {
     }
 
     @Test
-    public void crashRecoveryClaimDoesNotTakeSessionPersistenceOwnership() {
-        FaroPlugin crashOwner = new FaroPlugin();
+    public void crashRecoveryRequiresSessionPersistenceOwnership() {
+        FaroPlugin unidentifiedEngine = new FaroPlugin();
         FaroPlugin persistenceOwner = new FaroPlugin();
 
         try {
-            assertTrue(crashOwner.claimCrashRecoveryOwnership());
+            assertFalse(unidentifiedEngine.canRecoverCrashReports());
             assertTrue(persistenceOwner.claimSessionPersistenceOwnership());
-            assertFalse(crashOwner.claimSessionPersistenceOwnership());
+            assertTrue(persistenceOwner.canRecoverCrashReports());
+            assertFalse(unidentifiedEngine.canRecoverCrashReports());
         } finally {
-            crashOwner.releaseCrashRecoveryOwnership();
-            crashOwner.releaseSessionPersistenceOwnership();
-            persistenceOwner.releaseCrashRecoveryOwnership();
+            unidentifiedEngine.releaseSessionPersistenceOwnership();
             persistenceOwner.releaseSessionPersistenceOwnership();
         }
     }
 
     @Test
-    public void persistenceOwnerExcludesSecondaryCrashRecovery() {
-        FaroPlugin owner = new FaroPlugin();
-        FaroPlugin secondary = new FaroPlugin();
+    public void crashRecoveryTransfersWithSessionPersistenceOwnership() {
+        FaroPlugin firstOwner = new FaroPlugin();
+        FaroPlugin replacement = new FaroPlugin();
 
         try {
-            assertTrue(owner.claimSessionPersistenceOwnership());
-            assertTrue(owner.claimCrashRecoveryOwnership());
-            assertFalse(secondary.claimCrashRecoveryOwnership());
+            assertTrue(firstOwner.claimSessionPersistenceOwnership());
+            assertTrue(firstOwner.canRecoverCrashReports());
+            assertFalse(replacement.claimSessionPersistenceOwnership());
+            assertFalse(replacement.canRecoverCrashReports());
+
+            firstOwner.releaseSessionPersistenceOwnership();
+
+            assertTrue(replacement.claimSessionPersistenceOwnership());
+            assertTrue(replacement.canRecoverCrashReports());
+            assertFalse(firstOwner.canRecoverCrashReports());
         } finally {
-            owner.releaseCrashRecoveryOwnership();
-            owner.releaseSessionPersistenceOwnership();
-            secondary.releaseCrashRecoveryOwnership();
-            secondary.releaseSessionPersistenceOwnership();
+            firstOwner.releaseSessionPersistenceOwnership();
+            replacement.releaseSessionPersistenceOwnership();
         }
     }
 }

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -448,21 +448,35 @@ enabled, Android and iOS native crashes recovered on the next launch retain
 the persisted session ID that was active when the process stopped. The crash
 payload also includes `crashedSessionId` in the session attributes and uses
 that session's persisted sampling decision. Sending the recovered crash does
-not rotate or otherwise change the new live session. Android continues to
-deduplicate historical `ApplicationExitInfo` records, while iOS purges the
-pending PLCrashReporter record after Dart accepts it for transport. The report
-uses the configured collector and custom transports, sampling decision, data
-collection policy, collector headers, and `type: crash`; its native signal and
-code are preserved in `context.nativeType`. `FaroTransport` uses the collector
-response to confirm the handoff. For a custom `BaseTransport`, a completed
-`send` call counts as acceptance. Custom transports must complete with an error
-when they cannot accept or durably queue the payload; hiding that failure can
-cause the SDK to purge the retained native report. A pending iOS report is
-discarded without being sent when data collection was disabled at launch. If
-persistence is active but a recovered crash cannot be matched to a persisted
-session, the SDK discards that crash rather than attributing it to the new live
-session. If persistence is disabled or unavailable, the SDK cannot recover the
-prior session identity and retains the legacy live-session fallback.
+not rotate or otherwise change the new live session.
+
+On Android, when runtime ownership is known, only the root Flutter engine that
+owns the process-scoped session record attempts to read historical
+`ApplicationExitInfo` records. Other engines skip recovery so an old crash
+cannot be emitted with an unrelated live session. Enable crash reporting on
+every root-engine entrypoint that may initialize Faro first. An already
+initialized non-owner does not take over recovery when the owner detaches; a
+new engine can claim ownership after the previous owner is destroyed. If
+native runtime identity is unavailable, a root engine retains the legacy
+recovery fallback without claiming session persistence. Android continues to
+deduplicate historical exit records.
+
+On iOS, Faro purges the pending PLCrashReporter record after Dart accepts it
+for transport. The report uses the configured collector and custom transports,
+sampling decision, data collection policy, collector headers, and
+`type: crash`; its native signal and code are preserved in
+`context.nativeType`. `FaroTransport` uses the collector response to confirm
+the handoff. For a custom `BaseTransport`, a completed `send` call counts as
+acceptance. Custom transports must complete with an error when they cannot
+accept or durably queue the payload; hiding that failure can cause the SDK to
+purge the retained native report. A pending iOS report is discarded without
+being sent when data collection was disabled at launch.
+
+If persistence is active but a recovered crash cannot be matched to a
+persisted session, the SDK discards that crash rather than attributing it to
+the new live session. If persistence is disabled or unavailable, the SDK
+cannot recover the prior session identity and retains the legacy live-session
+fallback.
 
 **What counts as activity.** Faro classifies telemetry as meaningful work or
 passive telemetry. Every item checks session expiry before it is attributed,

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -450,16 +450,16 @@ payload also includes `crashedSessionId` in the session attributes and uses
 that session's persisted sampling decision. Sending the recovered crash does
 not rotate or otherwise change the new live session.
 
-On Android, when runtime ownership is known, only the root Flutter engine that
-owns the process-scoped session record attempts to read historical
-`ApplicationExitInfo` records. Other engines skip recovery so an old crash
-cannot be emitted with an unrelated live session. Enable crash reporting on
-every root-engine entrypoint that may initialize Faro first. An already
-initialized non-owner does not take over recovery when the owner detaches; a
-new engine can claim ownership after the previous owner is destroyed. If
-native runtime identity is unavailable, a root engine retains the legacy
-recovery fallback without claiming session persistence. Android continues to
-deduplicate historical exit records.
+On Android, only the root Flutter engine that owns the process-scoped session
+record attempts to read historical `ApplicationExitInfo` records. Other
+engines skip recovery so an old crash cannot be emitted with an unrelated live
+session. Enable crash reporting on every root-engine entrypoint that may
+initialize Faro first. An already initialized non-owner does not take over
+recovery when the owner detaches; a new engine can claim ownership after the
+previous owner is destroyed. If native runtime identity is unavailable, Faro
+does not read or mark historical exits as handled. A later process launch may
+recover them if Android still retains the records and ownership can then be
+resolved. Android continues to deduplicate historical exit records.
 
 On iOS, Faro purges the pending PLCrashReporter record after Dart accepts it
 for transport. The report uses the configured collector and custom transports,
@@ -474,9 +474,9 @@ being sent when data collection was disabled at launch.
 
 If persistence is active but a recovered crash cannot be matched to a
 persisted session, the SDK discards that crash rather than attributing it to
-the new live session. If persistence is disabled or unavailable, the SDK
-cannot recover the prior session identity and retains the legacy live-session
-fallback.
+the new live session. If persistence storage is disabled or unavailable after
+runtime ownership is established, the SDK cannot recover the prior session
+identity and retains the legacy live-session fallback.
 
 **What counts as activity.** Faro classifies telemetry as meaningful work or
 passive telemetry. Every item checks session expiry before it is attributed,

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -454,12 +454,14 @@ On Android, only the root Flutter engine that owns the process-scoped session
 record attempts to read historical `ApplicationExitInfo` records. Other
 engines skip recovery so an old crash cannot be emitted with an unrelated live
 session. Enable crash reporting on every root-engine entrypoint that may
-initialize Faro first. An already initialized non-owner does not take over
-recovery when the owner detaches; a new engine can claim ownership after the
-previous owner is destroyed. If native runtime identity is unavailable, Faro
-does not read or mark historical exits as handled. A later process launch may
-recover them if Android still retains the records and ownership can then be
-resolved. Android continues to deduplicate historical exit records.
+initialize Faro first. Recovery delivery is asynchronous, so the owning engine
+must remain alive until its configured transport accepts the payload. An
+already initialized non-owner does not take over recovery when the owner
+detaches; a new engine can claim ownership after the previous owner is
+destroyed. If native runtime identity is unavailable, Faro does not read or
+mark historical exits as handled. A later process launch may recover them if
+Android still retains the records and ownership can then be resolved. Android
+continues to deduplicate historical exit records.
 
 On iOS, Faro purges the pending PLCrashReporter record after Dart accepts it
 for transport. The report uses the configured collector and custom transports,

--- a/example/README.md
+++ b/example/README.md
@@ -216,12 +216,12 @@ Invalid JSON is silently ignored, falling back to the normal initial user.
 The Android instrumentation test starts Activity-backed and headless Flutter
 engines in the same process, in both startup orders. It verifies that ownership
 is first-come rather than tied to an engine role. The non-owner resets its live
-session and attempts crash recovery without changing the durable session file
-or consuming the recovered crash. After the owner is destroyed, a newly created
-engine claims persistence without linking through the non-owner session and
-replays the crash through the historical transport with the original owner's
-metadata. Each engine also emits a Faro event so the test can verify its session
-and runtime metadata.
+session and is refused by the SDK recovery gate before synthetic crash
+delivery, without changing the durable session file. After the owner is
+destroyed, a newly created engine claims persistence without linking through
+the non-owner session and replays the crash through the historical transport
+with the original owner's metadata. Each engine also emits a Faro event so the
+test can verify its session and runtime metadata.
 
 The test deletes the example app's `faro/sessions` directory before and after
 the run. Use a disposable debug install rather than an app whose local session

--- a/example/README.md
+++ b/example/README.md
@@ -211,6 +211,28 @@ Non-string attribute values (booleans, numbers) in the user JSON are
 automatically converted to strings to match the `FaroUser.attributes` contract.
 Invalid JSON is silently ignored, falling back to the normal initial user.
 
+## Secondary engine session harness
+
+The Android instrumentation test starts an Activity-backed Flutter engine and a
+headless engine in the same process. It verifies that only the first engine owns
+the durable session file, then destroys that owner and confirms that a newly
+created engine can claim persistence without linking through the headless
+session. Each engine also emits a Faro event so the test can verify its session
+and runtime metadata. Finally, the replacement engine replays a synthetic
+Android crash against the persisted history and verifies that it is attributed
+to the original owner, not the secondary or current live session.
+
+Run it on a connected Android device or emulator:
+
+```bash
+cd example
+flutter pub get
+cd android
+./gradlew :app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=\
+com.grafana.faro_example.SecondaryEngineSessionTest
+```
+
 ## WebView Tracing Feature
 
 The example app includes a `WebView Tracing` feature page. It opens an

--- a/example/README.md
+++ b/example/README.md
@@ -213,14 +213,19 @@ Invalid JSON is silently ignored, falling back to the normal initial user.
 
 ## Secondary engine session harness
 
-The Android instrumentation test starts an Activity-backed Flutter engine and a
-headless engine in the same process. It verifies that only the first engine owns
-the durable session file, then destroys that owner and confirms that a newly
-created engine can claim persistence without linking through the headless
-session. Each engine also emits a Faro event so the test can verify its session
-and runtime metadata. Finally, the replacement engine replays a synthetic
-Android crash against the persisted history and verifies that it is attributed
-to the original owner, not the secondary or current live session.
+The Android instrumentation test starts Activity-backed and headless Flutter
+engines in the same process, in both startup orders. It verifies that ownership
+is first-come rather than tied to an engine role. The non-owner resets its live
+session and attempts crash recovery without changing the durable session file
+or consuming the recovered crash. After the owner is destroyed, a newly created
+engine claims persistence without linking through the non-owner session and
+replays the crash through the historical transport with the original owner's
+metadata. Each engine also emits a Faro event so the test can verify its session
+and runtime metadata.
+
+The test deletes the example app's `faro/sessions` directory before and after
+the run. Use a disposable debug install rather than an app whose local session
+history needs to be retained.
 
 Run it on a connected Android device or emulator:
 
@@ -228,9 +233,7 @@ Run it on a connected Android device or emulator:
 cd example
 flutter pub get
 cd android
-./gradlew :app:connectedDebugAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.class=\
-com.grafana.faro_example.SecondaryEngineSessionTest
+./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.grafana.faro_example.SecondaryEngineSessionTest
 ```
 
 ## WebView Tracing Feature

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -43,6 +43,7 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -52,6 +53,13 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+}
+
+dependencies {
+    debugImplementation "androidx.activity:activity:1.9.3"
+    androidTestImplementation "androidx.test:core:1.7.0"
+    androidTestImplementation "androidx.test.ext:junit:1.3.0"
+    androidTestImplementation "androidx.test:runner:1.7.0"
 }
 
 configurations.all {

--- a/example/android/app/src/androidTest/java/com/grafana/faro_example/SecondaryEngineSessionTest.java
+++ b/example/android/app/src/androidTest/java/com/grafana/faro_example/SecondaryEngineSessionTest.java
@@ -55,6 +55,7 @@ public final class SecondaryEngineSessionTest {
     private static final long ENGINE_START_TIMEOUT_SECONDS = 45;
     private static final long COMMAND_TIMEOUT_SECONDS = 20;
     private static final long PERSISTENCE_TIMEOUT_MILLIS = 5_000;
+    private static final long NEGATIVE_ASSERTION_SETTLE_MILLIS = 500;
 
     private final List<EngineHandle> engines = new ArrayList<>();
     private Context context;
@@ -91,7 +92,7 @@ public final class SecondaryEngineSessionTest {
             assertNotNull(owner.report.processName);
             assertEquals("main", owner.report.engineRole);
             assertEquals("main", owner.report.isolateName);
-            assertTrue(owner.report.previousSessionPresent);
+            assertFalse(owner.report.previousSessionPresent);
             assertNull(owner.report.previousSession);
             assertNotNull(owner.report.sessionDirectory);
             assertEquals(
@@ -103,7 +104,7 @@ public final class SecondaryEngineSessionTest {
             assertNotNull(secondary.report.processName);
             assertEquals("headless", secondary.report.engineRole);
             assertEquals("headless", secondary.report.isolateName);
-            assertTrue(secondary.report.previousSessionPresent);
+            assertFalse(secondary.report.previousSessionPresent);
             assertNull(secondary.report.previousSession);
             assertEquals(owner.report.processName, secondary.report.processName);
             assertNotEquals(owner.report.sessionId, secondary.report.sessionId);
@@ -128,7 +129,10 @@ public final class SecondaryEngineSessionTest {
                 secondary.report.sessionId,
                 secondaryReset.get("sessionId")
             );
-            List<PersistedRecord> afterSecondaryReset = waitForPersistedRecords(
+            assertTrue(secondaryReset.get("sessionId") instanceof String);
+            String secondaryResetSessionId =
+                (String) secondaryReset.get("sessionId");
+            List<PersistedRecord> afterSecondaryReset = assertPersistedRecordsRemain(
                 1,
                 owner.report.sessionId
             );
@@ -172,6 +176,7 @@ public final class SecondaryEngineSessionTest {
                 assertTrue(record.isSampled);
             }
             assertFalse(persistedSessionIds.contains(secondary.report.sessionId));
+            assertFalse(persistedSessionIds.contains(secondaryResetSessionId));
 
             Map<String, Object> crashResult = reportRecoveredCrash(
                 replacement,
@@ -182,6 +187,7 @@ public final class SecondaryEngineSessionTest {
             assertEquals(Boolean.TRUE, crashResult.get("recoveryAttempted"));
             assertEquals("historicalAcknowledged", crashResult.get("deliveryMethod"));
             assertEquals(owner.report.sessionId, crashResult.get("payloadSessionId"));
+            assertEquals(Boolean.FALSE, crashResult.get("payloadPreviousSessionPresent"));
             assertNull(crashResult.get("payloadPreviousSession"));
             assertEquals(owner.report.sessionId, crashResult.get("crashedSessionId"));
             assertEquals(Boolean.TRUE, crashResult.get("fatal"));
@@ -214,8 +220,10 @@ public final class SecondaryEngineSessionTest {
 
             assertTrue(first.report.ownsSessionPersistence);
             assertEquals("headless", first.report.engineRole);
+            assertFalse(first.report.previousSessionPresent);
             assertFalse(activityEngine.report.ownsSessionPersistence);
             assertEquals("main", activityEngine.report.engineRole);
+            assertFalse(activityEngine.report.previousSessionPresent);
             assertEquals(first.report.processName, activityEngine.report.processName);
             assertNotEquals(first.report.sessionId, activityEngine.report.sessionId);
 
@@ -504,6 +512,25 @@ public final class SecondaryEngineSessionTest {
         return decoded;
     }
 
+    private List<PersistedRecord> assertPersistedRecordsRemain(
+        int expectedCount,
+        String expectedLastSessionId
+    ) throws Exception {
+        long deadline = System.currentTimeMillis() + NEGATIVE_ASSERTION_SETTLE_MILLIS;
+        List<PersistedRecord> records = null;
+        while (System.currentTimeMillis() < deadline) {
+            records = readPersistedRecords();
+            assertEquals(expectedCount, records.size());
+            assertEquals(
+                expectedLastSessionId,
+                records.get(records.size() - 1).sessionId
+            );
+            Thread.sleep(25);
+        }
+        assertNotNull(records);
+        return records;
+    }
+
     private static void deleteRecursively(File file, boolean strict) {
         if (!file.exists()) {
             return;
@@ -620,7 +647,7 @@ public final class SecondaryEngineSessionTest {
             return new EngineReport(
                 (String) values.get("label"),
                 (String) values.get("sessionId"),
-                values.containsKey("previousSession"),
+                Boolean.TRUE.equals(values.get("previousSessionPresent")),
                 (String) values.get("previousSession"),
                 (String) values.get("processName"),
                 (String) values.get("isolateName"),

--- a/example/android/app/src/androidTest/java/com/grafana/faro_example/SecondaryEngineSessionTest.java
+++ b/example/android/app/src/androidTest/java/com/grafana/faro_example/SecondaryEngineSessionTest.java
@@ -1,0 +1,513 @@
+package com.grafana.faro_example;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.app.Activity;
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.flutter.FlutterInjector;
+import io.flutter.embedding.android.ExclusiveAppComponent;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.plugin.common.MethodChannel;
+
+@RunWith(AndroidJUnit4.class)
+public final class SecondaryEngineSessionTest {
+    private static final String REPORT_CHANNEL = "faro_example/session_engine_harness";
+    private static final long ENGINE_START_TIMEOUT_SECONDS = 45;
+
+    private final List<EngineHandle> engines = new ArrayList<>();
+    private Context context;
+    private File sessionDirectory;
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+        sessionDirectory = new File(context.getFilesDir(), "faro/sessions");
+        deleteRecursively(sessionDirectory);
+    }
+
+    @After
+    public void tearDown() {
+        for (int index = engines.size() - 1; index >= 0; index--) {
+            destroyEngine(engines.get(index));
+        }
+        engines.clear();
+        deleteRecursively(sessionDirectory);
+    }
+
+    @Test
+    public void secondaryEngineCannotMutateTheDurableSessionChain() throws Exception {
+        try (ActivityScenario<SessionEngineHarnessActivity> scenario =
+                 ActivityScenario.launch(SessionEngineHarnessActivity.class)) {
+            AtomicReference<SessionEngineHarnessActivity> activity = new AtomicReference<>();
+            scenario.onActivity(activity::set);
+
+            EngineHandle owner = startEngine("owner", activity.get());
+            EngineHandle secondary = startEngine("secondary", null);
+
+            assertTrue(owner.report.ownsSessionPersistence);
+            assertEquals("main", owner.report.engineRole);
+            assertEquals("main", owner.report.isolateName);
+            assertNull(owner.report.previousSession);
+
+            assertFalse(secondary.report.ownsSessionPersistence);
+            assertEquals("headless", secondary.report.engineRole);
+            assertEquals("headless", secondary.report.isolateName);
+            assertNull(secondary.report.previousSession);
+            assertEquals(owner.report.processName, secondary.report.processName);
+            assertNotEquals(owner.report.sessionId, secondary.report.sessionId);
+            assertTelemetryMatchesEngine(owner);
+            assertTelemetryMatchesEngine(secondary);
+
+            List<PersistedRecord> whileSecondaryIsRunning = readPersistedRecords();
+            assertEquals(1, whileSecondaryIsRunning.size());
+            assertEquals(owner.report.sessionId, whileSecondaryIsRunning.get(0).sessionId);
+            assertNull(whileSecondaryIsRunning.get(0).previousSessionId);
+
+            destroyEngine(owner);
+
+            EngineHandle replacement = startEngine("replacement", null);
+            assertTrue(replacement.report.ownsSessionPersistence);
+            assertEquals("headless", replacement.report.engineRole);
+            assertEquals("headless", replacement.report.isolateName);
+            assertEquals(owner.report.processName, replacement.report.processName);
+            assertEquals(owner.report.sessionId, replacement.report.previousSession);
+            assertNotEquals(owner.report.sessionId, replacement.report.sessionId);
+            assertNotEquals(secondary.report.sessionId, replacement.report.sessionId);
+            assertTelemetryMatchesEngine(replacement);
+
+            List<PersistedRecord> afterOwnershipTransfer = readPersistedRecords();
+            assertEquals(2, afterOwnershipTransfer.size());
+            assertEquals(owner.report.sessionId, afterOwnershipTransfer.get(0).sessionId);
+            assertNull(afterOwnershipTransfer.get(0).previousSessionId);
+            assertEquals(replacement.report.sessionId, afterOwnershipTransfer.get(1).sessionId);
+            assertEquals(owner.report.sessionId, afterOwnershipTransfer.get(1).previousSessionId);
+
+            Set<String> persistedSessionIds = new HashSet<>();
+            for (PersistedRecord record : afterOwnershipTransfer) {
+                assertTrue("duplicate persisted session", persistedSessionIds.add(record.sessionId));
+            }
+            assertFalse(persistedSessionIds.contains(secondary.report.sessionId));
+
+            Map<String, Object> crashResult = reportRecoveredCrash(
+                replacement,
+                afterOwnershipTransfer,
+                owner.report.sessionId,
+                owner.report.processName
+            );
+            assertEquals(owner.report.sessionId, crashResult.get("payloadSessionId"));
+            assertNull(crashResult.get("payloadPreviousSession"));
+            assertEquals(owner.report.sessionId, crashResult.get("crashedSessionId"));
+            assertEquals(Boolean.TRUE, crashResult.get("fatal"));
+            assertEquals(replacement.report.sessionId, crashResult.get("liveSessionIdAfter"));
+            assertEquals(1, ((Number) crashResult.get("crashPayloadCount")).intValue());
+            assertNotEquals(secondary.report.sessionId, crashResult.get("payloadSessionId"));
+            assertNotEquals(replacement.report.sessionId, crashResult.get("payloadSessionId"));
+
+            System.out.println(
+                "Faro session engine harness: process=" + owner.report.processName
+                    + ", owner=" + owner.report.sessionId
+                    + ", secondary=" + secondary.report.sessionId
+                    + ", replacement=" + replacement.report.sessionId
+                    + ", replacement.previous=" + replacement.report.previousSession
+            );
+        }
+    }
+
+    private static void assertTelemetryMatchesEngine(EngineHandle engine) {
+        assertEquals(engine.report.sessionId, engine.report.telemetrySessionId);
+        assertEquals(engine.report.previousSession, engine.report.telemetryPreviousSession);
+        assertEquals(engine.report.processName, engine.report.telemetryProcessName);
+        assertEquals(engine.report.isolateName, engine.report.telemetryIsolateName);
+        assertEquals(engine.report.label, engine.report.telemetryProbeLabel);
+        assertEquals(1, engine.report.telemetryProbeCount);
+    }
+
+    private EngineHandle startEngine(
+        String label,
+        @Nullable SessionEngineHarnessActivity activity
+    ) throws InterruptedException {
+        CountDownLatch reportReceived = new CountDownLatch(1);
+        AtomicReference<FlutterEngine> engineReference = new AtomicReference<>();
+        AtomicReference<EngineReport> reportReference = new AtomicReference<>();
+        AtomicReference<MethodChannel> channelReference = new AtomicReference<>();
+        AtomicReference<Throwable> startFailure = new AtomicReference<>();
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+            try {
+                FlutterEngine engine = new FlutterEngine(context);
+                engineReference.set(engine);
+                if (activity != null) {
+                    engine.getActivityControlSurface().attachToActivity(
+                        new TestActivityComponent(activity),
+                        activity.getLifecycle()
+                    );
+                }
+
+                MethodChannel reportChannel = new MethodChannel(
+                    engine.getDartExecutor().getBinaryMessenger(),
+                    REPORT_CHANNEL
+                );
+                channelReference.set(reportChannel);
+                reportChannel.setMethodCallHandler((call, result) -> {
+                    if (!"report".equals(call.method) || !(call.arguments instanceof Map)) {
+                        result.notImplemented();
+                        return;
+                    }
+                    reportReference.set(EngineReport.from(call.arguments));
+                    reportReceived.countDown();
+                    result.success(null);
+                });
+
+                DartExecutor.DartEntrypoint entrypoint = new DartExecutor.DartEntrypoint(
+                    FlutterInjector.instance().flutterLoader().findAppBundlePath(),
+                    "faroSessionEngineHarnessMain"
+                );
+                engine.getDartExecutor().executeDartEntrypoint(
+                    entrypoint,
+                    Collections.singletonList(label)
+                );
+            } catch (Throwable error) {
+                startFailure.set(error);
+                reportReceived.countDown();
+            }
+        });
+
+        if (!reportReceived.await(ENGINE_START_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            fail("Timed out waiting for the " + label + " engine report");
+        }
+        if (startFailure.get() != null) {
+            throw new AssertionError("Failed to start the " + label + " engine", startFailure.get());
+        }
+
+        FlutterEngine engine = engineReference.get();
+        EngineReport report = reportReference.get();
+        MethodChannel reportChannel = channelReference.get();
+        assertNotNull(engine);
+        assertNotNull(report);
+        assertNotNull(reportChannel);
+        if (report.error != null) {
+            fail(label + " engine failed: " + report.error + "\n" + report.stackTrace);
+        }
+
+        EngineHandle handle = new EngineHandle(
+            engine,
+            reportChannel,
+            activity != null,
+            report
+        );
+        engines.add(handle);
+        return handle;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> reportRecoveredCrash(
+        EngineHandle engine,
+        List<PersistedRecord> records,
+        String crashedSessionId,
+        String processName
+    ) throws InterruptedException {
+        CountDownLatch resultReceived = new CountDownLatch(1);
+        AtomicReference<Object> resultReference = new AtomicReference<>();
+        AtomicReference<Throwable> errorReference = new AtomicReference<>();
+        List<Map<String, Object>> encodedRecords = new ArrayList<>();
+        for (PersistedRecord record : records) {
+            encodedRecords.add(record.toMap());
+        }
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put("recoveredSessions", encodedRecords);
+        arguments.put("crashedSessionId", crashedSessionId);
+        arguments.put("processName", processName);
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(() ->
+            engine.reportChannel.invokeMethod(
+                "reportRecoveredCrash",
+                arguments,
+                new MethodChannel.Result() {
+                    @Override
+                    public void success(@Nullable Object result) {
+                        resultReference.set(result);
+                        resultReceived.countDown();
+                    }
+
+                    @Override
+                    public void error(
+                        String code,
+                        @Nullable String message,
+                        @Nullable Object details
+                    ) {
+                        errorReference.set(
+                            new AssertionError(code + ": " + message + " " + details)
+                        );
+                        resultReceived.countDown();
+                    }
+
+                    @Override
+                    public void notImplemented() {
+                        errorReference.set(
+                            new AssertionError("Harness method not implemented")
+                        );
+                        resultReceived.countDown();
+                    }
+                }
+            )
+        );
+
+        if (!resultReceived.await(ENGINE_START_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            fail("Timed out waiting for the recovered crash report");
+        }
+        if (errorReference.get() != null) {
+            throw new AssertionError(
+                "Failed to report recovered crash",
+                errorReference.get()
+            );
+        }
+        assertTrue(resultReference.get() instanceof Map);
+        return (Map<String, Object>) resultReference.get();
+    }
+
+    private void destroyEngine(EngineHandle handle) {
+        if (handle.destroyed) {
+            return;
+        }
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+            if (handle.attachedToActivity) {
+                handle.engine.getActivityControlSurface().detachFromActivity();
+            }
+            handle.engine.destroy();
+        });
+        handle.destroyed = true;
+    }
+
+    private List<PersistedRecord> readPersistedRecords() throws Exception {
+        File[] files = sessionDirectory.listFiles(
+            (directory, name) -> name.endsWith(".json")
+        );
+        assertNotNull("session directory was not created", files);
+        assertEquals("expected one process-scoped session file", 1, files.length);
+
+        StringBuilder contents = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(
+            new InputStreamReader(
+                new FileInputStream(files[0]),
+                StandardCharsets.UTF_8
+            )
+        )) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                contents.append(line);
+            }
+        }
+
+        JSONArray records = new JSONObject(contents.toString()).getJSONArray("records");
+        List<PersistedRecord> decoded = new ArrayList<>();
+        for (int index = 0; index < records.length(); index++) {
+            JSONObject record = records.getJSONObject(index);
+            decoded.add(new PersistedRecord(
+                record.getString("currentSessionId"),
+                record.isNull("previousSessionId")
+                    ? null
+                    : record.getString("previousSessionId"),
+                record.getString("startedAt"),
+                record.getString("lastActivityAt"),
+                record.getBoolean("isSampled")
+            ));
+        }
+        return decoded;
+    }
+
+    private static void deleteRecursively(File file) {
+        if (!file.exists()) {
+            return;
+        }
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        assertTrue("failed to delete " + file, file.delete());
+    }
+
+    private static final class TestActivityComponent
+        implements ExclusiveAppComponent<Activity> {
+        private final Activity activity;
+
+        private TestActivityComponent(Activity activity) {
+            this.activity = activity;
+        }
+
+        @Override
+        public void detachFromFlutterEngine() {}
+
+        @Override
+        public Activity getAppComponent() {
+            return activity;
+        }
+    }
+
+    private static final class EngineHandle {
+        private final FlutterEngine engine;
+        private final MethodChannel reportChannel;
+        private final boolean attachedToActivity;
+        private final EngineReport report;
+        private boolean destroyed;
+
+        private EngineHandle(
+            FlutterEngine engine,
+            MethodChannel reportChannel,
+            boolean attachedToActivity,
+            EngineReport report
+        ) {
+            this.engine = engine;
+            this.reportChannel = reportChannel;
+            this.attachedToActivity = attachedToActivity;
+            this.report = report;
+        }
+    }
+
+    private static final class EngineReport {
+        private final String label;
+        private final String sessionId;
+        private final @Nullable String previousSession;
+        private final String processName;
+        private final String isolateName;
+        private final boolean ownsSessionPersistence;
+        private final String engineRole;
+        private final String telemetrySessionId;
+        private final @Nullable String telemetryPreviousSession;
+        private final String telemetryProcessName;
+        private final String telemetryIsolateName;
+        private final String telemetryProbeLabel;
+        private final int telemetryProbeCount;
+        private final @Nullable String error;
+        private final @Nullable String stackTrace;
+
+        private EngineReport(
+            String label,
+            String sessionId,
+            @Nullable String previousSession,
+            String processName,
+            String isolateName,
+            boolean ownsSessionPersistence,
+            String engineRole,
+            String telemetrySessionId,
+            @Nullable String telemetryPreviousSession,
+            String telemetryProcessName,
+            String telemetryIsolateName,
+            String telemetryProbeLabel,
+            int telemetryProbeCount,
+            @Nullable String error,
+            @Nullable String stackTrace
+        ) {
+            this.label = label;
+            this.sessionId = sessionId;
+            this.previousSession = previousSession;
+            this.processName = processName;
+            this.isolateName = isolateName;
+            this.ownsSessionPersistence = ownsSessionPersistence;
+            this.engineRole = engineRole;
+            this.telemetrySessionId = telemetrySessionId;
+            this.telemetryPreviousSession = telemetryPreviousSession;
+            this.telemetryProcessName = telemetryProcessName;
+            this.telemetryIsolateName = telemetryIsolateName;
+            this.telemetryProbeLabel = telemetryProbeLabel;
+            this.telemetryProbeCount = telemetryProbeCount;
+            this.error = error;
+            this.stackTrace = stackTrace;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static EngineReport from(Object arguments) {
+            Map<String, Object> values = (Map<String, Object>) arguments;
+            return new EngineReport(
+                (String) values.get("label"),
+                (String) values.get("sessionId"),
+                (String) values.get("previousSession"),
+                (String) values.get("processName"),
+                (String) values.get("isolateName"),
+                Boolean.TRUE.equals(values.get("ownsSessionPersistence")),
+                (String) values.get("engineRole"),
+                (String) values.get("telemetrySessionId"),
+                (String) values.get("telemetryPreviousSession"),
+                (String) values.get("telemetryProcessName"),
+                (String) values.get("telemetryIsolateName"),
+                (String) values.get("telemetryProbeLabel"),
+                values.get("telemetryProbeCount") instanceof Number
+                    ? ((Number) values.get("telemetryProbeCount")).intValue()
+                    : 0,
+                (String) values.get("error"),
+                (String) values.get("stackTrace")
+            );
+        }
+    }
+
+    private static final class PersistedRecord {
+        private final String sessionId;
+        private final @Nullable String previousSessionId;
+        private final String startedAt;
+        private final String lastActivityAt;
+        private final boolean isSampled;
+
+        private PersistedRecord(
+            String sessionId,
+            @Nullable String previousSessionId,
+            String startedAt,
+            String lastActivityAt,
+            boolean isSampled
+        ) {
+            this.sessionId = sessionId;
+            this.previousSessionId = previousSessionId;
+            this.startedAt = startedAt;
+            this.lastActivityAt = lastActivityAt;
+            this.isSampled = isSampled;
+        }
+
+        private Map<String, Object> toMap() {
+            Map<String, Object> result = new HashMap<>();
+            result.put("schemaVersion", 1);
+            result.put("currentSessionId", sessionId);
+            result.put("previousSessionId", previousSessionId);
+            result.put("startedAt", startedAt);
+            result.put("lastActivityAt", lastActivityAt);
+            result.put("isSampled", isSampled);
+            return result;
+        }
+    }
+}

--- a/example/android/app/src/androidTest/java/com/grafana/faro_example/SecondaryEngineSessionTest.java
+++ b/example/android/app/src/androidTest/java/com/grafana/faro_example/SecondaryEngineSessionTest.java
@@ -6,10 +6,10 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import android.app.Activity;
 import android.content.Context;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 import androidx.test.core.app.ActivityScenario;
@@ -48,8 +48,13 @@ import io.flutter.plugin.common.MethodChannel;
 
 @RunWith(AndroidJUnit4.class)
 public final class SecondaryEngineSessionTest {
+    private static final String TAG = "FaroSessionEngineTest";
     private static final String REPORT_CHANNEL = "faro_example/session_engine_harness";
+    private static final String COMMAND_CHANNEL =
+        "faro_example/session_engine_harness_commands";
     private static final long ENGINE_START_TIMEOUT_SECONDS = 45;
+    private static final long COMMAND_TIMEOUT_SECONDS = 20;
+    private static final long PERSISTENCE_TIMEOUT_MILLIS = 5_000;
 
     private final List<EngineHandle> engines = new ArrayList<>();
     private Context context;
@@ -59,7 +64,7 @@ public final class SecondaryEngineSessionTest {
     public void setUp() {
         context = ApplicationProvider.getApplicationContext();
         sessionDirectory = new File(context.getFilesDir(), "faro/sessions");
-        deleteRecursively(sessionDirectory);
+        deleteRecursively(sessionDirectory, true);
     }
 
     @After
@@ -68,37 +73,75 @@ public final class SecondaryEngineSessionTest {
             destroyEngine(engines.get(index));
         }
         engines.clear();
-        deleteRecursively(sessionDirectory);
+        deleteRecursively(sessionDirectory, false);
     }
 
     @Test
-    public void secondaryEngineCannotMutateTheDurableSessionChain() throws Exception {
+    public void firstEngineOwnsPersistenceAndSecondaryCannotMutateIt() throws Exception {
         try (ActivityScenario<SessionEngineHarnessActivity> scenario =
                  ActivityScenario.launch(SessionEngineHarnessActivity.class)) {
             AtomicReference<SessionEngineHarnessActivity> activity = new AtomicReference<>();
             scenario.onActivity(activity::set);
+            assertNotNull("harness Activity did not launch", activity.get());
 
             EngineHandle owner = startEngine("owner", activity.get());
             EngineHandle secondary = startEngine("secondary", null);
 
             assertTrue(owner.report.ownsSessionPersistence);
+            assertNotNull(owner.report.processName);
             assertEquals("main", owner.report.engineRole);
             assertEquals("main", owner.report.isolateName);
+            assertTrue(owner.report.previousSessionPresent);
             assertNull(owner.report.previousSession);
+            assertNotNull(owner.report.sessionDirectory);
+            assertEquals(
+                sessionDirectory.getCanonicalPath(),
+                new File(owner.report.sessionDirectory).getCanonicalPath()
+            );
 
             assertFalse(secondary.report.ownsSessionPersistence);
+            assertNotNull(secondary.report.processName);
             assertEquals("headless", secondary.report.engineRole);
             assertEquals("headless", secondary.report.isolateName);
+            assertTrue(secondary.report.previousSessionPresent);
             assertNull(secondary.report.previousSession);
             assertEquals(owner.report.processName, secondary.report.processName);
             assertNotEquals(owner.report.sessionId, secondary.report.sessionId);
             assertTelemetryMatchesEngine(owner);
             assertTelemetryMatchesEngine(secondary);
 
-            List<PersistedRecord> whileSecondaryIsRunning = readPersistedRecords();
+            List<PersistedRecord> whileSecondaryIsRunning = waitForPersistedRecords(
+                1,
+                owner.report.sessionId
+            );
             assertEquals(1, whileSecondaryIsRunning.size());
             assertEquals(owner.report.sessionId, whileSecondaryIsRunning.get(0).sessionId);
             assertNull(whileSecondaryIsRunning.get(0).previousSessionId);
+            assertTrue(whileSecondaryIsRunning.get(0).isSampled);
+
+            Map<String, Object> secondaryReset = resetSession(secondary);
+            assertEquals(
+                secondary.report.sessionId,
+                secondaryReset.get("previousSessionId")
+            );
+            assertNotEquals(
+                secondary.report.sessionId,
+                secondaryReset.get("sessionId")
+            );
+            List<PersistedRecord> afterSecondaryReset = waitForPersistedRecords(
+                1,
+                owner.report.sessionId
+            );
+            assertEquals(owner.report.sessionId, afterSecondaryReset.get(0).sessionId);
+
+            Map<String, Object> secondaryCrash = reportRecoveredCrash(
+                secondary,
+                afterSecondaryReset,
+                owner.report.sessionId,
+                owner.report.processName
+            );
+            assertEquals(Boolean.FALSE, secondaryCrash.get("recoveryAttempted"));
+            assertEquals(0, ((Number) secondaryCrash.get("crashPayloadCount")).intValue());
 
             destroyEngine(owner);
 
@@ -107,12 +150,16 @@ public final class SecondaryEngineSessionTest {
             assertEquals("headless", replacement.report.engineRole);
             assertEquals("headless", replacement.report.isolateName);
             assertEquals(owner.report.processName, replacement.report.processName);
+            assertTrue(replacement.report.previousSessionPresent);
             assertEquals(owner.report.sessionId, replacement.report.previousSession);
             assertNotEquals(owner.report.sessionId, replacement.report.sessionId);
             assertNotEquals(secondary.report.sessionId, replacement.report.sessionId);
             assertTelemetryMatchesEngine(replacement);
 
-            List<PersistedRecord> afterOwnershipTransfer = readPersistedRecords();
+            List<PersistedRecord> afterOwnershipTransfer = waitForPersistedRecords(
+                2,
+                replacement.report.sessionId
+            );
             assertEquals(2, afterOwnershipTransfer.size());
             assertEquals(owner.report.sessionId, afterOwnershipTransfer.get(0).sessionId);
             assertNull(afterOwnershipTransfer.get(0).previousSessionId);
@@ -122,6 +169,7 @@ public final class SecondaryEngineSessionTest {
             Set<String> persistedSessionIds = new HashSet<>();
             for (PersistedRecord record : afterOwnershipTransfer) {
                 assertTrue("duplicate persisted session", persistedSessionIds.add(record.sessionId));
+                assertTrue(record.isSampled);
             }
             assertFalse(persistedSessionIds.contains(secondary.report.sessionId));
 
@@ -131,6 +179,8 @@ public final class SecondaryEngineSessionTest {
                 owner.report.sessionId,
                 owner.report.processName
             );
+            assertEquals(Boolean.TRUE, crashResult.get("recoveryAttempted"));
+            assertEquals("historicalAcknowledged", crashResult.get("deliveryMethod"));
             assertEquals(owner.report.sessionId, crashResult.get("payloadSessionId"));
             assertNull(crashResult.get("payloadPreviousSession"));
             assertEquals(owner.report.sessionId, crashResult.get("crashedSessionId"));
@@ -140,12 +190,45 @@ public final class SecondaryEngineSessionTest {
             assertNotEquals(secondary.report.sessionId, crashResult.get("payloadSessionId"));
             assertNotEquals(replacement.report.sessionId, crashResult.get("payloadSessionId"));
 
-            System.out.println(
+            Log.i(
+                TAG,
                 "Faro session engine harness: process=" + owner.report.processName
                     + ", owner=" + owner.report.sessionId
                     + ", secondary=" + secondary.report.sessionId
                     + ", replacement=" + replacement.report.sessionId
                     + ", replacement.previous=" + replacement.report.previousSession
+            );
+        }
+    }
+
+    @Test
+    public void headlessEngineCanOwnPersistenceWhenItStartsFirst() throws Exception {
+        try (ActivityScenario<SessionEngineHarnessActivity> scenario =
+                 ActivityScenario.launch(SessionEngineHarnessActivity.class)) {
+            AtomicReference<SessionEngineHarnessActivity> activity = new AtomicReference<>();
+            scenario.onActivity(activity::set);
+            assertNotNull("harness Activity did not launch", activity.get());
+
+            EngineHandle first = startEngine("headless-owner", null);
+            EngineHandle activityEngine = startEngine("activity-secondary", activity.get());
+
+            assertTrue(first.report.ownsSessionPersistence);
+            assertEquals("headless", first.report.engineRole);
+            assertFalse(activityEngine.report.ownsSessionPersistence);
+            assertEquals("main", activityEngine.report.engineRole);
+            assertEquals(first.report.processName, activityEngine.report.processName);
+            assertNotEquals(first.report.sessionId, activityEngine.report.sessionId);
+
+            List<PersistedRecord> records = waitForPersistedRecords(
+                1,
+                first.report.sessionId
+            );
+            assertEquals(first.report.sessionId, records.get(0).sessionId);
+            assertTrue(records.get(0).isSampled);
+            assertFalse(
+                records.stream().anyMatch(
+                    record -> record.sessionId.equals(activityEngine.report.sessionId)
+                )
             );
         }
     }
@@ -166,7 +249,7 @@ public final class SecondaryEngineSessionTest {
         CountDownLatch reportReceived = new CountDownLatch(1);
         AtomicReference<FlutterEngine> engineReference = new AtomicReference<>();
         AtomicReference<EngineReport> reportReference = new AtomicReference<>();
-        AtomicReference<MethodChannel> channelReference = new AtomicReference<>();
+        AtomicReference<MethodChannel> commandChannelReference = new AtomicReference<>();
         AtomicReference<Throwable> startFailure = new AtomicReference<>();
 
         InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
@@ -184,7 +267,6 @@ public final class SecondaryEngineSessionTest {
                     engine.getDartExecutor().getBinaryMessenger(),
                     REPORT_CHANNEL
                 );
-                channelReference.set(reportChannel);
                 reportChannel.setMethodCallHandler((call, result) -> {
                     if (!"report".equals(call.method) || !(call.arguments instanceof Map)) {
                         result.notImplemented();
@@ -194,6 +276,10 @@ public final class SecondaryEngineSessionTest {
                     reportReceived.countDown();
                     result.success(null);
                 });
+                commandChannelReference.set(new MethodChannel(
+                    engine.getDartExecutor().getBinaryMessenger(),
+                    COMMAND_CHANNEL
+                ));
 
                 DartExecutor.DartEntrypoint entrypoint = new DartExecutor.DartEntrypoint(
                     FlutterInjector.instance().flutterLoader().findAppBundlePath(),
@@ -210,30 +296,46 @@ public final class SecondaryEngineSessionTest {
         });
 
         if (!reportReceived.await(ENGINE_START_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-            fail("Timed out waiting for the " + label + " engine report");
+            destroyFlutterEngine(engineReference.get(), activity != null);
+            throw new AssertionError("Timed out waiting for the " + label + " engine report");
         }
         if (startFailure.get() != null) {
+            destroyFlutterEngine(engineReference.get(), activity != null);
             throw new AssertionError("Failed to start the " + label + " engine", startFailure.get());
         }
 
         FlutterEngine engine = engineReference.get();
         EngineReport report = reportReference.get();
-        MethodChannel reportChannel = channelReference.get();
-        assertNotNull(engine);
-        assertNotNull(report);
-        assertNotNull(reportChannel);
+        MethodChannel commandChannel = commandChannelReference.get();
+        if (engine == null || report == null || commandChannel == null) {
+            destroyFlutterEngine(engine, activity != null);
+            throw new AssertionError(label + " engine returned an incomplete harness report");
+        }
         if (report.error != null) {
-            fail(label + " engine failed: " + report.error + "\n" + report.stackTrace);
+            destroyFlutterEngine(engine, activity != null);
+            throw new AssertionError(
+                label + " engine failed: " + report.error + "\n" + report.stackTrace
+            );
         }
 
         EngineHandle handle = new EngineHandle(
             engine,
-            reportChannel,
+            commandChannel,
             activity != null,
             report
         );
         engines.add(handle);
         return handle;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> resetSession(EngineHandle engine) throws InterruptedException {
+        return (Map<String, Object>) invokeCommand(
+            engine,
+            "resetSession",
+            null,
+            COMMAND_TIMEOUT_SECONDS
+        );
     }
 
     @SuppressWarnings("unchecked")
@@ -243,9 +345,6 @@ public final class SecondaryEngineSessionTest {
         String crashedSessionId,
         String processName
     ) throws InterruptedException {
-        CountDownLatch resultReceived = new CountDownLatch(1);
-        AtomicReference<Object> resultReference = new AtomicReference<>();
-        AtomicReference<Throwable> errorReference = new AtomicReference<>();
         List<Map<String, Object>> encodedRecords = new ArrayList<>();
         for (PersistedRecord record : records) {
             encodedRecords.add(record.toMap());
@@ -255,9 +354,29 @@ public final class SecondaryEngineSessionTest {
         arguments.put("crashedSessionId", crashedSessionId);
         arguments.put("processName", processName);
 
+        Object result = invokeCommand(
+            engine,
+            "reportRecoveredCrash",
+            arguments,
+            COMMAND_TIMEOUT_SECONDS
+        );
+        assertTrue(result instanceof Map);
+        return (Map<String, Object>) result;
+    }
+
+    private Object invokeCommand(
+        EngineHandle engine,
+        String method,
+        @Nullable Object arguments,
+        long timeoutSeconds
+    ) throws InterruptedException {
+        CountDownLatch resultReceived = new CountDownLatch(1);
+        AtomicReference<Object> resultReference = new AtomicReference<>();
+        AtomicReference<Throwable> errorReference = new AtomicReference<>();
+
         InstrumentationRegistry.getInstrumentation().runOnMainSync(() ->
-            engine.reportChannel.invokeMethod(
-                "reportRecoveredCrash",
+            engine.commandChannel.invokeMethod(
+                method,
                 arguments,
                 new MethodChannel.Result() {
                     @Override
@@ -281,7 +400,7 @@ public final class SecondaryEngineSessionTest {
                     @Override
                     public void notImplemented() {
                         errorReference.set(
-                            new AssertionError("Harness method not implemented")
+                            new AssertionError("Harness method not implemented: " + method)
                         );
                         resultReceived.countDown();
                     }
@@ -289,30 +408,63 @@ public final class SecondaryEngineSessionTest {
             )
         );
 
-        if (!resultReceived.await(ENGINE_START_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-            fail("Timed out waiting for the recovered crash report");
+        if (!resultReceived.await(timeoutSeconds, TimeUnit.SECONDS)) {
+            throw new AssertionError("Timed out waiting for harness method " + method);
         }
         if (errorReference.get() != null) {
-            throw new AssertionError(
-                "Failed to report recovered crash",
-                errorReference.get()
-            );
+            throw new AssertionError("Harness method failed: " + method, errorReference.get());
         }
-        assertTrue(resultReference.get() instanceof Map);
-        return (Map<String, Object>) resultReference.get();
+        return resultReference.get();
     }
 
     private void destroyEngine(EngineHandle handle) {
         if (handle.destroyed) {
             return;
         }
-        InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
-            if (handle.attachedToActivity) {
-                handle.engine.getActivityControlSurface().detachFromActivity();
-            }
-            handle.engine.destroy();
-        });
+        destroyFlutterEngine(handle.engine, handle.attachedToActivity);
         handle.destroyed = true;
+    }
+
+    private void destroyFlutterEngine(
+        @Nullable FlutterEngine engine,
+        boolean attachedToActivity
+    ) {
+        if (engine == null) {
+            return;
+        }
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+            if (attachedToActivity) {
+                engine.getActivityControlSurface().detachFromActivity();
+            }
+            engine.destroy();
+        });
+    }
+
+    private List<PersistedRecord> waitForPersistedRecords(
+        int expectedCount,
+        String expectedLastSessionId
+    ) throws Exception {
+        long deadline = System.currentTimeMillis() + PERSISTENCE_TIMEOUT_MILLIS;
+        Throwable lastFailure = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                List<PersistedRecord> records = readPersistedRecords();
+                if (records.size() == expectedCount
+                    && expectedLastSessionId.equals(
+                        records.get(records.size() - 1).sessionId
+                    )) {
+                    return records;
+                }
+            } catch (Exception | AssertionError error) {
+                lastFailure = error;
+            }
+            Thread.sleep(25);
+        }
+        throw new AssertionError(
+            "Timed out waiting for " + expectedCount
+                + " persisted records ending at " + expectedLastSessionId,
+            lastFailure
+        );
     }
 
     private List<PersistedRecord> readPersistedRecords() throws Exception {
@@ -352,17 +504,20 @@ public final class SecondaryEngineSessionTest {
         return decoded;
     }
 
-    private static void deleteRecursively(File file) {
+    private static void deleteRecursively(File file, boolean strict) {
         if (!file.exists()) {
             return;
         }
         File[] children = file.listFiles();
         if (children != null) {
             for (File child : children) {
-                deleteRecursively(child);
+                deleteRecursively(child, strict);
             }
         }
-        assertTrue("failed to delete " + file, file.delete());
+        boolean deleted = file.delete();
+        if (strict && !deleted && file.exists()) {
+            throw new AssertionError("failed to delete " + file);
+        }
     }
 
     private static final class TestActivityComponent
@@ -384,19 +539,19 @@ public final class SecondaryEngineSessionTest {
 
     private static final class EngineHandle {
         private final FlutterEngine engine;
-        private final MethodChannel reportChannel;
+        private final MethodChannel commandChannel;
         private final boolean attachedToActivity;
         private final EngineReport report;
         private boolean destroyed;
 
         private EngineHandle(
             FlutterEngine engine,
-            MethodChannel reportChannel,
+            MethodChannel commandChannel,
             boolean attachedToActivity,
             EngineReport report
         ) {
             this.engine = engine;
-            this.reportChannel = reportChannel;
+            this.commandChannel = commandChannel;
             this.attachedToActivity = attachedToActivity;
             this.report = report;
         }
@@ -405,11 +560,13 @@ public final class SecondaryEngineSessionTest {
     private static final class EngineReport {
         private final String label;
         private final String sessionId;
+        private final boolean previousSessionPresent;
         private final @Nullable String previousSession;
         private final String processName;
         private final String isolateName;
         private final boolean ownsSessionPersistence;
         private final String engineRole;
+        private final String sessionDirectory;
         private final String telemetrySessionId;
         private final @Nullable String telemetryPreviousSession;
         private final String telemetryProcessName;
@@ -422,11 +579,13 @@ public final class SecondaryEngineSessionTest {
         private EngineReport(
             String label,
             String sessionId,
+            boolean previousSessionPresent,
             @Nullable String previousSession,
             String processName,
             String isolateName,
             boolean ownsSessionPersistence,
             String engineRole,
+            String sessionDirectory,
             String telemetrySessionId,
             @Nullable String telemetryPreviousSession,
             String telemetryProcessName,
@@ -438,11 +597,13 @@ public final class SecondaryEngineSessionTest {
         ) {
             this.label = label;
             this.sessionId = sessionId;
+            this.previousSessionPresent = previousSessionPresent;
             this.previousSession = previousSession;
             this.processName = processName;
             this.isolateName = isolateName;
             this.ownsSessionPersistence = ownsSessionPersistence;
             this.engineRole = engineRole;
+            this.sessionDirectory = sessionDirectory;
             this.telemetrySessionId = telemetrySessionId;
             this.telemetryPreviousSession = telemetryPreviousSession;
             this.telemetryProcessName = telemetryProcessName;
@@ -459,11 +620,13 @@ public final class SecondaryEngineSessionTest {
             return new EngineReport(
                 (String) values.get("label"),
                 (String) values.get("sessionId"),
+                values.containsKey("previousSession"),
                 (String) values.get("previousSession"),
                 (String) values.get("processName"),
                 (String) values.get("isolateName"),
                 Boolean.TRUE.equals(values.get("ownsSessionPersistence")),
                 (String) values.get("engineRole"),
+                (String) values.get("sessionDirectory"),
                 (String) values.get("telemetrySessionId"),
                 (String) values.get("telemetryPreviousSession"),
                 (String) values.get("telemetryProcessName"),

--- a/example/android/app/src/debug/AndroidManifest.xml
+++ b/example/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,10 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <application>
+        <activity
+            android:name=".SessionEngineHarnessActivity"
+            android:exported="false"
+            android:theme="@style/NormalTheme" />
+    </application>
 </manifest>

--- a/example/android/app/src/debug/java/com/grafana/faro_example/SessionEngineHarnessActivity.java
+++ b/example/android/app/src/debug/java/com/grafana/faro_example/SessionEngineHarnessActivity.java
@@ -1,0 +1,6 @@
+package com.grafana.faro_example;
+
+import androidx.activity.ComponentActivity;
+
+/** Empty host used by the secondary-engine session instrumentation test. */
+public final class SessionEngineHarnessActivity extends ComponentActivity {}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,9 +13,15 @@ import 'package:faro_example/features/user_settings/user_settings_page.dart';
 import 'package:faro_example/features/user_settings/user_settings_service.dart';
 import 'package:faro_example/features/webview_handoff/presentation/webview_handoff_page.dart';
 import 'package:faro_example/qa_config.dart';
+import 'package:faro_example/session_engine_harness.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+@pragma('vm:entry-point')
+Future<void> faroSessionEngineHarnessMain(List<String> args) {
+  return runSessionEngineHarness(args);
+}
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/example/lib/session_engine_harness.dart
+++ b/example/lib/session_engine_harness.dart
@@ -2,14 +2,19 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:faro/faro.dart';
 import 'package:faro/src/session/session_persistence.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:path_provider/path_provider.dart';
 
 const _nativeChannel = MethodChannel('faro');
 const _reportChannel = MethodChannel('faro_example/session_engine_harness');
+const _commandChannel = MethodChannel(
+  'faro_example/session_engine_harness_commands',
+);
 
 Future<void> runSessionEngineHarness(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -43,6 +48,12 @@ Future<void> runSessionEngineHarness(List<String> args) async {
       'getSessionRuntimeInfo',
       {'claimSessionPersistence': false},
     );
+    final supportDirectory = await getApplicationSupportDirectory();
+    final sessionDirectory = [
+      supportDirectory.path,
+      'faro',
+      'sessions',
+    ].join(Platform.pathSeparator);
     final session = Faro().meta.session;
     final attributes = session?.attributes;
 
@@ -59,10 +70,19 @@ Future<void> runSessionEngineHarness(List<String> args) async {
       telemetryPayload,
     ).firstWhere((event) => event['name'] == 'session_engine_probe');
 
-    _reportChannel.setMethodCallHandler((call) async {
+    _commandChannel.setMethodCallHandler((call) async {
+      if (call.method == 'resetSession') {
+        final previousSessionId = Faro().meta.session?.id;
+        await Faro().resetSession();
+        return <String, Object?>{
+          'previousSessionId': previousSessionId,
+          'sessionId': Faro().meta.session?.id,
+        };
+      }
       if (call.method != 'reportRecoveredCrash') {
         throw MissingPluginException('Unknown harness method ${call.method}');
       }
+
       final arguments = _map(call.arguments);
       final records = (arguments['recoveredSessions'] as List<dynamic>)
           .map((record) => PersistedSessionRecord.fromJson(_map(record)))
@@ -82,21 +102,32 @@ Future<void> runSessionEngineHarness(List<String> args) async {
         'processName': arguments['processName'],
       });
 
-      await Faro().reportAndroidCrashesForTesting(
-        <String>[crashReport],
-        recoveredSessions: records,
-        processIdentifier: arguments['processName'] as String,
-      );
+      final recoveryAttempted = await Faro()
+          .attemptAndroidCrashRecoveryForTesting(
+            <String>[crashReport],
+            recoveredSessions: records,
+            processIdentifier: arguments['processName'] as String,
+          );
+
+      if (!recoveryAttempted) {
+        return <String, Object?>{
+          'recoveryAttempted': false,
+          'liveSessionIdAfter': Faro().meta.session?.id,
+          'crashPayloadCount': transport.crashCount(after: payloadCount),
+        };
+      }
 
       final crashPayload = await transport.waitForCrash(after: payloadCount);
-      final crashSession = _map(_map(crashPayload['meta'])['session']);
+      final crashSession = _map(_map(crashPayload.payload['meta'])['session']);
       final crashAttributes = _map(crashSession['attributes']);
       final crashException = _map(
-        (crashPayload['exceptions'] as List<dynamic>).single,
+        (crashPayload.payload['exceptions'] as List<dynamic>).single,
       );
       final crashContext = _map(crashException['context']);
 
       return <String, Object?>{
+        'recoveryAttempted': true,
+        'deliveryMethod': crashPayload.deliveryMethod.name,
         'payloadSessionId': crashSession['id'],
         'payloadPreviousSession': crashAttributes['previousSession'],
         'crashedSessionId': crashContext['crashedSessionId'],
@@ -114,6 +145,7 @@ Future<void> runSessionEngineHarness(List<String> args) async {
       'isolateName': attributes?['dart_isolate_name'],
       'ownsSessionPersistence': runtimeInfo?['ownsSessionPersistence'] == true,
       'engineRole': runtimeInfo?['engineRole'],
+      'sessionDirectory': sessionDirectory,
       'telemetrySessionId': telemetrySession['id'],
       'telemetryPreviousSession': telemetryAttributes['previousSession'],
       'telemetryProcessName': telemetryAttributes['process_name'],
@@ -166,78 +198,95 @@ class _HarnessTransport extends FaroTransport {
         sessionIdResolver: () => Faro().meta.session?.id ?? '',
       );
 
-  final List<Map<String, dynamic>> _payloads = <Map<String, dynamic>>[];
+  final List<_RecordedPayload> _payloads = <_RecordedPayload>[];
 
   int get payloadCount => _payloads.length;
 
   @override
   Future<void> send(Map<String, dynamic> payloadJson) async {
-    _record(payloadJson);
+    _record(payloadJson, _DeliveryMethod.send);
   }
 
   @override
   Future<bool> sendHistoricalAcknowledged(
     Map<String, dynamic> payloadJson,
   ) async {
-    _record(payloadJson);
+    _record(payloadJson, _DeliveryMethod.historicalAcknowledged);
     return true;
   }
 
   Future<Map<String, dynamic>> waitForEvent(String name) {
     return _waitFor(
-      (payload) => _events(payload).any((event) => event['name'] == name),
+      (record) => _events(record.payload).any((event) => event['name'] == name),
       description: 'event $name',
-    );
+    ).then((record) => record.payload);
   }
 
   int eventCount(String name) {
     return _payloads
-        .expand(_events)
+        .expand((record) => _events(record.payload))
         .where((event) => event['name'] == name)
         .length;
   }
 
-  Future<Map<String, dynamic>> waitForCrash({required int after}) {
+  Future<_RecordedPayload> waitForCrash({required int after}) {
     return _waitFor(
-      (payload) {
-        final exceptions = payload['exceptions'];
+      (record) {
+        final exceptions = record.payload['exceptions'];
         return exceptions is List<dynamic> && exceptions.isNotEmpty;
       },
       startIndex: after,
       description: 'recovered crash',
+      timeout: const Duration(seconds: 15),
     );
   }
 
   int crashCount({required int after}) {
-    return _payloads.skip(after).where((payload) {
-      final exceptions = payload['exceptions'];
+    return _payloads.skip(after).where((record) {
+      final exceptions = record.payload['exceptions'];
       return exceptions is List<dynamic> && exceptions.isNotEmpty;
     }).length;
   }
 
-  void _record(Map<String, dynamic> payloadJson) {
+  void _record(
+    Map<String, dynamic> payloadJson,
+    _DeliveryMethod deliveryMethod,
+  ) {
     _payloads.add(
-      Map<String, dynamic>.from(
-        jsonDecode(jsonEncode(payloadJson)) as Map<dynamic, dynamic>,
+      _RecordedPayload(
+        Map<String, dynamic>.from(
+          jsonDecode(jsonEncode(payloadJson)) as Map<dynamic, dynamic>,
+        ),
+        deliveryMethod,
       ),
     );
   }
 
-  Future<Map<String, dynamic>> _waitFor(
-    bool Function(Map<String, dynamic>) predicate, {
+  Future<_RecordedPayload> _waitFor(
+    bool Function(_RecordedPayload) predicate, {
     int startIndex = 0,
     required String description,
+    Duration timeout = const Duration(seconds: 5),
   }) async {
-    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    final deadline = DateTime.now().add(timeout);
     while (DateTime.now().isBefore(deadline)) {
       for (var index = startIndex; index < _payloads.length; index++) {
-        final payload = _payloads[index];
-        if (predicate(payload)) {
-          return payload;
+        final record = _payloads[index];
+        if (predicate(record)) {
+          return record;
         }
       }
       await Future<void>.delayed(const Duration(milliseconds: 10));
     }
     throw TimeoutException('Timed out waiting for $description');
   }
+}
+
+enum _DeliveryMethod { send, historicalAcknowledged }
+
+class _RecordedPayload {
+  const _RecordedPayload(this.payload, this.deliveryMethod);
+
+  final Map<String, dynamic> payload;
+  final _DeliveryMethod deliveryMethod;
 }

--- a/example/lib/session_engine_harness.dart
+++ b/example/lib/session_engine_harness.dart
@@ -1,0 +1,243 @@
+// ignore_for_file: implementation_imports, invalid_use_of_visible_for_testing_member
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:faro/faro.dart';
+import 'package:faro/src/session/session_persistence.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+const _nativeChannel = MethodChannel('faro');
+const _reportChannel = MethodChannel('faro_example/session_engine_harness');
+
+Future<void> runSessionEngineHarness(List<String> args) async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final label = args.isEmpty ? 'unnamed' : args.first;
+  final transport = _HarnessTransport();
+
+  try {
+    await Faro().init(
+      optionsConfiguration: FaroConfig(
+        appName: 'session-engine-harness',
+        appVersion: '1.0.0',
+        appEnv: 'test',
+        apiKey: 'test-api-key',
+        collectorUrl: null,
+        transports: <FaroTransport>[transport],
+        batchConfig: BatchConfig(enabled: false),
+        enableFlutterErrorReporting: false,
+        enableCrashReporting: false,
+        memoryUsageVitals: false,
+        cpuUsageVitals: false,
+        anrTracking: false,
+        refreshRateVitals: false,
+        enableUiActivityMonitoring: false,
+        persistUser: false,
+        persistSession: true,
+      ),
+    );
+    Faro().enableDataCollection = true;
+
+    final runtimeInfo = await _nativeChannel.invokeMapMethod<String, dynamic>(
+      'getSessionRuntimeInfo',
+      {'claimSessionPersistence': false},
+    );
+    final session = Faro().meta.session;
+    final attributes = session?.attributes;
+
+    Faro().pushEvent(
+      'session_engine_probe',
+      attributes: <String, dynamic>{'engine_label': label},
+    );
+    final telemetryPayload = await transport.waitForEvent(
+      'session_engine_probe',
+    );
+    final telemetrySession = _map(_map(telemetryPayload['meta'])['session']);
+    final telemetryAttributes = _map(telemetrySession['attributes']);
+    final probeEvent = _events(
+      telemetryPayload,
+    ).firstWhere((event) => event['name'] == 'session_engine_probe');
+
+    _reportChannel.setMethodCallHandler((call) async {
+      if (call.method != 'reportRecoveredCrash') {
+        throw MissingPluginException('Unknown harness method ${call.method}');
+      }
+      final arguments = _map(call.arguments);
+      final records = (arguments['recoveredSessions'] as List<dynamic>)
+          .map((record) => PersistedSessionRecord.fromJson(_map(record)))
+          .toList();
+      final crashedSessionId = arguments['crashedSessionId'] as String;
+      final crashedSession = records.firstWhere(
+        (record) => record.currentSessionId == crashedSessionId,
+      );
+      final crashTimestamp = _crashTimestampWithin(crashedSession, records);
+      final payloadCount = transport.payloadCount;
+      final crashReport = jsonEncode(<String, dynamic>{
+        'reason': 'CRASH',
+        'status': 0,
+        'description': 'Secondary-engine attribution probe',
+        'timestamp': crashTimestamp,
+        'importance': 100,
+        'processName': arguments['processName'],
+      });
+
+      await Faro().reportAndroidCrashesForTesting(
+        <String>[crashReport],
+        recoveredSessions: records,
+        processIdentifier: arguments['processName'] as String,
+      );
+
+      final crashPayload = await transport.waitForCrash(after: payloadCount);
+      final crashSession = _map(_map(crashPayload['meta'])['session']);
+      final crashAttributes = _map(crashSession['attributes']);
+      final crashException = _map(
+        (crashPayload['exceptions'] as List<dynamic>).single,
+      );
+      final crashContext = _map(crashException['context']);
+
+      return <String, Object?>{
+        'payloadSessionId': crashSession['id'],
+        'payloadPreviousSession': crashAttributes['previousSession'],
+        'crashedSessionId': crashContext['crashedSessionId'],
+        'fatal': crashException['fatal'],
+        'liveSessionIdAfter': Faro().meta.session?.id,
+        'crashPayloadCount': transport.crashCount(after: payloadCount),
+      };
+    });
+
+    await _reportChannel.invokeMethod<void>('report', <String, Object?>{
+      'label': label,
+      'sessionId': session?.id,
+      'previousSession': attributes?['previousSession'],
+      'processName': attributes?['process_name'],
+      'isolateName': attributes?['dart_isolate_name'],
+      'ownsSessionPersistence': runtimeInfo?['ownsSessionPersistence'] == true,
+      'engineRole': runtimeInfo?['engineRole'],
+      'telemetrySessionId': telemetrySession['id'],
+      'telemetryPreviousSession': telemetryAttributes['previousSession'],
+      'telemetryProcessName': telemetryAttributes['process_name'],
+      'telemetryIsolateName': telemetryAttributes['dart_isolate_name'],
+      'telemetryProbeLabel': _map(probeEvent['attributes'])['engine_label'],
+      'telemetryProbeCount': transport.eventCount('session_engine_probe'),
+    });
+  } catch (error, stackTrace) {
+    await _reportChannel.invokeMethod<void>('report', <String, Object?>{
+      'label': label,
+      'error': error.toString(),
+      'stackTrace': stackTrace.toString(),
+    });
+  }
+}
+
+Map<String, dynamic> _map(Object? value) {
+  return Map<String, dynamic>.from(value! as Map<dynamic, dynamic>);
+}
+
+List<Map<String, dynamic>> _events(Map<String, dynamic> payload) {
+  return (payload['events'] as List<dynamic>? ?? const <dynamic>[])
+      .map((event) => _map(event))
+      .toList();
+}
+
+int _crashTimestampWithin(
+  PersistedSessionRecord crashedSession,
+  List<PersistedSessionRecord> records,
+) {
+  final timestamp = crashedSession.startedAt.millisecondsSinceEpoch + 1;
+  final crashTime = DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true);
+  final laterStarts =
+      records
+          .map((record) => record.startedAt)
+          .where((startedAt) => startedAt.isAfter(crashedSession.startedAt))
+          .toList()
+        ..sort();
+  if (laterStarts.isNotEmpty && !crashTime.isBefore(laterStarts.first)) {
+    throw StateError('No millisecond inside the crashed session interval');
+  }
+  return timestamp;
+}
+
+class _HarnessTransport extends FaroTransport {
+  _HarnessTransport()
+    : super(
+        collectorUrl: 'https://example.invalid',
+        apiKey: 'test-api-key',
+        sessionIdResolver: () => Faro().meta.session?.id ?? '',
+      );
+
+  final List<Map<String, dynamic>> _payloads = <Map<String, dynamic>>[];
+
+  int get payloadCount => _payloads.length;
+
+  @override
+  Future<void> send(Map<String, dynamic> payloadJson) async {
+    _record(payloadJson);
+  }
+
+  @override
+  Future<bool> sendHistoricalAcknowledged(
+    Map<String, dynamic> payloadJson,
+  ) async {
+    _record(payloadJson);
+    return true;
+  }
+
+  Future<Map<String, dynamic>> waitForEvent(String name) {
+    return _waitFor(
+      (payload) => _events(payload).any((event) => event['name'] == name),
+      description: 'event $name',
+    );
+  }
+
+  int eventCount(String name) {
+    return _payloads
+        .expand(_events)
+        .where((event) => event['name'] == name)
+        .length;
+  }
+
+  Future<Map<String, dynamic>> waitForCrash({required int after}) {
+    return _waitFor(
+      (payload) {
+        final exceptions = payload['exceptions'];
+        return exceptions is List<dynamic> && exceptions.isNotEmpty;
+      },
+      startIndex: after,
+      description: 'recovered crash',
+    );
+  }
+
+  int crashCount({required int after}) {
+    return _payloads.skip(after).where((payload) {
+      final exceptions = payload['exceptions'];
+      return exceptions is List<dynamic> && exceptions.isNotEmpty;
+    }).length;
+  }
+
+  void _record(Map<String, dynamic> payloadJson) {
+    _payloads.add(
+      Map<String, dynamic>.from(
+        jsonDecode(jsonEncode(payloadJson)) as Map<dynamic, dynamic>,
+      ),
+    );
+  }
+
+  Future<Map<String, dynamic>> _waitFor(
+    bool Function(Map<String, dynamic>) predicate, {
+    int startIndex = 0,
+    required String description,
+  }) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (DateTime.now().isBefore(deadline)) {
+      for (var index = startIndex; index < _payloads.length; index++) {
+        final payload = _payloads[index];
+        if (predicate(payload)) {
+          return payload;
+        }
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    throw TimeoutException('Timed out waiting for $description');
+  }
+}

--- a/example/lib/session_engine_harness.dart
+++ b/example/lib/session_engine_harness.dart
@@ -129,6 +129,9 @@ Future<void> runSessionEngineHarness(List<String> args) async {
         'recoveryAttempted': true,
         'deliveryMethod': crashPayload.deliveryMethod.name,
         'payloadSessionId': crashSession['id'],
+        'payloadPreviousSessionPresent': crashAttributes.containsKey(
+          'previousSession',
+        ),
         'payloadPreviousSession': crashAttributes['previousSession'],
         'crashedSessionId': crashContext['crashedSessionId'],
         'fatal': crashException['fatal'],
@@ -140,6 +143,8 @@ Future<void> runSessionEngineHarness(List<String> args) async {
     await _reportChannel.invokeMethod<void>('report', <String, Object?>{
       'label': label,
       'sessionId': session?.id,
+      'previousSessionPresent':
+          attributes?.containsKey('previousSession') ?? false,
       'previousSession': attributes?['previousSession'],
       'processName': attributes?['process_name'],
       'isolateName': attributes?['dart_isolate_name'],

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -504,7 +504,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   faro:
     path: ../
   http: ^1.2.2
+  path_provider: ^2.1.5
   shared_preferences: ^2.3.4
 
   # State management

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -1161,9 +1161,15 @@ class Faro {
     }
   }
 
-  bool get _shouldAttemptCrashRecovery =>
-      _ownsSessionPersistence == true ||
-      (_ownsSessionPersistence == null && RootIsolateToken.instance != null);
+  bool get _shouldAttemptCrashRecovery {
+    if (_isAndroidPlatform()) {
+      // An unresolved runtime must not consume a historical exit before the
+      // process-scoped session owner can attribute it correctly.
+      return _ownsSessionPersistence == true;
+    }
+    return _ownsSessionPersistence == true ||
+        (_ownsSessionPersistence == null && RootIsolateToken.instance != null);
+  }
 
   Future<void> _reportAndPurgeIOSCrashReports(
     List<String> crashReports, {

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -1109,19 +1109,15 @@ class Faro {
     try {
       if (_isIOSPlatform()) {
         await _nativeChannel?.enableCrashReporter(const <String, dynamic>{});
-        final shouldAttemptRecovery =
-            _ownsSessionPersistence == true ||
-            (_ownsSessionPersistence == null &&
-                RootIsolateToken.instance != null);
         if (!collectionEnabledAtStart || !enableDataCollection) {
-          if (shouldAttemptRecovery) {
+          if (_shouldAttemptCrashRecovery) {
             // Do not upload a pending crash while collection is disabled.
             await _nativeChannel?.purgeCrashReport();
           }
           return;
         }
 
-        if (shouldAttemptRecovery) {
+        if (_shouldAttemptCrashRecovery) {
           final crashReports = await _nativeChannel?.getCrashReport();
           if (crashReports != null && crashReports.isNotEmpty) {
             final recoveredSessions = _sessionPersistence != null
@@ -1137,7 +1133,7 @@ class Faro {
           }
         }
       }
-      if (_isAndroidPlatform()) {
+      if (_isAndroidPlatform() && _shouldAttemptCrashRecovery) {
         final crashReports = await _nativeChannel?.getCrashReport();
         if (crashReports != null) {
           final recoveredSessions = _sessionPersistence != null
@@ -1164,6 +1160,10 @@ class Faro {
       );
     }
   }
+
+  bool get _shouldAttemptCrashRecovery =>
+      _ownsSessionPersistence == true ||
+      (_ownsSessionPersistence == null && RootIsolateToken.instance != null);
 
   Future<void> _reportAndPurgeIOSCrashReports(
     List<String> crashReports, {
@@ -1218,6 +1218,25 @@ class Faro {
               : <PersistedSessionRecord>[recoveredSession]),
       processIdentifier: processIdentifier,
     );
+  }
+
+  @visibleForTesting
+  Future<bool> attemptAndroidCrashRecoveryForTesting(
+    List<String> crashReports, {
+    PersistedSessionRecord? recoveredSession,
+    List<PersistedSessionRecord>? recoveredSessions,
+    String? processIdentifier,
+  }) async {
+    if (!_shouldAttemptCrashRecovery) {
+      return false;
+    }
+    await reportAndroidCrashesForTesting(
+      crashReports,
+      recoveredSession: recoveredSession,
+      recoveredSessions: recoveredSessions,
+      processIdentifier: processIdentifier,
+    );
+    return true;
   }
 
   Meta _metaForRecoveredSession(PersistedSessionRecord recoveredSession) {

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -479,6 +479,37 @@ void main() {
         verifyNever(() => mockFaroNativeMethods.purgeCrashReport());
       });
 
+      test('Android non-owner does not consume the pending crash', () async {
+        stubRuntimeInfo(ownsPersistence: false);
+        Faro().iosPlatformResolver = () => false;
+        Faro().androidPlatformResolver = () => true;
+
+        await Faro().init(
+          optionsConfiguration: createConfig(enableCrashReporting: true),
+        );
+
+        verifyNever(() => mockFaroNativeMethods.getCrashReport());
+      });
+
+      test(
+        'Android recovery falls back when runtime info is unavailable',
+        () async {
+          when(
+            () => mockFaroNativeMethods.getSessionRuntimeInfo(
+              claimSessionPersistence: true,
+            ),
+          ).thenAnswer((_) async => null);
+          Faro().iosPlatformResolver = () => false;
+          Faro().androidPlatformResolver = () => true;
+
+          await Faro().init(
+            optionsConfiguration: createConfig(enableCrashReporting: true),
+          );
+
+          verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
+        },
+      );
+
       test(
         'iOS recovery falls back when runtime info is unavailable',
         () async {

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -491,24 +491,21 @@ void main() {
         verifyNever(() => mockFaroNativeMethods.getCrashReport());
       });
 
-      test(
-        'Android recovery falls back when runtime info is unavailable',
-        () async {
-          when(
-            () => mockFaroNativeMethods.getSessionRuntimeInfo(
-              claimSessionPersistence: true,
-            ),
-          ).thenAnswer((_) async => null);
-          Faro().iosPlatformResolver = () => false;
-          Faro().androidPlatformResolver = () => true;
+      test('Android recovery stops when runtime info is unavailable', () async {
+        when(
+          () => mockFaroNativeMethods.getSessionRuntimeInfo(
+            claimSessionPersistence: true,
+          ),
+        ).thenAnswer((_) async => null);
+        Faro().iosPlatformResolver = () => false;
+        Faro().androidPlatformResolver = () => true;
 
-          await Faro().init(
-            optionsConfiguration: createConfig(enableCrashReporting: true),
-          );
+        await Faro().init(
+          optionsConfiguration: createConfig(enableCrashReporting: true),
+        );
 
-          verify(() => mockFaroNativeMethods.getCrashReport()).called(1);
-        },
-      );
+        verifyNever(() => mockFaroNativeMethods.getCrashReport());
+      });
 
       test(
         'iOS recovery falls back when runtime info is unavailable',


### PR DESCRIPTION
## Description

Makes recovered Android crashes follow the same process-scoped owner as durable session persistence. A root Flutter engine that does not own persistence now skips historical crash recovery instead of consuming a crash with an unrelated live session. If ownership is unavailable, recovery is left for a later launch.

Adds a retained Android device harness that runs Activity-backed and headless engines in both startup orders. It verifies first-come ownership, non-owner isolation, ownership handoff, runtime metadata, durable session-chain integrity, and recovered-crash attribution.

## Related Issue(s)

Related to #340

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation
- [x] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Screenshots (if applicable)

Not applicable; there is no UI change.


## Additional Notes

Crash recovery delivery remains asynchronous, so the owning engine must stay alive until its configured transport accepts the payload. The documentation covers this requirement and the fail-closed behavior when runtime ownership cannot be established.

After merge, the retained device test will be rerun from `main` before #340 is closed.
