### PR TITLE
feat(webview): propagate an app-owned span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   takes precedence over the active span. Span context is captured at push
   time, so buffered signals keep the span that was active when they were
   recorded.
+- **App-owned spans in `FaroWebViewBridge`.** `instrumentedUrl` accepts an
+  optional `span` and propagates that span's `traceparent` instead of
+  creating a span of its own, so repeated calls during one WebView session
+  keep injecting the same `traceparent`. The bridge leaves a span you pass
+  in untouched — no attributes, no status, and `end()` will not end it. See
+  the Reference docs for details.
 - **`FaroStartupProvider`**, a content provider merged into your Android
   manifest automatically. It samples process importance at startup so the SDK
   can tell a user-initiated launch from a background one; it stores no data and

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -1117,9 +1117,9 @@ When your Flutter app opens a web page in a WebView, `FaroWebViewBridge` propaga
 
 ### How It Works
 
-1. **Flutter → Web**: `instrumentedUrl()` starts a span and appends `traceparent`, `session.parent_id`, and `session.parent_app` as query parameters. The web app reads these to continue the trace and identify the originating mobile session.
+1. **Flutter → Web**: `instrumentedUrl()` appends `traceparent`, `session.parent_id`, and `session.parent_app` as query parameters. The web app reads these to continue the trace and identify the originating mobile session. By default the bridge starts a span of its own to propagate; pass `span:` to propagate a span your app already holds instead.
 2. **Web → Flutter**: The web app sends its Faro session ID back (e.g. via a JavaScript channel). You call `linkChildSession()` to push a `session.linked` event that correlates the two sessions.
-3. **Span lifecycle**: Call `end()` when the WebView is dismissed so the span duration reflects how long the user spent in the WebView.
+3. **Span lifecycle**: Call `end()` when the WebView is dismissed so the span duration reflects how long the user spent in the WebView. If you passed your own span, end it yourself — the bridge never ends a span it did not create.
 
 ### Basic Usage
 
@@ -1187,9 +1187,31 @@ class _MyWebViewPageState extends State<MyWebViewPage> {
 }
 ```
 
+### Propagating a Span Your App Owns
+
+The default flow works well when the WebView is opened once and the bridge span matches the WebView lifetime. If your app already tracks the WebView with its own span — for example one that also covers setup work before the load, or a WebView that reloads several URLs — pass that span to `instrumentedUrl()` and it becomes the propagated trace context:
+
+```dart
+final webViewSpan = Faro().startSpanManual('webview.lifecycle');
+final bridge = FaroWebViewBridge();
+
+// Every call injects the same traceparent, so the whole WebView session
+// stays in one trace.
+controller.loadRequest(bridge.instrumentedUrl(loginUrl, span: webViewSpan));
+controller.loadRequest(bridge.instrumentedUrl(profileUrl, span: webViewSpan));
+
+// You own the span, so you end it — bridge.end() will not.
+webViewSpan.setStatus(SpanStatusCode.ok);
+webViewSpan.end();
+```
+
+The bridge reads only the `traceparent` from your span. It sets no attributes, no status, and never ends it, so nothing the bridge does can truncate a span that has to outlive a single load. Add the request context you want yourself, for example `span.addEvent('webview.url_loaded', attributes: {'url.full': url.toString()})`.
+
+Ownership is what decides lifecycle: `end()` and the superseding behaviour of repeated `instrumentedUrl()` calls apply only to spans the bridge created.
+
 ### API Reference
 
-#### `instrumentedUrl(Uri url, {String spanName = 'WebView'})`
+#### `instrumentedUrl(Uri url, {String spanName = 'WebView', Span? span})`
 
 Returns a new `Uri` with three query parameters appended:
 
@@ -1199,7 +1221,9 @@ Returns a new `Uri` with three query parameters appended:
 | `session.parent_id` | The current Flutter Faro session ID            |
 | `session.parent_app`| The Flutter app name from Faro config          |
 
-Starts a manual span named `spanName` (default `'WebView'`). If called while a previous span is still active, the previous span is ended with an error status.
+Without `span`, starts a manual span named `spanName` (default `'WebView'`) and propagates it. If called while a previous bridge-created span is still active, that span is ended with an error status.
+
+With `span`, propagates that span's `traceparent` and leaves the span untouched — `spanName` is ignored, and ending the span is up to you.
 
 #### `linkChildSession({required String sessionId, String? appName})`
 
@@ -1214,7 +1238,7 @@ The parent session info is automatically included via Faro's session context on 
 
 #### `end({SpanStatusCode status = SpanStatusCode.ok, String? message})`
 
-Ends the active WebView span. Safe to call multiple times or without a prior `instrumentedUrl()` call.
+Ends the WebView span the bridge created. Safe to call multiple times or without a prior `instrumentedUrl()` call. Does nothing when `instrumentedUrl()` was given a `span` — that span belongs to your app.
 
 ### Web-Side Setup
 

--- a/example/README.md
+++ b/example/README.md
@@ -148,6 +148,8 @@ The example app showcases various Faro SDK features:
 
 - Open a React app in a WebView using `FaroWebViewBridge` which appends
   `traceparent`, `session.parent_id`, and `session.parent_app` query params
+- Two span ownership models: the bridge's own `WebView` span, or a span
+  the app owns and passes in to keep the `traceparent` stable across reloads
 - The web app continues the native trace when making HTTP requests
 - The web app reports its own Faro session ID back to Flutter, which
   calls `bridge.linkChildSession()` to push a `session.linked` event
@@ -251,6 +253,22 @@ completing the bidirectional link.
    `http://localhost:5173` for the iOS simulator.
 
 3. Run the Flutter example app as usual.
+
+### Comparing span ownership
+
+The feature page offers two entry points:
+
+- **Open React demo in WebView** — the bridge starts and ends its own
+  `WebView` span. Reloading from the WebView page supersedes that span and
+  produces a new `traceparent`, so each load is its own trace.
+- **Open with an app-owned span** — the page starts a
+  `webview.lifecycle` span, passes it via `instrumentedUrl(url, span: ...)`,
+  and ends it in `dispose()`. Reloading keeps the same `traceparent`, so
+  every load stays in one trace.
+
+The WebView page shows the propagated trace ID and has a reload button, so
+you can watch the trace ID change in the first mode and stay put in the
+second.
 
 ### What to inspect
 

--- a/example/lib/features/webview_handoff/presentation/webview_handoff_page.dart
+++ b/example/lib/features/webview_handoff/presentation/webview_handoff_page.dart
@@ -33,6 +33,14 @@ class WebViewHandoffPage extends ConsumerWidget {
             icon: const Icon(Icons.open_in_new),
             label: const Text('Open React demo in WebView'),
           ),
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            onPressed: uiState.isConfigured
+                ? () => _openWebView(context, actions, useAppOwnedSpan: true)
+                : null,
+            icon: const Icon(Icons.open_in_new),
+            label: const Text('Open with an app-owned span'),
+          ),
         ],
       ),
     );
@@ -40,12 +48,16 @@ class WebViewHandoffPage extends ConsumerWidget {
 
   Future<void> _openWebView(
     BuildContext context,
-    WebViewHandoffPageActions actions,
-  ) async {
+    WebViewHandoffPageActions actions, {
+    bool useAppOwnedSpan = false,
+  }) async {
     final url = actions.getBaseUrl();
     final result = await Navigator.of(context).push<Map<String, dynamic>>(
       MaterialPageRoute<Map<String, dynamic>>(
-        builder: (_) => WebViewHandoffWebViewPage(url: url),
+        builder: (_) => WebViewHandoffWebViewPage(
+          url: url,
+          useAppOwnedSpan: useAppOwnedSpan,
+        ),
       ),
     );
 
@@ -89,6 +101,13 @@ class _OverviewCard extends StatelessWidget {
               'traceparent so the web app can continue the native trace. '
               'Use Grafana Tempo to verify the Flutter and React spans '
               'share the same trace ID.',
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'The second option hands the bridge a span this app owns, so '
+              'reloading the WebView keeps the same traceparent instead of '
+              'starting a new trace. Reload from the WebView page to compare '
+              'the two.',
             ),
           ],
         ),

--- a/example/lib/features/webview_handoff/presentation/webview_handoff_webview_page.dart
+++ b/example/lib/features/webview_handoff/presentation/webview_handoff_webview_page.dart
@@ -6,10 +6,16 @@ import 'package:webview_flutter/webview_flutter.dart';
 
 /// Hosts the React demo inside a WebView.
 ///
-/// Uses [FaroWebViewBridge] to create a `WebView` span and inject
-/// `traceparent` and `session.parent_*` query parameters into the URL
-/// so the web app can continue the Flutter trace and identify its
-/// originating session.
+/// Uses [FaroWebViewBridge] to inject `traceparent` and `session.parent_*`
+/// query parameters into the URL so the web app can continue the Flutter
+/// trace and identify its originating session.
+///
+/// Demonstrates both span ownership models. With [useAppOwnedSpan] off,
+/// the bridge starts and ends its own `WebView` span, and each reload
+/// supersedes it with a new span and a new `traceparent`. With it on, this
+/// page starts a span covering the whole WebView lifecycle and passes it
+/// to `instrumentedUrl`, so reloads keep propagating the same
+/// `traceparent` and ending the span is up to this page.
 ///
 /// A `HandoffBridge` JavaScript channel is registered so the React app
 /// can send messages back. Supported message types:
@@ -17,9 +23,16 @@ import 'package:webview_flutter/webview_flutter.dart';
 ///   `session.linked` event with `session.child_*` attributes.
 /// - `login_result` — login result data; auto-pops the page.
 class WebViewHandoffWebViewPage extends StatefulWidget {
-  const WebViewHandoffWebViewPage({required this.url, super.key});
+  const WebViewHandoffWebViewPage({
+    required this.url,
+    this.useAppOwnedSpan = false,
+    super.key,
+  });
 
   final Uri url;
+
+  /// Whether this page owns the span whose trace context is propagated.
+  final bool useAppOwnedSpan;
 
   @override
   State<WebViewHandoffWebViewPage> createState() =>
@@ -29,6 +42,8 @@ class WebViewHandoffWebViewPage extends StatefulWidget {
 class _WebViewHandoffWebViewPageState extends State<WebViewHandoffWebViewPage> {
   late final WebViewController _controller;
   late final FaroWebViewBridge _bridge;
+  Span? _appSpan;
+  String _traceparent = '';
   String _status = 'Opening WebView\u2026';
   bool _hasLoadError = false;
 
@@ -36,10 +51,16 @@ class _WebViewHandoffWebViewPageState extends State<WebViewHandoffWebViewPage> {
   void initState() {
     super.initState();
 
-    // Starts a WebView span and appends traceparent + session correlation
-    // query params so the web app can continue the trace and link sessions.
     _bridge = FaroWebViewBridge();
-    final instrumentedUrl = _bridge.instrumentedUrl(widget.url);
+
+    if (widget.useAppOwnedSpan) {
+      // This span lives for as long as the WebView does, which keeps the
+      // propagated traceparent stable across reloads.
+      _appSpan = Faro().startSpanManual(
+        'webview.lifecycle',
+        attributes: {'component': 'webview', 'url.full': widget.url.toString()},
+      );
+    }
 
     _controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
@@ -71,17 +92,47 @@ class _WebViewHandoffWebViewPageState extends State<WebViewHandoffWebViewPage> {
             });
           },
         ),
-      )
-      ..loadRequest(instrumentedUrl);
+      );
+
+    _loadInstrumentedUrl();
   }
 
   @override
   void dispose() {
-    // End the WebView span started by instrumentedUrl(). Always call
-    // bridge.end() when the WebView is dismissed so the span duration
-    // accurately reflects the time the user spent in the WebView.
-    _bridge.end();
+    // Always close out the WebView span when the WebView is dismissed, so
+    // its duration reflects the time the user spent in the WebView. The
+    // bridge only ends spans it created itself, so an app-owned span has
+    // to be ended here.
+    final appSpan = _appSpan;
+    if (appSpan != null) {
+      appSpan.setStatus(SpanStatusCode.ok);
+      appSpan.end();
+    } else {
+      _bridge.end();
+    }
     super.dispose();
+  }
+
+  /// Decorates the URL with the trace and session parameters and loads it.
+  ///
+  /// Passing a null [Span] is the default behaviour: the bridge starts and
+  /// owns a span of its own.
+  void _loadInstrumentedUrl() {
+    final instrumentedUrl = _bridge.instrumentedUrl(widget.url, span: _appSpan);
+    _traceparent = instrumentedUrl.queryParameters['traceparent'] ?? '';
+    _controller.loadRequest(instrumentedUrl);
+  }
+
+  void _reload() {
+    _loadInstrumentedUrl();
+    setState(() => _status = 'Reloading\u2026');
+  }
+
+  /// Extracts the trace ID from a `traceparent`, so it can be pasted into
+  /// Tempo to compare traces across reloads.
+  String _traceIdOf(String traceparent) {
+    final parts = traceparent.split('-');
+    return parts.length >= 2 ? parts[1] : 'n/a';
   }
 
   void _handleBridgeMessage(JavaScriptMessage message) {
@@ -111,8 +162,18 @@ class _WebViewHandoffWebViewPageState extends State<WebViewHandoffWebViewPage> {
             color: Colors.indigo.shade50,
             child: ListTile(
               leading: const Icon(Icons.link),
-              title: const Text('React demo app'),
-              subtitle: Text(_status),
+              isThreeLine: true,
+              title: Text(
+                widget.useAppOwnedSpan
+                    ? 'React demo \u2014 app-owned span'
+                    : 'React demo \u2014 SDK-owned span',
+              ),
+              subtitle: Text('$_status\ntrace: ${_traceIdOf(_traceparent)}'),
+              trailing: IconButton(
+                icon: const Icon(Icons.refresh),
+                tooltip: 'Reload with a freshly instrumented URL',
+                onPressed: _reload,
+              ),
             ),
           ),
           Expanded(

--- a/lib/src/webview/faro_webview_bridge.dart
+++ b/lib/src/webview/faro_webview_bridge.dart
@@ -26,39 +26,48 @@ import 'package:faro/src/tracing/span.dart';
 /// // When the WebView is dismissed:
 /// bridge.end();
 /// ```
+///
+/// If your app already tracks the WebView with its own span, pass it to
+/// [instrumentedUrl] to propagate that span's trace context instead. The
+/// injected `traceparent` then stays the same for every call, and your
+/// app keeps full control over the span.
+///
+/// ```dart
+/// final webViewSpan = Faro().startSpanManual('webview');
+/// final bridge = FaroWebViewBridge();
+/// controller.loadRequest(bridge.instrumentedUrl(myUrl, span: webViewSpan));
+///
+/// // Your span, your responsibility — bridge.end() will not end it.
+/// webViewSpan.end();
+/// ```
 class FaroWebViewBridge {
-  Span? _activeSpan;
+  Span? _ownedSpan;
 
   /// Returns a new [Uri] with `traceparent`, `session.parent_id`, and
-  /// `session.parent_app` query parameters appended, and starts a span
-  /// that tracks the WebView lifetime.
+  /// `session.parent_app` query parameters appended.
   ///
-  /// The [spanName] defaults to `'WebView'` but can be customized for
-  /// different use cases.
+  /// By default the bridge starts a span that tracks the WebView lifetime
+  /// and propagates that span's trace context. The [spanName] defaults to
+  /// `'WebView'` but can be customized for different use cases. If called
+  /// while a previous bridge-created span is still active, that span is
+  /// ended with [SpanStatusCode.error].
   ///
-  /// If called while a previous span is still active, the previous span
-  /// is ended with [SpanStatusCode.error].
-  Uri instrumentedUrl(Uri url, {String spanName = 'WebView'}) {
-    _endActiveSpan(SpanStatusCode.error, message: 'Superseded by new load');
+  /// Pass [span] to propagate the trace context of a span your app
+  /// already holds, such as one covering the whole WebView lifecycle. The
+  /// bridge reads its `traceparent` and otherwise leaves it untouched: no
+  /// attributes, no status, and no [end] call, so repeated calls keep
+  /// injecting the same `traceparent`. Ending it stays your app's
+  /// responsibility, and [spanName] is ignored.
+  Uri instrumentedUrl(Uri url, {String spanName = 'WebView', Span? span}) {
+    _endOwnedSpan(SpanStatusCode.error, message: 'Superseded by new load');
 
+    final propagatedSpan = span ?? _startOwnedSpan(url, spanName);
     final faro = Faro();
-    final span = faro.startSpanManual(
-      spanName,
-      attributes: {
-        'http.request.method': 'GET',
-        'url.full': url.toString(),
-        'server.address': url.host,
-        'server.port': url.hasPort ? url.port : _defaultPort(url.scheme),
-        'url.scheme': url.scheme,
-        'component': 'webview',
-      },
-    );
-    _activeSpan = span;
 
     return url.replace(
       queryParameters: {
         ...url.queryParametersAll,
-        'traceparent': span.traceparent,
+        'traceparent': propagatedSpan.traceparent,
         'session.parent_id': faro.meta.session?.id ?? '',
         'session.parent_app': faro.meta.app?.name ?? '',
       },
@@ -84,18 +93,37 @@ class FaroWebViewBridge {
     );
   }
 
-  /// Ends the active span. Call this when the WebView is disposed or
-  /// popped from the navigation stack.
+  /// Ends the span the bridge started. Call this when the WebView is
+  /// disposed or popped from the navigation stack.
+  ///
+  /// Does nothing when [instrumentedUrl] was given a span: that span
+  /// belongs to your app, which is responsible for ending it.
   void end({SpanStatusCode status = SpanStatusCode.ok, String? message}) {
-    _endActiveSpan(status, message: message);
+    _endOwnedSpan(status, message: message);
   }
 
-  void _endActiveSpan(SpanStatusCode status, {String? message}) {
-    final span = _activeSpan;
+  Span _startOwnedSpan(Uri url, String spanName) {
+    final span = Faro().startSpanManual(
+      spanName,
+      attributes: {
+        'http.request.method': 'GET',
+        'url.full': url.toString(),
+        'server.address': url.host,
+        'server.port': url.hasPort ? url.port : _defaultPort(url.scheme),
+        'url.scheme': url.scheme,
+        'component': 'webview',
+      },
+    );
+    _ownedSpan = span;
+    return span;
+  }
+
+  void _endOwnedSpan(SpanStatusCode status, {String? message}) {
+    final span = _ownedSpan;
     if (span == null || span.wasEnded) return;
     span.setStatus(status, message: message);
     span.end();
-    _activeSpan = null;
+    _ownedSpan = null;
   }
 
   static int _defaultPort(String scheme) => scheme == 'https' ? 443 : 80;

--- a/test/src/webview/faro_webview_bridge_test.dart
+++ b/test/src/webview/faro_webview_bridge_test.dart
@@ -8,6 +8,55 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class MockBaseTransport extends Mock implements BaseTransport {}
 
+/// Wraps a real span and records every mutating call, so tests can assert
+/// that the bridge leaves an app-owned span alone.
+class RecordingSpan implements Span {
+  RecordingSpan(this._delegate);
+
+  final Span _delegate;
+  final List<String> mutations = [];
+
+  @override
+  String get traceparent => _delegate.traceparent;
+
+  @override
+  String get traceId => _delegate.traceId;
+
+  @override
+  String get spanId => _delegate.spanId;
+
+  @override
+  bool get wasEnded => mutations.contains('end');
+
+  @override
+  SpanStatusCode get status => SpanStatusCode.unset;
+
+  @override
+  bool get statusHasBeenSet => mutations.contains('setStatus');
+
+  @override
+  void setStatus(SpanStatusCode statusCode, {String? message}) =>
+      mutations.add('setStatus');
+
+  @override
+  void addEvent(String message, {Map<String, Object> attributes = const {}}) =>
+      mutations.add('addEvent');
+
+  @override
+  void setAttributes(Map<String, Object> attributes) =>
+      mutations.add('setAttributes');
+
+  @override
+  void setAttribute(String key, Object value) => mutations.add('setAttribute');
+
+  @override
+  void recordException(dynamic exception, {StackTrace? stackTrace}) =>
+      mutations.add('recordException');
+
+  @override
+  void end() => mutations.add('end');
+}
+
 void main() {
   const testUrl = 'https://example.com/login?existing=param';
 
@@ -160,6 +209,109 @@ void main() {
         final result = bridge.instrumentedUrl(url, spanName: 'CustomWebView');
 
         expect(result.queryParameters.containsKey('traceparent'), isTrue);
+      });
+    });
+
+    group('instrumentedUrl with an app-owned span:', () {
+      test('should propagate the traceparent of the provided span', () {
+        final bridge = FaroWebViewBridge();
+        final appSpan = faro.startSpanManual('webview');
+
+        final result = bridge.instrumentedUrl(
+          Uri.parse(testUrl),
+          span: appSpan,
+        );
+
+        expect(
+          result.queryParameters['traceparent'],
+          equals(appSpan.traceparent),
+        );
+
+        appSpan.end();
+      });
+
+      test('should keep the traceparent stable across repeated calls', () {
+        final bridge = FaroWebViewBridge();
+        final appSpan = faro.startSpanManual('webview');
+
+        final first = bridge.instrumentedUrl(Uri.parse(testUrl), span: appSpan);
+        final second = bridge.instrumentedUrl(
+          Uri.parse('https://example.com/profile'),
+          span: appSpan,
+        );
+
+        expect(
+          first.queryParameters['traceparent'],
+          equals(second.queryParameters['traceparent']),
+        );
+
+        appSpan.end();
+      });
+
+      test('should not modify the provided span', () {
+        final bridge = FaroWebViewBridge();
+        final appSpan = RecordingSpan(faro.startSpanManual('webview'));
+
+        bridge.instrumentedUrl(Uri.parse(testUrl), span: appSpan);
+
+        expect(appSpan.mutations, isEmpty);
+      });
+
+      test('should still append the session correlation parameters', () {
+        final bridge = FaroWebViewBridge();
+        final appSpan = faro.startSpanManual('webview');
+
+        final result = bridge.instrumentedUrl(
+          Uri.parse(testUrl),
+          span: appSpan,
+        );
+
+        expect(
+          result.queryParameters['session.parent_id'],
+          equals(faro.meta.session?.id),
+        );
+        expect(
+          result.queryParameters['session.parent_app'],
+          equals('TestFlutterApp'),
+        );
+
+        appSpan.end();
+      });
+
+      test('should not end the provided span on end()', () {
+        final bridge = FaroWebViewBridge();
+        final appSpan = RecordingSpan(faro.startSpanManual('webview'));
+
+        bridge.instrumentedUrl(Uri.parse(testUrl), span: appSpan);
+        bridge.end();
+
+        expect(appSpan.wasEnded, isFalse);
+        expect(appSpan.mutations, isEmpty);
+      });
+
+      test('should not end the provided span on a later call', () {
+        final bridge = FaroWebViewBridge();
+        final appSpan = RecordingSpan(faro.startSpanManual('webview'));
+
+        bridge.instrumentedUrl(Uri.parse(testUrl), span: appSpan);
+        bridge.instrumentedUrl(Uri.parse(testUrl), span: appSpan);
+        bridge.instrumentedUrl(Uri.parse(testUrl));
+
+        expect(appSpan.wasEnded, isFalse);
+        expect(appSpan.mutations, isEmpty);
+      });
+
+      test('should not end the provided span when it supersedes a '
+          'bridge-created span', () {
+        final bridge = FaroWebViewBridge();
+        final appSpan = RecordingSpan(faro.startSpanManual('webview'));
+
+        bridge.instrumentedUrl(Uri.parse(testUrl));
+        bridge.instrumentedUrl(Uri.parse(testUrl), span: appSpan);
+        bridge.end();
+
+        expect(appSpan.wasEnded, isFalse);
+        expect(appSpan.mutations, isEmpty);
       });
     });
 


### PR DESCRIPTION
## Description

`FaroWebViewBridge.instrumentedUrl` always started its own span, so the
`traceparent` it injected into the WebView URL could never match a span the
app already used to track that WebView. Passing the same `spanName` did not
connect them, the app's span and the web app's telemetry landed in two
unrelated traces. And because every call started a fresh span, the
`traceparent` changed on each call, which breaks WebViews that load more than
one URL during their lifetime.

`instrumentedUrl` now accepts an optional `span` and propagates that span's
trace context. Span lifecycle follows ownership: the bridge only ends spans it
created. A span you pass in is never given attributes or a status and is never
ended, so repeated calls keep injecting the same `traceparent`, and nothing the
bridge does can truncate a span that has to outlive a single load. The default
path is unchanged.

## Related Issue(s)

None.

## Type of Change

- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] 📈 Performance improvement
- [ ] 🏗️ Code refactoring
- [ ] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Validation

`dart tool/pre_release_check.dart`: all 6 checks pass.

Verified end to end by running the example app on an iOS simulator through both
WebView entry points, then inspecting the emitted telemetry in Mobile o11y with
gcx. The app-owned span keeps a single trace across three `instrumentedUrl`
calls, with the React app's request parented to it, while the default path
still creates a span per load. Session correlation (`session.linked` and the
`session.parent_*` attributes on the web session) is unchanged.
