### PR TITLE
chore: bump version to v0.17.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0-beta.3] - 2026-08-27
+
 ### Added
 
 - Add `Faro.resetSession()` for logout, account changes, and custom session

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana.faro'
-version '0.17.0-beta.2'
+version '0.17.0-beta.3'
 
 buildscript {
     repositories {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -199,7 +199,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.17.0-beta.2"
+    version: "0.17.0-beta.3"
   ffi:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -133,18 +133,18 @@ packages:
     dependency: transitive
     description:
       name: dartastic_opentelemetry
-      sha256: ce60d797f5ad11bad0050b10e560e78c60aa3f67b53d1cfe0a9923a082ad4526
+      sha256: "4f3c36df67269bc169ba99bae33363d4e9e062eba8fc0e3c693648e8ad13e667"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0-beta.5"
+    version: "1.1.0-beta.14"
   dartastic_opentelemetry_api:
     dependency: transitive
     description:
       name: dartastic_opentelemetry_api
-      sha256: "7635ce77bf53b39709a605d17d68ac3655afa5123884d41bbefc433c6fd3ccdb"
+      sha256: e3908518510346de8f99d901a818524e85bd2543e05d9fb2cee970a4f14e07bd
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-beta.6"
+    version: "1.0.0-rc.2"
   dartypod:
     dependency: transitive
     description:

--- a/ios/faro.podspec
+++ b/ios/faro.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'faro'
-  s.version          = '0.17.0-beta.2'
+  s.version          = '0.17.0-beta.3'
   s.summary          = 'Grafana Faro SDK for Flutter - mobile observability and real user monitoring.'
   s.description      = <<-DESC
 Grafana Faro SDK for Flutter applications. Monitor your Flutter app with ease

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,7 +1,7 @@
 /// Constants for the Faro Flutter SDK
 class FaroConstants {
   /// The version of the Faro Flutter SDK
-  static const String sdkVersion = '0.17.0-beta.2';
+  static const String sdkVersion = '0.17.0-beta.3';
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-mobile-flutter';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: faro
 description: Grafana Faro SDK for Flutter applications - Monitor your Flutter app with ease.
-version: 0.17.0-beta.2
+version: 0.17.0-beta.3
 homepage: https://grafana.com/oss/faro/
 repository: https://github.com/grafana/faro-flutter-sdk
 


### PR DESCRIPTION
## Description

Prepares the `0.17.0-beta.3` release. Bumps the version in `pubspec.yaml`,
`ios/faro.podspec`, `android/build.gradle`, `lib/src/util/constants.dart` and
`example/pubspec.lock`, and moves the accumulated `CHANGELOG.md` Unreleased
content under a dated `0.17.0-beta.3` heading.

Release contents: 5 Added, 7 Changed (4 marked BREAKING), 1 Deprecated,
12 Fixed. Staying on the beta line because the 1.1.0 OTel dependency is still
a prerelease.

## Validation

Verified end-to-end against Grafana Cloud, not just unit tests, by pointing the
QuickPizza Flutter demo app at this branch (iOS simulator, dev stack):

- Compiles and runs unchanged despite the four breaking changes.
- Cold start reports a plausible 3.3s with the new `prewarmed` field, and no
  phantom warm start alongside it.
- Log-trace correlation resolves every correlated signal to a real Tempo span
  (5/5 traces, 0 dangling refs).
- The 15-minute inactivity rotation fires correctly — periodic vitals no longer
  keep an idle session alive.
- Session linking holds across both rotation and repeated cold starts, emitting
  `session_start` with `previousSession` and no `session_extend`.

## Related Issue(s)

None — release chore.

## Type of Change

- [x] 🧹 Chore / Housekeeping

## Checklist

- [x] I have made corresponding changes to the documentation — n/a, no API change
- [x] I have added tests that prove my fix is effective — n/a, no behaviour change
- [x] I have updated the CHANGELOG.md — inverted for a release PR: this moves
      the existing Unreleased content under the new version heading

Made with [Cursor](https://cursor.com)