### PR TITLE
fix(http): leave successful spans unset and record HTTP error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as a network error, matching the Faro Web SDK. 4xx/5xx responses also
   mark the span as error
   ([#183](https://github.com/grafana/faro-flutter-sdk/issues/183)).
-- **HTTP spans wait to mark success until the response body completes.**
-  A 2xx status from headers no longer sets span status `OK` immediately, so
-  a later body-stream error can still be recorded as a failed request.
+- **Successful HTTP spans leave status unset**, following OpenTelemetry HTTP
+  conventions. Response completion preserves any previously recorded error
+  ([#24](https://github.com/grafana/faro-flutter-sdk/issues/24)).
+- **HTTP error responses include a string `error.type`**, such as `"404"` or
+  `"500"`, and omit the redundant status description. The HTTP event also
+  includes this attribute
+  ([#24](https://github.com/grafana/faro-flutter-sdk/issues/24)).
 
 ## [0.17.0-beta.3] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Use Dartastic OpenTelemetry stable `0.11.0`**, which preserves unset span
+  status when a span ends. This also includes upstream sampling fixes: child
+  spans respect an unsampled parent, and only sampled spans are exported.
+
 ### Fixed
 
 - **HTTP spans now record `http.status_code` 0 on network failures.**

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -133,18 +133,18 @@ packages:
     dependency: transitive
     description:
       name: dartastic_opentelemetry
-      sha256: "4f3c36df67269bc169ba99bae33363d4e9e062eba8fc0e3c693648e8ad13e667"
+      sha256: e8bf3c1cff40199f5e9c679aeff7922b40c6f0ccd5d7a6c3567cd35be869c9b8
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0-beta.14"
+    version: "0.11.0"
   dartastic_opentelemetry_api:
     dependency: transitive
     description:
       name: dartastic_opentelemetry_api
-      sha256: e3908518510346de8f99d901a818524e85bd2543e05d9fb2cee970a4f14e07bd
+      sha256: "273aeef3d3aacdfd68acb73fa29c6ac38701c6a05fe578c0863bcb1c50bc7415"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-rc.2"
+    version: "0.11.0"
   dartypod:
     dependency: transitive
     description:

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -241,7 +241,6 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
   final Span _httpSpan;
   var _operationFinished = false;
   var _statusCodeRecorded = false;
-  var _errorStatusRecorded = false;
 
   void _finishOperation() {
     if (_operationFinished) {
@@ -255,16 +254,8 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
     if (!_statusCodeRecorded) {
       _httpSpan.setAttribute('http.status_code', 0);
     }
-    _errorStatusRecorded = true;
     _httpSpan.setStatus(SpanStatusCode.error, message: error.toString());
     _httpSpan.recordException(error, stackTrace: stackTrace);
-  }
-
-  void _recordOperationSuccess() {
-    if (_errorStatusRecorded) {
-      return;
-    }
-    _httpSpan.setStatus(SpanStatusCode.ok);
   }
 
   Future<HttpClientResponse> _trackResponseFuture(
@@ -280,12 +271,11 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
         'http.content_type': '${value.headers.contentType}',
       });
       _statusCodeRecorded = true;
-      if (value.statusCode >= 400) {
-        _errorStatusRecorded = true;
-        _httpSpan.setStatus(
-          SpanStatusCode.error,
-          message: 'HTTP status code ${value.statusCode}',
-        );
+      // Successful responses leave status unset. Preserve an error already
+      // recorded on the span instead of replacing its diagnostic information.
+      if (value.statusCode >= 400 && _httpSpan.status != SpanStatusCode.error) {
+        _httpSpan.setAttribute('error.type', value.statusCode.toString());
+        _httpSpan.setStatus(SpanStatusCode.error);
       }
 
       return FaroTrackingHttpResponse(
@@ -300,7 +290,6 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
         },
         spanContext: _httpSpan.spanContext,
         onFinish: _finishOperation,
-        onSuccess: _recordOperationSuccess,
         onStreamError: _recordOperationError,
       );
     } catch (error, stackTrace) {
@@ -427,29 +416,23 @@ class FaroTrackingHttpResponse extends Stream<List<int>>
     this.userAttributes, {
     required FaroSpanContext spanContext,
     required void Function() onFinish,
-    required void Function() onSuccess,
     required void Function(Object error, StackTrace stackTrace) onStreamError,
   }) : _spanContext = spanContext,
        _onFinish = onFinish,
-       _onSuccess = onSuccess,
        _onStreamError = onStreamError;
   final HttpClientResponse innerResponse;
   final Map<String, Object?> userAttributes;
   final FaroSpanContext _spanContext;
   final void Function() _onFinish;
-  final void Function() _onSuccess;
   final void Function(Object error, StackTrace stackTrace) _onStreamError;
   Object? lastError;
   var _finished = false;
 
-  void _finishOnce({bool succeeded = false}) {
+  void _finishOnce() {
     if (_finished) {
       return;
     }
     _finished = true;
-    if (succeeded) {
-      _onSuccess();
-    }
     _onFinish();
   }
 
@@ -484,14 +467,14 @@ class FaroTrackingHttpResponse extends Stream<List<int>>
           }
         },
         onDone: () {
-          _finishOnce(succeeded: true);
+          _finishOnce();
           if (onDone != null) {
             onDone();
           }
         },
       ),
       onCancel: _finishOnce,
-      onComplete: () => _finishOnce(succeeded: true),
+      onComplete: _finishOnce,
       onStreamError: _onStreamError,
     );
   }

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -247,16 +247,7 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
       return;
     }
     _operationFinished = true;
-    final span = _httpSpan;
-    if (span is InternalSpan && span.status == SpanStatusCode.unset) {
-      // Older supported Dartastic versions promote UNSET to OK in end().
-      // Preserve UNSET explicitly for HTTP spans only. Newer versions ignore
-      // this deprecated argument for UNSET and already preserve the status.
-      // ignore: deprecated_member_use
-      span.otelSpan.end(spanStatus: span.otelSpan.status);
-    } else {
-      span.end();
-    }
+    _httpSpan.end();
   }
 
   void _recordOperationError(Object error, [StackTrace? stackTrace]) {

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -247,7 +247,16 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
       return;
     }
     _operationFinished = true;
-    _httpSpan.end();
+    final span = _httpSpan;
+    if (span is InternalSpan && span.status == SpanStatusCode.unset) {
+      // Older supported Dartastic versions promote UNSET to OK in end().
+      // Preserve UNSET explicitly for HTTP spans only. Newer versions ignore
+      // this deprecated argument for UNSET and already preserve the status.
+      // ignore: deprecated_member_use
+      span.otelSpan.end(spanStatus: span.otelSpan.status);
+    } else {
+      span.end();
+    }
   }
 
   void _recordOperationError(Object error, [StackTrace? stackTrace]) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   connectivity_plus: ">=6.1.2 <8.0.0"
-  dartastic_opentelemetry: ">=1.1.0-beta.5 <1.2.0"
+  dartastic_opentelemetry: ^0.11.0
   dartypod: ^0.2.0
   device_info_plus: ">=12.3.0 <14.0.0"
   equatable: ^2.0.8

--- a/test/src/integrations/http_response_semantics_test.dart
+++ b/test/src/integrations/http_response_semantics_test.dart
@@ -120,6 +120,7 @@ void main() {
         : await tracked.close();
     expect(recordingSpan.isEnded, isFalse);
     await trackedResponse.drain<void>();
+    expect(span.wasEnded, isTrue);
     expect(processor.ended, [same(recordingSpan)]);
     return recordingSpan;
   }

--- a/test/src/integrations/http_response_semantics_test.dart
+++ b/test/src/integrations/http_response_semantics_test.dart
@@ -1,0 +1,195 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
+import 'package:faro/src/integrations/http_tracking_client.dart';
+import 'package:faro/src/models/span_record.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/tracing/faro_exporter.dart';
+import 'package:faro/src/tracing/span.dart';
+import 'package:faro/src/user_actions/telemetry_router.dart';
+import 'package:faro/src/user_actions/user_action_types.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockRequest extends Mock implements HttpClientRequest {}
+
+class _MockResponse extends Mock implements HttpClientResponse {}
+
+class _MockHeaders extends Mock implements HttpHeaders {}
+
+class _RecordingProcessor implements otel.SpanProcessor {
+  final ended = <otel.Span>[];
+
+  @override
+  Future<void> onStart(otel.Span span, otel.Context? parentContext) async {}
+  @override
+  Future<void> onEnd(otel.Span span) async => ended.add(span);
+  @override
+  Future<void> onNameUpdate(otel.Span span, String newName) async {}
+  @override
+  Future<void> shutdown() async {}
+  @override
+  Future<void> forceFlush() async {}
+}
+
+class _RecordingRouter implements TelemetryRouter {
+  final items = <TelemetryItem>[];
+
+  @override
+  void ingest(
+    TelemetryItem item, {
+    required SessionActivityKind activity,
+    bool skipBuffer = false,
+  }) {
+    items.add(item);
+  }
+}
+
+void main() {
+  final processor = _RecordingProcessor();
+  late otel.Tracer tracer;
+
+  setUpAll(() async {
+    await otel.OTel.initialize(
+      serviceName: 'http-response-test',
+      spanProcessor: processor,
+      detectPlatformResources: false,
+      enableMetrics: false,
+      enableLogs: false,
+    );
+    tracer = otel.OTel.tracer();
+  });
+
+  setUp(processor.ended.clear);
+
+  tearDownAll(() async {
+    // ignore: invalid_use_of_visible_for_testing_member
+    await otel.OTel.reset();
+  });
+
+  Future<otel.Span> completeResponse(
+    int statusCode, {
+    required bool useDone,
+    bool existingError = false,
+  }) async {
+    final recordingSpan = tracer.startSpan(
+      'HTTP GET',
+      kind: otel.SpanKind.client,
+      attributes: otel.OTel.attributesFromMap({'http.method': 'GET'}),
+    );
+    final span = SpanProvider().getSpan(recordingSpan, otel.Context.current);
+    if (existingError) {
+      span.setStatus(SpanStatusCode.error, message: 'previous failure');
+      span.setAttribute('error.type', 'previous_failure');
+    }
+
+    final request = _MockRequest();
+    final response = _MockResponse();
+    final requestHeaders = _MockHeaders();
+    final responseHeaders = _MockHeaders();
+    when(() => request.headers).thenReturn(requestHeaders);
+    when(() => request.method).thenReturn('GET');
+    when(() => request.uri).thenReturn(Uri.parse('https://example.com/test'));
+    when(() => request.contentLength).thenReturn(0);
+    when(request.close).thenAnswer((_) async => response);
+    when(() => request.done).thenAnswer((_) async => response);
+    when(() => response.statusCode).thenReturn(statusCode);
+    when(() => response.headers).thenReturn(responseHeaders);
+    when(() => responseHeaders.contentLength).thenReturn(0);
+    when(() => responseHeaders.contentType).thenReturn(null);
+    when(
+      () => response.listen(
+        any(),
+        onError: any(named: 'onError'),
+        onDone: any(named: 'onDone'),
+        cancelOnError: any(named: 'cancelOnError'),
+      ),
+    ).thenAnswer((invocation) {
+      return const Stream<List<int>>.empty().listen(
+        invocation.positionalArguments[0] as void Function(List<int>)?,
+        onError: invocation.namedArguments[#onError] as Function?,
+        onDone: invocation.namedArguments[#onDone] as void Function()?,
+        cancelOnError: invocation.namedArguments[#cancelOnError] as bool?,
+      );
+    });
+
+    final tracked = FaroTrackingHttpClientRequest(request, httpSpan: span);
+    final trackedResponse = useDone
+        ? await tracked.done
+        : await tracked.close();
+    expect(recordingSpan.isEnded, isFalse);
+    await trackedResponse.drain<void>();
+    expect(processor.ended, [same(recordingSpan)]);
+    return recordingSpan;
+  }
+
+  Map<String, dynamic> attributesOf(Map<String, dynamic> json) => {
+    for (final attribute in json['attributes'] as List<dynamic>)
+      attribute['key'] as String: attribute['value'],
+  };
+
+  for (final useDone in [false, true]) {
+    group(useDone ? 'done' : 'close', () {
+      for (final statusCode in [200, 204, 302, 400, 404, 499, 500, 599]) {
+        test('serializes HTTP $statusCode status and error type', () async {
+          final span = await completeResponse(statusCode, useDone: useDone);
+          final json = SpanRecord(otelReadOnlySpan: span).getSpan().toJson();
+          final attributes = attributesOf(json);
+
+          expect(json['status'], {'code': statusCode >= 400 ? 2 : 0});
+          expect(attributes['http.status_code'], {'intValue': statusCode});
+          if (statusCode >= 400) {
+            expect(attributes['error.type'], {'stringValue': '$statusCode'});
+          } else {
+            expect(attributes, isNot(contains('error.type')));
+          }
+        });
+      }
+
+      for (final statusCode in [200, 404, 500]) {
+        test(
+          'HTTP $statusCode preserves a previously recorded error',
+          () async {
+            final span = await completeResponse(
+              statusCode,
+              useDone: useDone,
+              existingError: true,
+            );
+            final json = SpanRecord(otelReadOnlySpan: span).getSpan().toJson();
+
+            expect(json['status'], {'code': 2, 'message': 'previous failure'});
+            expect(attributesOf(json)['error.type'], {
+              'stringValue': 'previous_failure',
+            });
+          },
+        );
+      }
+    });
+  }
+
+  for (final statusCode in [200, 404, 500]) {
+    test('exports correlated HTTP $statusCode event and span', () async {
+      final span = await completeResponse(statusCode, useDone: false);
+      final router = _RecordingRouter();
+      await FaroExporter(telemetryRouter: router).export([span]);
+
+      final event = router.items
+          .singleWhere((item) => item.asEvent != null)
+          .asEvent!;
+      final record = SpanRecord(otelReadOnlySpan: span);
+      expect(event.name, 'faro.tracing.fetch');
+      expect(event.trace, record.getFaroSpanContext());
+      expect(
+        int.parse(event.attributes!['duration_ns']!),
+        greaterThanOrEqualTo(0),
+      );
+      if (statusCode >= 400) {
+        expect(event.attributes!['error.type'], '$statusCode');
+      } else {
+        expect(event.attributes, isNot(contains('error.type')));
+      }
+      expect(router.items, hasLength(2));
+    });
+  }
+}

--- a/test/src/integrations/http_tracking_client_test.dart
+++ b/test/src/integrations/http_tracking_client_test.dart
@@ -124,6 +124,8 @@ void main() {
       mockResponseHeaders = MockHttpHeaders();
       mockSpan = MockSpan();
 
+      when(() => mockSpan.status).thenReturn(SpanStatusCode.unset);
+
       when(() => mockSpan.traceId).thenReturn('trace-id');
       when(() => mockSpan.spanId).thenReturn('span-id');
       when(() => mockSpan.traceparent).thenReturn('00-trace-id-span-id-01');
@@ -170,7 +172,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(response, isA<HttpClientResponse>());
-      verify(() => mockSpan.setStatus(SpanStatusCode.ok)).called(1);
+      verifyNever(() => mockSpan.setStatus(SpanStatusCode.ok));
       verify(() => mockSpan.end()).called(1);
     });
 
@@ -261,7 +263,7 @@ void main() {
       response.listen((_) {});
       await Future<void>.delayed(Duration.zero);
 
-      verify(() => mockSpan.setStatus(SpanStatusCode.ok)).called(1);
+      verifyNever(() => mockSpan.setStatus(SpanStatusCode.ok));
       verify(() => mockSpan.end()).called(1);
     });
 


### PR DESCRIPTION
## Description

Automatically instrumented HTTP spans now leave successful responses UNSET. Ordinary 4xx/5xx responses retain ERROR, add the response code as a string `error.type`, and omit the redundant status description. Response completion preserves previously recorded errors.

Upgrade Dartastic OpenTelemetry to stable `^0.11.0`, which preserves UNSET when ending a span, and remove the HTTP compatibility workaround. This includes upstream sampling corrections: child spans respect unsampled parents, and only sampled spans are exported. The `faro.tracing.fetch` event retains its name, duration and correlation, and also carries `error.type` for HTTP errors.

## Related Issue(s)

Fixes #24

## Type of Change

- [x] 🛠️ Bug fix

## Checklist

- [x] Added regression tests for the changed behavior and serialized payloads
- [x] Updated CHANGELOG.md under Unreleased

## Additional Notes

Written with TDD. The 25 new cases cover both `close()` and `done()`, successful and HTTP error responses, prior-error preservation, serialization, and event correlation. All 895 Flutter tests pass with Dartastic SDK/API `0.11.0`, including the HTTP regression tests. The complete pre-release check passes all six gates.

Verified the SDK example and QuickPizza Flutter with Dartastic `0.11.0` on Android API 35 and the iOS 26.5 simulator. All 44 captured spans matched stored traces. The twelve representative 200/404/500 HTTP spans and matching events retained their status, error types, duration and correlation. Custom logs, events, errors and measurements also retained trace/session correlation, and native startup/memory/refresh-rate measurements arrived. HTTP fields matched the earlier verified candidate after excluding run-specific IDs and timing. Callback spans still finish OK; manually ended spans now preserve UNSET as intended by the upstream fix. Verification used temporary entry points running each normal app; it is not a product UI sign-off. Temporary dependency overrides were restored.

Additional QuickPizza UI runs on September 9 exercised navigation, recommendations, ratings, profile/history, controlled HTTP errors and recovery on both platforms. Both Dartastic SDK and API resolved to `0.11.0` in the compiler package configuration. All 265 captured events/logs/measurements and 35 spans matched stored telemetry, including session-start events and cold-start measurements. Successful HTTP responses remained UNSET; 401/500 responses carried ERROR and string `error.type`. iOS accessibility actions verified explicit user-action events, but not raw touch capture. These are point-in-time ingestion checks; a later availability discrepancy affecting records from the earlier runs remains unexplained.

Naming, stable attribute migration, and consolidated HTTP documentation remain separate follow-ups. No release is included.
