### PR TITLE
fix(http): use method-only names for known client methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Known HTTP client span names are now method-only**, such as `GET` and
-  `POST`, instead of `HTTP GET` and `HTTP POST`. Update span-name queries to
-  include both forms when searching across an SDK upgrade. HTTP convenience
-  methods now use uppercase verbs
+  `POST`, instead of `HTTP GET` and `HTTP POST`. HTTP convenience methods now
+  use uppercase verbs. When querying across an SDK upgrade, include both old
+  and new names. For example, a GET TraceQL filter can use
+  `{ name = "GET" || name = "HTTP GET" || name = "HTTP get" }`
   ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
 - **Known HTTP methods include `http.request.method`** on spans and
-  `faro.tracing.fetch` events. The legacy `http.method` field remains during
-  the consumer migration. See the Reference docs for details
+  `faro.tracing.fetch` events. The legacy `http.method` field remains until
+  deployed consumers support stable fields and historical records, as tracked
+  in [the HTTP attribute migration](https://github.com/grafana/faro-flutter-sdk/issues/346)
   ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
-
 - **Use Dartastic OpenTelemetry stable `0.11.0`**, which preserves unset span
   status when a span ends. This also includes upstream sampling fixes: child
   spans respect an unsampled parent, and only sampled spans are exported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Automatic HTTP spans use the `faro-mobile-flutter.http` scope.**
+  Queries that filter by instrumentation scope should include this scope
+  alongside `faro-mobile-flutter` when searching across SDK versions.
+  WebView and custom spans carrying only `http.request.method` retain their
+  `span.<name>` events; legacy HTTP attribute classification is preserved.
+
 - **Known HTTP client span names are now method-only**, such as `GET` and
   `POST`, instead of `HTTP GET` and `HTTP POST`. HTTP convenience methods now
   use uppercase verbs. When querying across an SDK upgrade, include both old

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Known HTTP methods include `http.request.method`** on spans and
+  `faro.tracing.fetch` events. The legacy `http.method` attribute remains
+  available for compatibility
+  ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
+
 ### Changed
 
-- **Automatic HTTP spans use the `faro-mobile-flutter.http` scope.**
-  Queries that filter by instrumentation scope should include this scope
-  alongside `faro-mobile-flutter` when searching across SDK versions.
-  WebView and custom spans carrying only `http.request.method` retain their
-  `span.<name>` events; legacy HTTP attribute classification is preserved.
-
-- **Known HTTP client span names are now method-only**, such as `GET` and
-  `POST`, instead of `HTTP GET` and `HTTP POST`. HTTP convenience methods now
-  use uppercase verbs. When querying across an SDK upgrade, include both old
+- **Known HTTP client span names are method-only**, such as `GET` and
+  `POST`, instead of `HTTP GET` and `HTTP POST`. HTTP convenience methods use
+  uppercase verbs. When querying across an SDK upgrade, include both old
   and new names. For example, a GET TraceQL filter can use
   `{ name = "GET" || name = "HTTP GET" || name = "HTTP get" }`
   ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
-- **Known HTTP methods include `http.request.method`** on spans and
-  `faro.tracing.fetch` events. The legacy `http.method` field remains until
-  deployed consumers support stable fields and historical records, as tracked
-  in [the HTTP attribute migration](https://github.com/grafana/faro-flutter-sdk/issues/346)
+- **Automatic HTTP spans use the `faro-mobile-flutter.http` scope.**
+  Queries that filter by instrumentation scope should include this scope
+  alongside `faro-mobile-flutter` when searching across SDK versions
   ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
 - **Use Dartastic OpenTelemetry stable `0.11.0`**, which preserves unset span
   status when a span ends. This also includes upstream sampling fixes: child
@@ -34,10 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Lowercase and mixed-case known HTTP methods use canonical span names**,
   matching the method sent by Dart's HTTP client. For example, `get` and `GeT`
-  produce `GET`; spans and events record the supplied spelling in
-  `http.request.method_original`
+  produce `GET`. When the spelling differs from the canonical method, spans
+  and events record it in `http.request.method_original`
   ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
-
 - **HTTP spans now record `http.status_code` 0 on network failures.**
   Requests that never receive a response (DNS failure, connection error,
   dropped body, failed upload, or abort, including `abort()` with no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Lowercase and mixed-case known HTTP methods use canonical span names**,
+  matching the method sent by Dart's HTTP client. For example, `get` and `GeT`
+  produce `GET`; spans and events record the supplied spelling in
+  `http.request.method_original`
+  ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
+
 - **HTTP spans now record `http.status_code` 0 on network failures.**
   Requests that never receive a response (DNS failure, connection error,
   dropped body, failed upload, or abort, including `abort()` with no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Known HTTP client span names are now method-only**, such as `GET` and
+  `POST`, instead of `HTTP GET` and `HTTP POST`. Update span-name queries to
+  include both forms when searching across an SDK upgrade. HTTP convenience
+  methods now use uppercase verbs
+  ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
+- **Known HTTP methods include `http.request.method`** on spans and
+  `faro.tracing.fetch` events. The legacy `http.method` field remains during
+  the consumer migration. See the Reference docs for details
+  ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
+
 - **Use Dartastic OpenTelemetry stable `0.11.0`**, which preserves unset span
   status when a span ends. This also includes upstream sampling fixes: child
   spans respect an unsampled parent, and only sampled spans are exported.

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -731,32 +731,22 @@ HttpOverrides.global = FaroHttpOverrides(HttpOverrides.current);
 
 ### HTTP span names and method attributes
 
-Automatically instrumented HTTP client spans use the known method as their
-name: `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`,
-`PATCH`, or `QUERY`. The span name does not include the URL or path. URL
-attributes remain separate; URL templates are not supported.
+Automatically instrumented HTTP client spans use the request method as their
+name for `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`,
+`PATCH`, and `QUERY`. For example, a request to `/users/123` using `GET`
+produces a span named `GET`. The URL is recorded separately in `http.url`;
+URL templates are not supported.
 
-For these methods, both the span and the accompanying event contain the string
-`http.request.method`, matching the span name. The event remains named
-`faro.tracing.fetch`, with its duration and trace/session correlation intact.
-The SDK's HTTP convenience methods use canonical uppercase verbs. Arbitrary
-methods supplied through `open` or `openUrl` retain their existing behavior;
-this change does not add unknown-method normalization.
+For these methods, spans and HTTP events include the string attributes
+`http.request.method` and `http.method`, both set to the method name.
+`http.method` is a compatibility alias. HTTP events use the name
+`faro.tracing.fetch` and include `duration_ns`, trace/span IDs, and session
+attributes for correlation.
 
-Previously, span names included an `HTTP ` prefix (for example, `HTTP GET`),
-and convenience methods could produce lowercase names such as `HTTP get`.
-Already-ingested spans keep those names. When querying across an SDK upgrade,
-include both old and new names. For example, a GET TraceQL filter can use
-`{ name = "GET" || name = "HTTP GET" || name = "HTTP get" }`.
-
-The legacy string `http.method` is temporarily emitted alongside
-`http.request.method` for known methods because existing HTTP event and trace
-queries consume it. The
-[HTTP attribute migration](https://github.com/grafana/faro-flutter-sdk/issues/346)
-will remove that alias once deployed consumers support stable fields and
-historical records. Other legacy HTTP fields are unchanged by this naming
-update. During migration, HTTP event classification recognizes either the
-stable method key or the existing legacy method/scheme keys.
+HTTP convenience methods such as `getUrl()` and `postUrl()` use uppercase
+verbs. For other method values passed to `open()` or `openUrl()`, the SDK
+uses `HTTP <method>` as the span name and records the supplied value in
+`http.method`, without adding `http.request.method` or changing its case.
 
 ---
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -729,6 +729,35 @@ HttpOverrides.global = FaroHttpOverrides(HttpOverrides.current);
 
 > **Important**: HTTP tracking only captures requests made from the Flutter/Dart layer (using packages like `http`, `dio`, etc.). Native HTTP calls made directly from Android/iOS code are not tracked.
 
+### HTTP span names and method attributes
+
+Automatically instrumented HTTP client spans use the known method as their
+name: `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`,
+`PATCH`, or `QUERY`. The span name does not include the URL or path. URL
+attributes remain separate; URL templates are not supported.
+
+For these methods, both the span and the accompanying event contain the string
+`http.request.method`, matching the span name. The event remains named
+`faro.tracing.fetch`, with its duration and trace/session correlation intact.
+The SDK's HTTP convenience methods use canonical uppercase verbs. Arbitrary
+methods supplied through `open` or `openUrl` retain their existing behavior;
+this change does not add unknown-method normalization.
+
+Previously, span names included an `HTTP ` prefix (for example, `HTTP GET`),
+and convenience methods could produce lowercase names such as `HTTP get`.
+Already-ingested spans keep those names. When querying across an SDK upgrade,
+include both old and new names. For example, a GET TraceQL filter can use
+`{ name = "GET" || name = "HTTP GET" || name = "HTTP get" }`.
+
+The legacy string `http.method` is temporarily emitted alongside
+`http.request.method` for known methods because existing HTTP event and trace
+queries consume it. The
+[HTTP attribute migration](https://github.com/grafana/faro-flutter-sdk/issues/346)
+will remove that alias once deployed consumers support stable fields and
+historical records. Other legacy HTTP fields are unchanged by this naming
+update. During migration, HTTP event classification recognizes either the
+stable method key or the existing legacy method/scheme keys.
+
 ---
 
 ## Custom Telemetry

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -731,6 +731,16 @@ HttpOverrides.global = FaroHttpOverrides(HttpOverrides.current);
 
 ### HTTP span names and method attributes
 
+Automatically instrumented HTTP spans use the instrumentation scope
+`faro-mobile-flutter.http`, with the SDK version as the scope version.
+Application spans and WebView lifetime spans use `faro-mobile-flutter`.
+
+The HTTP scope identifies spans whose accompanying event is
+`faro.tracing.fetch`. For compatibility, spans with a nonempty `http.method`
+or `http.scheme` also produce fetch events. The `http.request.method`
+attribute alone does not classify a span as an HTTP request. Other spans,
+including WebView lifetime spans, produce `span.<name>` events.
+
 Automatically instrumented HTTP client spans use the request method as their
 name for `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`,
 `PATCH`, and `QUERY`. For example, a request to `/users/123` using `GET`

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -743,8 +743,13 @@ For these methods, spans and HTTP events include the string attributes
 `faro.tracing.fetch` and include `duration_ns`, trace/span IDs, and session
 attributes for correlation.
 
-HTTP convenience methods such as `getUrl()` and `postUrl()` use uppercase
-verbs. For other method values passed to `open()` or `openUrl()`, the SDK
+Known method values passed to `open()` or `openUrl()` are normalized to
+uppercase, matching Dart's HTTP client. For example, `get` and `GeT` produce
+`GET`. When the supplied spelling differs, spans and HTTP events also include
+`http.request.method_original` with that spelling. HTTP convenience methods
+such as `getUrl()` and `postUrl()` use uppercase verbs.
+
+For other method values passed to `open()` or `openUrl()`, the SDK
 uses `HTTP <method>` as the span name and records the supplied value in
 `http.method`, without adding `http.request.method` or changing its case.
 

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -70,14 +70,32 @@ class FaroHttpTrackingClient implements HttpClient {
     return _openUrl(method, uri);
   }
 
+  // Keep arbitrary caller-provided methods unchanged. Unknown-method
+  // normalization is separate from the known-method naming migration.
+  static const _knownMethods = {
+    'GET',
+    'HEAD',
+    'POST',
+    'PUT',
+    'DELETE',
+    'CONNECT',
+    'OPTIONS',
+    'TRACE',
+    'PATCH',
+    'QUERY',
+  };
+
   Future<HttpClientRequest> _openUrl(String method, Uri url) async {
     if (!_trackingFilter.shouldTrack(url)) {
       return innerClient.openUrl(method, url);
     }
 
+    final isKnownMethod = _knownMethods.contains(method);
     final httpSpan = Faro().startSpanManual(
-      'HTTP $method',
+      isKnownMethod ? method : 'HTTP $method',
       attributes: {
+        if (isKnownMethod) 'http.request.method': method,
+        // Retain the legacy field until HTTP event/query consumers migrate.
         'http.method': method,
         'http.scheme': url.scheme,
         'http.url': url.toString(),
@@ -183,27 +201,27 @@ class FaroHttpTrackingClient implements HttpClient {
 
   @override
   Future<HttpClientRequest> delete(String host, int port, String path) =>
-      open('delete', host, port, path);
+      open('DELETE', host, port, path);
 
   @override
-  Future<HttpClientRequest> deleteUrl(Uri url) => _openUrl('delete', url);
+  Future<HttpClientRequest> deleteUrl(Uri url) => _openUrl('DELETE', url);
 
   @override
   set findProxy(String Function(Uri url)? f) => innerClient.findProxy = f;
 
   @override
   Future<HttpClientRequest> get(String host, int port, String path) =>
-      open('get', host, port, path);
+      open('GET', host, port, path);
 
   @override
-  Future<HttpClientRequest> getUrl(Uri url) => _openUrl('get', url);
+  Future<HttpClientRequest> getUrl(Uri url) => _openUrl('GET', url);
 
   @override
   Future<HttpClientRequest> head(String host, int port, String path) =>
-      open('head', host, port, path);
+      open('HEAD', host, port, path);
 
   @override
-  Future<HttpClientRequest> headUrl(Uri url) => _openUrl('head', url);
+  Future<HttpClientRequest> headUrl(Uri url) => _openUrl('HEAD', url);
 
   @override
   Future<HttpClientRequest> openUrl(String method, Uri url) =>
@@ -211,24 +229,24 @@ class FaroHttpTrackingClient implements HttpClient {
 
   @override
   Future<HttpClientRequest> patch(String host, int port, String path) =>
-      open('patch', host, port, path);
+      open('PATCH', host, port, path);
 
   @override
-  Future<HttpClientRequest> patchUrl(Uri url) => _openUrl('patch', url);
+  Future<HttpClientRequest> patchUrl(Uri url) => _openUrl('PATCH', url);
 
   @override
   Future<HttpClientRequest> post(String host, int port, String path) =>
-      open('post', host, port, path);
+      open('POST', host, port, path);
 
   @override
-  Future<HttpClientRequest> postUrl(Uri url) => _openUrl('post', url);
+  Future<HttpClientRequest> postUrl(Uri url) => _openUrl('POST', url);
 
   @override
   Future<HttpClientRequest> put(String host, int port, String path) =>
-      open('put', host, port, path);
+      open('PUT', host, port, path);
 
   @override
-  Future<HttpClientRequest> putUrl(Uri url) => _openUrl('put', url);
+  Future<HttpClientRequest> putUrl(Uri url) => _openUrl('PUT', url);
 }
 
 class FaroTrackingHttpClientRequest implements HttpClientRequest {

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -70,8 +70,7 @@ class FaroHttpTrackingClient implements HttpClient {
     return _openUrl(method, uri);
   }
 
-  // Keep arbitrary caller-provided methods unchanged. Unknown-method
-  // normalization is separate from the known-method naming migration.
+  // Unknown-method handling is separate from known-method normalization.
   static const _knownMethods = {
     'GET',
     'HEAD',
@@ -90,13 +89,18 @@ class FaroHttpTrackingClient implements HttpClient {
       return innerClient.openUrl(method, url);
     }
 
-    final isKnownMethod = _knownMethods.contains(method);
+    // Dart's HttpClient uppercases methods before sending the request.
+    final upperMethod = method.toUpperCase();
+    final isKnownMethod = _knownMethods.contains(upperMethod);
+    final recordedMethod = isKnownMethod ? upperMethod : method;
     final httpSpan = Faro().startSpanManual(
-      isKnownMethod ? method : 'HTTP $method',
+      isKnownMethod ? recordedMethod : 'HTTP $method',
       attributes: {
-        if (isKnownMethod) 'http.request.method': method,
+        if (isKnownMethod) 'http.request.method': recordedMethod,
+        if (isKnownMethod && recordedMethod != method)
+          'http.request.method_original': method,
         // Retain the legacy field until HTTP event/query consumers migrate.
-        'http.method': method,
+        'http.method': recordedMethod,
         'http.scheme': url.scheme,
         'http.url': url.toString(),
         'http.host': url.host,

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -7,6 +7,7 @@ import 'package:faro/src/faro.dart';
 import 'package:faro/src/integrations/http_tracking_filter.dart';
 import 'package:faro/src/models/log_level.dart';
 import 'package:faro/src/tracing/faro_span_context.dart';
+import 'package:faro/src/tracing/faro_tracer.dart';
 import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/user_actions/constants.dart';
 
@@ -22,17 +23,28 @@ class FaroHttpOverrides extends HttpOverrides {
     return FaroHttpTrackingClient(
       innerClient,
       trackingFilter: pod.resolve(httpTrackingFilterProvider),
+      // Resolve per request: this client can outlive initialization or reset.
+      startHttpSpan: (name, {required attributes}) => pod
+          .resolve(faroHttpTracerProvider)
+          .startSpanManual(name, attributes: attributes),
     );
   }
 }
+
+/// Starts a span for an automatically instrumented HTTP request.
+typedef StartHttpSpan =
+    Span Function(String name, {required Map<String, Object> attributes});
 
 class FaroHttpTrackingClient implements HttpClient {
   FaroHttpTrackingClient(
     this.innerClient, {
     required HttpTrackingFilter trackingFilter,
-  }) : _trackingFilter = trackingFilter;
+    required StartHttpSpan startHttpSpan,
+  }) : _trackingFilter = trackingFilter,
+       _startHttpSpan = startHttpSpan;
   final HttpClient innerClient;
   final HttpTrackingFilter _trackingFilter;
+  final StartHttpSpan _startHttpSpan;
 
   @override
   Future<HttpClientRequest> open(
@@ -93,7 +105,7 @@ class FaroHttpTrackingClient implements HttpClient {
     final upperMethod = method.toUpperCase();
     final isKnownMethod = _knownMethods.contains(upperMethod);
     final recordedMethod = isKnownMethod ? upperMethod : method;
-    final httpSpan = Faro().startSpanManual(
+    final httpSpan = _startHttpSpan(
       isKnownMethod ? recordedMethod : 'HTTP $method',
       attributes: {
         if (isKnownMethod) 'http.request.method': recordedMethod,

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -103,13 +103,16 @@ class SpanRecord {
 
   String getFaroEventName() {
     final attributes = _spanAttributes;
+    final requestMethod = attributes.getString('http.request.method');
     final httpScheme = attributes.getString('http.scheme');
     final httpMethod = attributes.getString('http.method');
 
     final hasHttpScheme = httpScheme != null && httpScheme.isNotEmpty;
     final hasHttpMethod = httpMethod != null && httpMethod.isNotEmpty;
 
-    if (hasHttpScheme || hasHttpMethod) {
+    final hasRequestMethod = requestMethod != null && requestMethod.isNotEmpty;
+
+    if (hasRequestMethod || hasHttpScheme || hasHttpMethod) {
       return 'faro.tracing.fetch';
     } else {
       return 'span.${name()}';

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -6,6 +6,7 @@ import 'package:faro/src/models/trace/trace_span_status.dart';
 import 'package:faro/src/tracing/dartastic_span_access.dart';
 import 'package:faro/src/tracing/extensions.dart';
 import 'package:faro/src/tracing/faro_span_context.dart';
+import 'package:faro/src/util/constants.dart';
 import 'package:fixnum/fixnum.dart';
 
 class SpanRecord {
@@ -103,16 +104,19 @@ class SpanRecord {
 
   String getFaroEventName() {
     final attributes = _spanAttributes;
-    final requestMethod = attributes.getString('http.request.method');
+    if (_otelReadOnlySpan.instrumentationScope.name ==
+        FaroConstants.httpInstrumentationScope) {
+      return 'faro.tracing.fetch';
+    }
+
+    // Preserve classification for custom spans using legacy HTTP attributes.
     final httpScheme = attributes.getString('http.scheme');
     final httpMethod = attributes.getString('http.method');
 
     final hasHttpScheme = httpScheme != null && httpScheme.isNotEmpty;
     final hasHttpMethod = httpMethod != null && httpMethod.isNotEmpty;
 
-    final hasRequestMethod = requestMethod != null && requestMethod.isNotEmpty;
-
-    if (hasRequestMethod || hasHttpScheme || hasHttpMethod) {
+    if (hasHttpScheme || hasHttpMethod) {
       return 'faro.tracing.fetch';
     } else {
       return 'span.${name()}';

--- a/lib/src/tracing/faro_tracer.dart
+++ b/lib/src/tracing/faro_tracer.dart
@@ -128,22 +128,40 @@ class FaroTracer {
   }
 }
 
-/// Scope for [faroTracerProvider]. Cleared when the tracer wrapper must be
-/// rebuilt without re-initializing the process-global OTel SDK.
+/// Cache scope for tracer wrappers, refreshed during initialization and reset.
 const tracerScope = CustomScope('tracer');
 
-/// Provides the shared [FaroTracer].
-final faroTracerProvider = Provider<FaroTracer>((pod) {
-  // Use OTelAPI directly so we degrade to a no-op tracer if the Faro
-  // bootstrap (which calls OTel.initialize) hasn't run yet — e.g. when
-  // FaroHttpTrackingClient is used in unit tests that never call Faro.init.
-  final otelTracer = otel.OTelAPI.tracerProvider().getTracer(
+/// Provides the shared tracer for application spans.
+final faroTracerProvider = Provider<FaroTracer>(
+  (pod) => _createTracer(
     FaroConstants.sdkName,
+    pod.resolve(sessionIdProviderProvider),
+  ),
+  scope: tracerScope,
+);
+
+/// Provides the tracer for automatically instrumented HTTP requests.
+final faroHttpTracerProvider = Provider<FaroTracer>(
+  (pod) => _createTracer(
+    FaroConstants.httpInstrumentationScope,
+    pod.resolve(sessionIdProviderProvider),
+  ),
+  scope: tracerScope,
+);
+
+FaroTracer _createTracer(
+  String scopeName,
+  SessionIdProvider sessionIdProvider,
+) {
+  // Use OTelAPI so requests before Faro initialization safely use a no-op
+  // tracer. Bootstrap clears tracerScope once the SDK provider is ready.
+  final otelTracer = otel.OTelAPI.tracerProvider().getTracer(
+    scopeName,
     version: FaroConstants.sdkVersion,
   );
   return FaroTracer(
     otelTracer: otelTracer,
     faroZoneSpanManager: FaroZoneSpanManagerFactory().create(),
-    sessionIdProvider: pod.resolve(sessionIdProviderProvider),
+    sessionIdProvider: sessionIdProvider,
   );
-}, scope: tracerScope);
+}

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -5,4 +5,7 @@ class FaroConstants {
 
   /// The name of the Faro Flutter SDK
   static const String sdkName = 'faro-mobile-flutter';
+
+  /// Instrumentation scope for automatically tracked HTTP requests.
+  static const String httpInstrumentationScope = '$sdkName.http';
 }

--- a/test/src/integrations/http_span_naming_test.dart
+++ b/test/src/integrations/http_span_naming_test.dart
@@ -7,12 +7,15 @@ import 'package:faro/src/faro.dart';
 import 'package:faro/src/integrations/http_tracking_client.dart';
 import 'package:faro/src/integrations/http_tracking_filter.dart';
 import 'package:faro/src/models/span_record.dart';
+import 'package:faro/src/models/trace/trace_resource_spans.dart';
 import 'package:faro/src/session/session_activity_kind.dart';
 import 'package:faro/src/session/session_id_provider.dart';
 import 'package:faro/src/tracing/faro_exporter.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
 import 'package:faro/src/user_actions/telemetry_router.dart';
 import 'package:faro/src/user_actions/user_action_types.dart';
+import 'package:faro/src/util/constants.dart';
+import 'package:faro/src/webview/faro_webview_bridge.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -80,6 +83,57 @@ void main() {
     await otel.OTel.reset();
   });
 
+  test(
+    'serializes application parent and HTTP child in separate scopes',
+    () async {
+      await Faro().startSpan('checkout', (parent) {
+        final child = pod
+            .resolve(faroHttpTracerProvider)
+            .startSpanManual('GET');
+        child.end();
+      });
+      await Future<void>.delayed(Duration.zero);
+      final batch = TraceResourceSpans();
+      for (final span in processor.ended) {
+        batch.addSpan(SpanRecord(otelReadOnlySpan: span));
+      }
+      final scopes = batch.toJson()['scopeSpans'] as List;
+      final http = scopes.singleWhere(
+        (s) => s['scope']['name'] == 'faro-mobile-flutter.http',
+      );
+      final application = scopes.singleWhere(
+        (s) => s['scope']['name'] == 'faro-mobile-flutter',
+      );
+      expect(scopes, hasLength(2));
+      expect(http['scope']['version'], FaroConstants.sdkVersion);
+      expect(application['scope']['version'], FaroConstants.sdkVersion);
+      final child = http['spans'].single;
+      final parent = application['spans'].single;
+      expect(child['traceId'], parent['traceId']);
+      expect(child['parentSpanId'], parent['spanId']);
+    },
+  );
+
+  for (final name in ['WebView', 'CustomWebView']) {
+    test('exports $name lifetime as a custom event', () async {
+      final bridge = FaroWebViewBridge();
+      bridge.instrumentedUrl(Uri.parse('https://example.com'), spanName: name);
+      bridge.end();
+      await Future<void>.delayed(Duration.zero);
+      final router = _RecordingRouter();
+      await FaroExporter(telemetryRouter: router).export(processor.ended);
+      final record = router.items.singleWhere((i) => i.asSpan != null).asSpan!;
+      final event = router.items.singleWhere((i) => i.asEvent != null).asEvent!;
+      expect(record.getScope().toJson()['name'], 'faro-mobile-flutter');
+      expect(record.name(), name);
+      expect(event.name, 'span.$name');
+      expect(event.attributes!['http.request.method'], 'GET');
+      expect(event.attributes!['component'], 'webview');
+      expect(event.attributes, contains('duration_ns'));
+      expect(event.trace, record.getFaroSpanContext());
+    });
+  }
+
   Future<void> verifyRequest(
     String method,
     Future<HttpClientRequest> Function(FaroHttpTrackingClient, Uri) open, {
@@ -92,7 +146,11 @@ void main() {
     final innerClient = _MockClient();
     final filter = HttpTrackingFilter()
       ..configure(collectorUrl: null, ignoreUrls: null);
-    final client = FaroHttpTrackingClient(innerClient, trackingFilter: filter);
+    final client = FaroHttpTrackingClient(
+      innerClient,
+      trackingFilter: filter,
+      startHttpSpan: pod.resolve(faroHttpTracerProvider).startSpanManual,
+    );
     final request = _MockRequest();
     final response = _MockResponse();
     final requestHeaders = _MockHeaders();
@@ -164,6 +222,8 @@ void main() {
           attribute['key'] as String: attribute['value'],
       };
       expect(exported['name'], expectedName);
+      expect(record.getScope().toJson()['name'], 'faro-mobile-flutter.http');
+      expect(record.getScope().toJson()['version'], FaroConstants.sdkVersion);
       expect(exported['kind'], 3);
       expect(exported['traceId'], parent.traceId);
       expect(exported['parentSpanId'], parent.spanId);
@@ -319,6 +379,7 @@ void main() {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       final client = FaroHttpTrackingClient(
         HttpClient()..findProxy = (_) => 'DIRECT',
+        startHttpSpan: pod.resolve(faroHttpTracerProvider).startSpanManual,
         trackingFilter: HttpTrackingFilter()
           ..configure(collectorUrl: null, ignoreUrls: null),
       );

--- a/test/src/integrations/http_span_naming_test.dart
+++ b/test/src/integrations/http_span_naming_test.dart
@@ -86,6 +86,7 @@ void main() {
     String path = '/users/123?view=details',
     int statusCode = 200,
     bool known = true,
+    String? normalizedMethod,
   }) async {
     final url = Uri.parse('http://example.com$path');
     final innerClient = _MockClient();
@@ -130,12 +131,13 @@ void main() {
       final tracked = await open(client, url);
       final span = processor.started.last;
       final record = SpanRecord(otelReadOnlySpan: span);
-      final expectedName = known ? method : 'HTTP $method';
+      final recordedMethod = normalizedMethod ?? method;
+      final expectedName = known ? recordedMethod : 'HTTP $method';
       // Inspect before response completion: naming and method are request data.
       expect(span.name, expectedName);
       expect(
         record.getFaroEventAttributes()['http.request.method'],
-        known ? method : isNull,
+        known ? recordedMethod : isNull,
       );
       verify(() => innerClient.openUrl(method, url)).called(1);
       verify(
@@ -168,9 +170,13 @@ void main() {
       expect(exported['spanId'], isNot(parent.spanId));
       expect(
         attributes['http.request.method'],
-        known ? {'stringValue': method} : isNull,
+        known ? {'stringValue': recordedMethod} : isNull,
       );
-      expect(attributes['http.method'], {'stringValue': method});
+      expect(attributes['http.method'], {'stringValue': recordedMethod});
+      expect(
+        attributes['http.request.method_original'],
+        normalizedMethod != null ? {'stringValue': method} : isNull,
+      );
       expect(attributes['http.url'], {'stringValue': url.toString()});
       expect(attributes, isNot(contains('url.template')));
       expect(exported['status'], {'code': statusCode >= 400 ? 2 : 0});
@@ -188,8 +194,15 @@ void main() {
         'trace_id': exported['traceId'],
         'span_id': exported['spanId'],
       });
-      expect(event.attributes!['http.request.method'], known ? method : isNull);
-      expect(event.attributes!['http.method'], method);
+      expect(
+        event.attributes!['http.request.method'],
+        known ? recordedMethod : isNull,
+      );
+      expect(event.attributes!['http.method'], recordedMethod);
+      expect(
+        event.attributes!['http.request.method_original'],
+        normalizedMethod != null ? method : isNull,
+      );
       expect(event.attributes!['session.id'], sessionId);
       expect(attributes['session.id'], {'stringValue': sessionId});
       final duration =
@@ -263,9 +276,82 @@ void main() {
   }
 
   // This scoped change must not normalize arbitrary caller-provided methods.
-  for (final method in ['CUSTOM', 'get', 'GeT']) {
+  for (final method in ['CUSTOM', 'custom', 'CuStOm']) {
     test('preserves existing behavior for caller method $method', () async {
       await verifyRequest(method, (c, u) => c.openUrl(method, u), known: false);
+    });
+  }
+  for (final pair in [
+    ('get', 'GET'),
+    ('GeT', 'GET'),
+    ('post', 'POST'),
+    ('PoSt', 'POST'),
+    ('head', 'HEAD'),
+    ('put', 'PUT'),
+    ('delete', 'DELETE'),
+    ('connect', 'CONNECT'),
+    ('options', 'OPTIONS'),
+    ('trace', 'TRACE'),
+    ('patch', 'PATCH'),
+    ('query', 'QUERY'),
+  ]) {
+    final (input, canonical) = pair;
+    for (final useOpenUrl in [true, false]) {
+      test('${useOpenUrl ? 'openUrl' : 'open'} normalizes $input', () async {
+        await verifyRequest(
+          input,
+          (client, url) => useOpenUrl
+              ? client.openUrl(input, url)
+              : client.open(
+                  input,
+                  url.host,
+                  url.port,
+                  '${url.path}?${url.query}',
+                ),
+          normalizedMethod: canonical,
+        );
+      });
+    }
+  }
+
+  for (final input in ['get', 'GeT', 'post', 'PoSt']) {
+    test('records the actual wire method for $input', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final client = FaroHttpTrackingClient(
+        HttpClient()..findProxy = (_) => 'DIRECT',
+        trackingFilter: HttpTrackingFilter()
+          ..configure(collectorUrl: null, ignoreUrls: null),
+      );
+      addTearDown(() async {
+        client.close(force: true);
+        await server.close(force: true);
+      });
+      final received = Completer<String>();
+      server.listen((request) async {
+        received.complete(request.method);
+        await request.drain<void>();
+        request.response.statusCode = 200;
+        await request.response.close();
+      });
+      final request = await client.openUrl(
+        input,
+        Uri.parse('http://127.0.0.1:${server.port}/users/123'),
+      );
+      final response = await request.close();
+      await response.drain<void>();
+      final wireMethod = await received.future;
+      expect(wireMethod, input.toUpperCase());
+      final record = SpanRecord(otelReadOnlySpan: processor.ended.single);
+      expect(record.name(), wireMethod);
+      expect(
+        record.getFaroEventAttributes()['http.request.method'],
+        wireMethod,
+      );
+      expect(record.getFaroEventAttributes()['http.method'], wireMethod);
+      expect(
+        record.getFaroEventAttributes()['http.request.method_original'],
+        input,
+      );
     });
   }
 }

--- a/test/src/integrations/http_span_naming_test.dart
+++ b/test/src/integrations/http_span_naming_test.dart
@@ -1,0 +1,271 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
+import 'package:faro/src/core/pod.dart';
+import 'package:faro/src/faro.dart';
+import 'package:faro/src/integrations/http_tracking_client.dart';
+import 'package:faro/src/integrations/http_tracking_filter.dart';
+import 'package:faro/src/models/span_record.dart';
+import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/session/session_id_provider.dart';
+import 'package:faro/src/tracing/faro_exporter.dart';
+import 'package:faro/src/tracing/faro_tracer.dart';
+import 'package:faro/src/user_actions/telemetry_router.dart';
+import 'package:faro/src/user_actions/user_action_types.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockClient extends Mock implements HttpClient {}
+
+class _MockRequest extends Mock implements HttpClientRequest {}
+
+class _MockResponse extends Mock implements HttpClientResponse {}
+
+class _MockHeaders extends Mock implements HttpHeaders {}
+
+class _RecordingProcessor implements otel.SpanProcessor {
+  final ended = <otel.Span>[];
+  final started = <otel.Span>[];
+
+  @override
+  Future<void> onStart(otel.Span span, otel.Context? parentContext) async =>
+      started.add(span);
+  @override
+  Future<void> onEnd(otel.Span span) async => ended.add(span);
+  @override
+  Future<void> onNameUpdate(otel.Span span, String newName) async {}
+  @override
+  Future<void> shutdown() async {}
+  @override
+  Future<void> forceFlush() async {}
+}
+
+class _RecordingRouter implements TelemetryRouter {
+  final items = <TelemetryItem>[];
+
+  @override
+  void ingest(
+    TelemetryItem item, {
+    required SessionActivityKind activity,
+    bool skipBuffer = false,
+  }) {
+    items.add(item);
+  }
+}
+
+void main() {
+  final processor = _RecordingProcessor();
+
+  setUpAll(() async {
+    registerFallbackValue(Uri.parse('https://example.com'));
+    await otel.OTel.initialize(
+      serviceName: 'http-naming-test',
+      spanProcessor: processor,
+      detectPlatformResources: false,
+      enableMetrics: false,
+      enableLogs: false,
+    );
+  });
+
+  setUp(() {
+    pod.clearScope(tracerScope);
+    processor.started.clear();
+    processor.ended.clear();
+  });
+
+  tearDownAll(() async {
+    pod.clearScope(tracerScope);
+    // ignore: invalid_use_of_visible_for_testing_member
+    await otel.OTel.reset();
+  });
+
+  Future<void> verifyRequest(
+    String method,
+    Future<HttpClientRequest> Function(FaroHttpTrackingClient, Uri) open, {
+    String path = '/users/123?view=details',
+    int statusCode = 200,
+    bool known = true,
+  }) async {
+    final url = Uri.parse('http://example.com$path');
+    final innerClient = _MockClient();
+    final filter = HttpTrackingFilter()
+      ..configure(collectorUrl: null, ignoreUrls: null);
+    final client = FaroHttpTrackingClient(innerClient, trackingFilter: filter);
+    final request = _MockRequest();
+    final response = _MockResponse();
+    final requestHeaders = _MockHeaders();
+    final responseHeaders = _MockHeaders();
+    when(() => request.headers).thenReturn(requestHeaders);
+    when(() => request.method).thenReturn(method);
+    when(() => request.uri).thenReturn(url);
+    when(() => request.contentLength).thenReturn(0);
+    when(request.close).thenAnswer((_) async => response);
+    when(() => request.done).thenAnswer((_) async => response);
+    when(() => response.statusCode).thenReturn(statusCode);
+    when(() => response.headers).thenReturn(responseHeaders);
+    when(() => responseHeaders.contentLength).thenReturn(0);
+    when(() => responseHeaders.contentType).thenReturn(null);
+    when(
+      () => response.listen(
+        any(),
+        onError: any(named: 'onError'),
+        onDone: any(named: 'onDone'),
+        cancelOnError: any(named: 'cancelOnError'),
+      ),
+    ).thenAnswer((invocation) {
+      return const Stream<List<int>>.empty().listen(
+        invocation.positionalArguments[0] as void Function(List<int>)?,
+        onError: invocation.namedArguments[#onError] as Function?,
+        onDone: invocation.namedArguments[#onDone] as void Function()?,
+        cancelOnError: invocation.namedArguments[#cancelOnError] as bool?,
+      );
+    });
+
+    when(
+      () => innerClient.openUrl(any(), any()),
+    ).thenAnswer((_) async => request);
+
+    await Faro().startSpan('application-operation', (parent) async {
+      final tracked = await open(client, url);
+      final span = processor.started.last;
+      final record = SpanRecord(otelReadOnlySpan: span);
+      final expectedName = known ? method : 'HTTP $method';
+      // Inspect before response completion: naming and method are request data.
+      expect(span.name, expectedName);
+      expect(
+        record.getFaroEventAttributes()['http.request.method'],
+        known ? method : isNull,
+      );
+      verify(() => innerClient.openUrl(method, url)).called(1);
+      verify(
+        () => requestHeaders.add(
+          'traceparent',
+          '00-${span.spanContext.traceId}-${span.spanContext.spanId}-01',
+        ),
+      ).called(1);
+      expect(span.isEnded, isFalse);
+
+      final response = await tracked.close();
+      await response.drain<void>();
+      expect(processor.ended, [same(span)]);
+
+      final router = _RecordingRouter();
+      await FaroExporter(telemetryRouter: router).export([span]);
+      final exported = router.items
+          .singleWhere((item) => item.asSpan != null)
+          .asSpan!
+          .getSpan()
+          .toJson();
+      final attributes = <String, dynamic>{
+        for (final attribute in exported['attributes'] as List<dynamic>)
+          attribute['key'] as String: attribute['value'],
+      };
+      expect(exported['name'], expectedName);
+      expect(exported['kind'], 3);
+      expect(exported['traceId'], parent.traceId);
+      expect(exported['parentSpanId'], parent.spanId);
+      expect(exported['spanId'], isNot(parent.spanId));
+      expect(
+        attributes['http.request.method'],
+        known ? {'stringValue': method} : isNull,
+      );
+      expect(attributes['http.method'], {'stringValue': method});
+      expect(attributes['http.url'], {'stringValue': url.toString()});
+      expect(attributes, isNot(contains('url.template')));
+      expect(exported['status'], {'code': statusCode >= 400 ? 2 : 0});
+      expect(
+        attributes['error.type'],
+        statusCode >= 400 ? {'stringValue': '$statusCode'} : isNull,
+      );
+
+      final event = router.items
+          .singleWhere((item) => item.asEvent != null)
+          .asEvent!;
+      final sessionId = pod.resolve(sessionIdProviderProvider).sessionId;
+      expect(event.name, 'faro.tracing.fetch');
+      expect(event.trace, {
+        'trace_id': exported['traceId'],
+        'span_id': exported['spanId'],
+      });
+      expect(event.attributes!['http.request.method'], known ? method : isNull);
+      expect(event.attributes!['http.method'], method);
+      expect(event.attributes!['session.id'], sessionId);
+      expect(attributes['session.id'], {'stringValue': sessionId});
+      final duration =
+          BigInt.parse(exported['endTimeUnixNano'] as String) -
+          BigInt.parse(exported['startTimeUnixNano'] as String);
+      expect(BigInt.parse(event.attributes!['duration_ns']!), duration);
+      expect(duration >= BigInt.zero, isTrue);
+      expect(router.items, hasLength(2));
+    });
+  }
+
+  for (final method in [
+    'GET',
+    'HEAD',
+    'POST',
+    'PUT',
+    'DELETE',
+    'CONNECT',
+    'OPTIONS',
+    'TRACE',
+    'PATCH',
+    'QUERY',
+  ]) {
+    test('openUrl exports $method without a target', () async {
+      await verifyRequest(method, (client, url) => client.openUrl(method, url));
+    });
+    test('open exports $method without a target', () async {
+      await verifyRequest(
+        method,
+        (client, url) =>
+            client.open(method, url.host, url.port, '${url.path}?${url.query}'),
+      );
+    });
+  }
+
+  final wrappers =
+      <String, Future<HttpClientRequest> Function(FaroHttpTrackingClient, Uri)>{
+        'get': (c, u) => c.get(u.host, u.port, '${u.path}?${u.query}'),
+        'getUrl': (c, u) => c.getUrl(u),
+        'post': (c, u) => c.post(u.host, u.port, '${u.path}?${u.query}'),
+        'postUrl': (c, u) => c.postUrl(u),
+        'head': (c, u) => c.head(u.host, u.port, '${u.path}?${u.query}'),
+        'headUrl': (c, u) => c.headUrl(u),
+        'put': (c, u) => c.put(u.host, u.port, '${u.path}?${u.query}'),
+        'putUrl': (c, u) => c.putUrl(u),
+        'delete': (c, u) => c.delete(u.host, u.port, '${u.path}?${u.query}'),
+        'deleteUrl': (c, u) => c.deleteUrl(u),
+        'patch': (c, u) => c.patch(u.host, u.port, '${u.path}?${u.query}'),
+        'patchUrl': (c, u) => c.patchUrl(u),
+      };
+  for (final entry in wrappers.entries) {
+    test('${entry.key} uses a canonical method', () async {
+      await verifyRequest(
+        entry.key.replaceAll('Url', '').toUpperCase(),
+        entry.value,
+      );
+    });
+  }
+
+  for (final method in ['GET', 'POST']) {
+    for (final status in [200, 404, 500]) {
+      test('$method name ignores URL and response $status', () async {
+        await verifyRequest(
+          method,
+          (c, u) => c.openUrl(method, u),
+          path: '/orders/another-id?sort=recent',
+          statusCode: status,
+        );
+      });
+    }
+  }
+
+  // This scoped change must not normalize arbitrary caller-provided methods.
+  for (final method in ['CUSTOM', 'get', 'GeT']) {
+    test('preserves existing behavior for caller method $method', () async {
+      await verifyRequest(method, (c, u) => c.openUrl(method, u), known: false);
+    });
+  }
+}

--- a/test/src/integrations/http_tracking_client_test.dart
+++ b/test/src/integrations/http_tracking_client_test.dart
@@ -5,6 +5,7 @@ import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/integrations/http_tracking_client.dart';
 import 'package:faro/src/integrations/http_tracking_filter.dart';
 import 'package:faro/src/session/session_activity_kind.dart';
+import 'package:faro/src/tracing/faro_tracer.dart';
 import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/user_actions/telemetry_router.dart';
 import 'package:faro/src/user_actions/user_action_types.dart';
@@ -60,10 +61,17 @@ void main() {
       client = FaroHttpTrackingClient(
         mockHttpClient,
         trackingFilter: trackingFilter,
+        startHttpSpan: pod.resolve(faroHttpTracerProvider).startSpanManual,
       );
     });
 
     test('should bypass tracking when filter rejects URL', () async {
+      client = FaroHttpTrackingClient(
+        mockHttpClient,
+        trackingFilter: trackingFilter,
+        startHttpSpan: (name, {required attributes}) =>
+            throw StateError('Filtered requests must not start spans'),
+      );
       trackingFilter.configure(
         collectorUrl: 'http://example.com/path',
         ignoreUrls: null,

--- a/test/src/models/span_record_test.dart
+++ b/test/src/models/span_record_test.dart
@@ -52,6 +52,28 @@ void main() {
 
   group('SpanRecord:', () {
     group('getFaroEventName:', () {
+      for (final attributes in [
+        {'http.request.method': 'GET'},
+        {'http.request.method': 'GET', 'http.method': 'GET'},
+      ]) {
+        test(
+          'recognizes HTTP attributes $attributes with method-only name',
+          () {
+            final span = makeEndedSpan('GET', attributes: attributes);
+            final record = SpanRecord(otelReadOnlySpan: span);
+            expect(record.getFaroEventName(), 'faro.tracing.fetch');
+          },
+        );
+      }
+
+      test('does not classify a custom span named GET as HTTP', () {
+        final span = makeEndedSpan('GET');
+        expect(
+          SpanRecord(otelReadOnlySpan: span).getFaroEventName(),
+          'span.GET',
+        );
+      });
+
       test('returns "faro.tracing.fetch" for HTTP spans with http.scheme', () {
         final span = makeEndedSpan(
           'HTTP GET',

--- a/test/src/models/span_record_test.dart
+++ b/test/src/models/span_record_test.dart
@@ -52,16 +52,37 @@ void main() {
 
   group('SpanRecord:', () {
     group('getFaroEventName:', () {
-      for (final attributes in [
-        {'http.request.method': 'GET'},
-        {'http.request.method': 'GET', 'http.method': 'GET'},
+      test('recognizes the HTTP instrumentation scope without attributes', () {
+        final span = otel.OTel.tracerProvider()
+            .getTracer('faro-mobile-flutter.http')
+            .startSpan('GET');
+        span.end();
+        expect(
+          SpanRecord(otelReadOnlySpan: span).getFaroEventName(),
+          'faro.tracing.fetch',
+        );
+      });
+
+      for (final scope in [
+        'faro-mobile-flutter',
+        'faro-mobile-flutter.http.custom',
       ]) {
         test(
-          'recognizes HTTP attributes $attributes with method-only name',
+          'stable HTTP attributes do not classify scope $scope as fetch',
           () {
-            final span = makeEndedSpan('GET', attributes: attributes);
-            final record = SpanRecord(otelReadOnlySpan: span);
-            expect(record.getFaroEventName(), 'faro.tracing.fetch');
+            final span = otel.OTel.tracerProvider()
+                .getTracer(scope)
+                .startSpan(
+                  'checkout',
+                  attributes: otel.OTel.attributesFromMap({
+                    'http.request.method': 'GET',
+                  }),
+                );
+            span.end();
+            expect(
+              SpanRecord(otelReadOnlySpan: span).getFaroEventName(),
+              'span.checkout',
+            );
           },
         );
       }

--- a/test/src/tracing/faro_otel_bootstrap_test.dart
+++ b/test/src/tracing/faro_otel_bootstrap_test.dart
@@ -1,7 +1,10 @@
 // ignore_for_file: lines_longer_than_80_chars
 
+import 'dart:io';
+
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/core/pod.dart';
+import 'package:faro/src/integrations/http_tracking_client.dart';
 import 'package:faro/src/models/models.dart';
 import 'package:faro/src/session/session_activity_kind.dart';
 import 'package:faro/src/tracing/faro_otel_bootstrap.dart';
@@ -52,6 +55,50 @@ void main() {
   });
 
   group('FaroOtelBootstrap:', () {
+    test('an existing HTTP client picks up initialization and reset', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((request) async {
+        await request.drain<void>();
+        await request.response.close();
+      });
+      final client = FaroHttpOverrides(null).createHttpClient(null)
+        ..findProxy = (_) => 'DIRECT';
+      addTearDown(() async {
+        client.close(force: true);
+        await server.close(force: true);
+      });
+      final url = Uri.parse('http://127.0.0.1:${server.port}/lifecycle');
+      Future<void> request() async {
+        final request = await client.getUrl(url);
+        final response = await request.close();
+        await response.drain<void>();
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      await request();
+      expect(router.ingested, isEmpty);
+      for (var cycle = 0; cycle < 2; cycle++) {
+        await FaroOtelBootstrap.initialize();
+        await request();
+        final record = router.ingested
+            .singleWhere((item) => item.asSpan != null)
+            .asSpan!;
+        expect(record.getScope().toJson()['name'], 'faro-mobile-flutter.http');
+        expect(record.name(), 'GET');
+        expect(
+          router.ingested.singleWhere((i) => i.asEvent != null).asEvent!.name,
+          'faro.tracing.fetch',
+        );
+        await FaroOtelBootstrap.resetForTesting();
+        router.ingested.clear();
+        pod.overrideProvider<otel.SpanProcessor>(
+          faroSpanProcessorProvider,
+          (_) => throw StateError('placeholder'),
+        );
+        pod.removeOverride(faroSpanProcessorProvider);
+      }
+    });
+
     test('initialize is idempotent — second call is a no-op that does not '
         'hang and leaves a working tracer', () async {
       // Regression test: the original implementation called OTel.reset()


### PR DESCRIPTION
## Description

Automatically instrumented HTTP client spans use known-method names such as `GET` and `POST` instead of `HTTP GET` and `HTTP POST`. Known methods supplied in lowercase or mixed case are normalized to uppercase, matching Dart's HTTP client, with the supplied spelling recorded in `http.request.method_original` when it differs. Spans and their accompanying events include `http.request.method`, while retaining `http.method` for compatibility.

Automatic HTTP spans use the `faro-mobile-flutter.http` instrumentation scope to identify their accompanying `faro.tracing.fetch` events. An injected callback resolves the HTTP tracer per request so clients created before initialization continue working after initialization or reset. WebView and custom spans carrying only `http.request.method` keep their `span.<name>` events; existing classification based on legacy HTTP attributes is preserved.

Reference documentation and the changelog cover method behavior, event classification, and span-name/scope query migration. URL templates and unknown-method normalization remain outside this change.

## Related Issue(s)

Fixes #109
Related to #346

## Type of Change

- [x] 🛠️ Bug fix
- [x] 💥 Breaking change: queries filtering by span name or instrumentation scope must account for the new values
- [x] 📝 Documentation

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Additional Notes

Implemented with failing regression tests first. Coverage includes casing, exact-scope event classification, real WebView bridge exports, ignored requests, clients reused across initialization/reset, and parent/session correlation across instrumentation scopes. All six pre-release gates pass, including the full Flutter suite and Android native unit tests.

The naming changes were verified with the SDK example and QuickPizza Flutter on Android and iOS. Final scope/classification verification ran both apps on Android API 35: 16 selected spans and 16 correlated events matched emitted payloads and stored Loki/Tempo data, including names, scopes, attributes, durations, status, session IDs, and parent-child links. The cases covered HTTP success/error responses, mixed-case and custom methods, WebView lifetimes, and stable/legacy custom-span attributes. Final scope changes were not rerun on iOS or through the Grafana UI. Temporary verification harnesses and dependency overrides were removed.
