### PR TITLE
feat(http): adopt stable span attributes and redact HTTP URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Known HTTP methods include `http.request.method`** on spans and
-  `faro.tracing.fetch` events. The legacy `http.method` attribute remains
-  available for compatibility
+  `faro.tracing.fetch` events
   ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
 
 ### Changed
+
+- **HTTP spans and events use stable attribute names**, including `url.full`,
+  `server.address`, `server.port`, and `http.response.status_code`. Legacy
+  HTTP fields are removed from automatic requests. Events keep string values
+  and their `faro.tracing.fetch` name. Update telemetry consumers before
+  adopting this breaking private-preview schema. See the Reference docs for
+  the complete payload and migration details
+  ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
 
 - **Known HTTP client span names are method-only**, such as `GET` and
   `POST`, instead of `HTTP GET` and `HTTP POST`. HTTP convenience methods use
@@ -37,14 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   produce `GET`. When the spelling differs from the canonical method, spans
   and events record it in `http.request.method_original`
   ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
-- **HTTP spans now record `http.status_code` 0 on network failures.**
-  Requests that never receive a response (DNS failure, connection error,
-  dropped body, failed upload, or abort, including `abort()` with no
-  exception) were omitted from Grafana Frontend Observability HTTP and
-  network-error views. Those views key off `http.status_code` and treat `0`
-  as a network error, matching the Faro Web SDK. 4xx/5xx responses also
-  mark the span as error
-  ([#183](https://github.com/grafana/faro-flutter-sdk/issues/183)).
+- **HTTP failures without a response omit the response code** and include
+  the exception type in `error.type`. Spans remain errors and their events
+  carry the same failure signal. Consumers must use `error.type` rather than
+  a synthetic status code of 0
+  ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
+- **HTTP URLs redact credentials and sensitive query values** in spans and
+  events, without changing the request sent to the server. See the Reference
+  docs for the sanitization policy
+  ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
 - **Successful HTTP spans leave status unset**, following OpenTelemetry HTTP
   conventions. Response completion preserves any previously recorded error
   ([#24](https://github.com/grafana/faro-flutter-sdk/issues/24)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **HTTP spans and events use stable attribute names**, including `url.full`,
+- **HTTP spans use stable attribute names**, including `url.full`,
   `server.address`, `server.port`, and `http.response.status_code`. Legacy
-  HTTP fields are removed from automatic requests. Events keep string values
-  and their `faro.tracing.fetch` name. Update telemetry consumers before
-  adopting this breaking private-preview schema. See the Reference docs for
-  the complete payload and migration details
+  HTTP fields are removed from automatic spans. The `faro.tracing.fetch`
+  event retains its existing fields and values for consumer compatibility.
+  Update span consumers before adopting this private-preview schema.
+  See the Reference docs for details
   ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
 
 - **Known HTTP client span names are method-only**, such as `GET` and
@@ -44,14 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   produce `GET`. When the spelling differs from the canonical method, spans
   and events record it in `http.request.method_original`
   ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).
-- **HTTP failures without a response omit the response code** and include
-  the exception type in `error.type`. Spans remain errors and their events
-  carry the same failure signal. Consumers must use `error.type` rather than
-  a synthetic status code of 0
+- **HTTP spans without a response omit the response code** and include
+  the exception type in `error.type`. Faro HTTP events retain the legacy
+  `http.status_code` value of `"0"`
   ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
-- **HTTP URLs redact credentials and sensitive query values** in spans and
-  events, without changing the request sent to the server. See the Reference
-  docs for the sanitization policy
+- **HTTP span URLs redact credentials and sensitive query values**,
+  without changing the request sent to the server. Faro HTTP event URLs
+  retain their previous behavior. See the Reference docs for the policy
   ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
 - **Successful HTTP spans leave status unset**, following OpenTelemetry HTTP
   conventions. Response completion preserves any previously recorded error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the exception type in `error.type`. Faro HTTP events retain the legacy
   `http.status_code` value of `"0"`
   ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
-- **HTTP span and event URLs redact credentials and sensitive query values**,
-  without changing the request sent to the server. Exact URL filters and
-  grouping use the redacted values. See the Reference docs for the policy
+- **HTTP telemetry URLs redact credentials and sensitive query values** in
+  spans, events and fallback network-error logs, including common token,
+  password and API-key query parameters. The request URL is unchanged. Exact
+  URL filters and grouping use the redacted values. See the Reference docs
+  for the policy
   ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
 - **Successful HTTP spans leave status unset**, following OpenTelemetry HTTP
   conventions. Response completion preserves any previously recorded error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **HTTP spans use stable attribute names**, including `url.full`,
   `server.address`, `server.port`, and `http.response.status_code`. Legacy
   HTTP fields are removed from automatic spans. The `faro.tracing.fetch`
-  event retains its existing fields and values for consumer compatibility.
+  event retains its existing fields, with URL redaction as described below.
   Update span consumers before adopting this private-preview schema.
   See the Reference docs for details
   ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
@@ -48,9 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the exception type in `error.type`. Faro HTTP events retain the legacy
   `http.status_code` value of `"0"`
   ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
-- **HTTP span URLs redact credentials and sensitive query values**,
-  without changing the request sent to the server. Faro HTTP event URLs
-  retain their previous behavior. See the Reference docs for the policy
+- **HTTP span and event URLs redact credentials and sensitive query values**,
+  without changing the request sent to the server. Exact URL filters and
+  grouping use the redacted values. See the Reference docs for the policy
   ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
 - **Successful HTTP spans leave status unset**, following OpenTelemetry HTTP
   conventions. Response completion preserves any previously recorded error

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -797,6 +797,8 @@ and the following query values with `REDACTED`:
 - `X-Amz-Signature`
 - `X-Amz-Credential`
 - `X-Amz-Security-Token`
+- `AWSAccessKeyId`
+- `Signature`
 - `sig`
 - `X-Goog-Signature`
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -791,9 +791,9 @@ attributes contain its actual code, including after a body failure.
 
 ### HTTP URL sanitization
 
-The span's `url.full` and event's `http.url` replace URL user information
-with `REDACTED:REDACTED`
-and the following query values with `REDACTED`:
+HTTP spans (`url.full`), HTTP events (`http.url`) and fallback `network_error`
+logs replace URL user information with `REDACTED:REDACTED` and the following
+query values with `REDACTED`:
 
 - `X-Amz-Signature`
 - `X-Amz-Credential`
@@ -802,6 +802,9 @@ and the following query values with `REDACTED`:
 - `Signature`
 - `sig`
 - `X-Goog-Signature`
+- `token`, `access_token`, `refresh_token`
+- `api_key`, `apikey`
+- `password`, `client_secret`
 
 Matching uses decoded, case-sensitive keys and covers repeated parameters.
 Other query parameters, the path and the fragment use their original values.

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -744,12 +744,11 @@ including WebView lifetime spans, produce `span.<name>` events.
 Automatically instrumented HTTP client spans use the request method as their
 name for `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`,
 `PATCH`, and `QUERY`. For example, a request to `/users/123` using `GET`
-produces a span named `GET`. The URL is recorded separately in `http.url`;
+produces a span named `GET`. The URL is recorded separately in `url.full`;
 URL templates are not supported.
 
-For these methods, spans and HTTP events include the string attributes
-`http.request.method` and `http.method`, both set to the method name.
-`http.method` is a compatibility alias. HTTP events use the name
+For these methods, spans and HTTP events include `http.request.method`,
+set to the method name. HTTP events use the name
 `faro.tracing.fetch` and include `duration_ns`, trace/span IDs, and session
 attributes for correlation.
 
@@ -761,7 +760,100 @@ such as `getUrl()` and `postUrl()` use uppercase verbs.
 
 For other method values passed to `open()` or `openUrl()`, the SDK
 uses `HTTP <method>` as the span name and records the supplied value in
-`http.method`, without adding `http.request.method` or changing its case.
+`http.request.method` without changing its case. This preserves the existing
+unknown-method value and naming behavior while migrating the attribute key.
+Unknown-method normalization to `_OTHER` and a configurable known-method list
+remain outside this migration; this is not full HTTP semconv conformance.
+
+
+### HTTP span and event attributes
+
+The private-preview HTTP schema uses the following attributes. Request fields
+are set when the span starts. The outer Faro payload structure is unchanged.
+
+| Attribute | Span type | HTTP event type | Availability |
+| --- | --- | --- | --- |
+| `http.request.method` | string | string | Request start; method behavior described above |
+| `http.request.method_original` | string | string | When a known method's spelling was normalized |
+| `url.full` | string | string | Request start; sanitized absolute request URL |
+| `server.address` | string | string | Request start; URI host without port or IPv6 brackets |
+| `server.port` | integer | decimal string | Request start; effective port, including HTTP 80 and HTTPS 443 defaults |
+| `http.response.status_code` | integer | decimal string | Only when an actual response is received |
+| `error.type` | string | string | HTTP error code or exception type; absent on ordinary success |
+| `duration_ns` | Not added; derived from timestamps | decimal string | Ended span with a valid time interval |
+
+Successful requests leave span status UNSET. HTTP error responses (400 and
+above) set ERROR and a string code such as `"404"` in `error.type`, without a
+redundant code-only status description. Failures without a response set ERROR
+and use `error.runtimeType.toString()` (for example `SocketException` or
+`HttpException`) for `error.type`; the response code is absent, never 0.
+Later failures preserve an already recorded error and its diagnostic information.
+An error while reading a response preserves its actual response code.
+
+Events also retain the span's other attributes as strings, including session
+correlation. The event's `trace` object carries `trace_id` and `span_id`.
+Existing user-action name/parent attributes are moved into the event's `action`
+object by the exporter. For example, the HTTP-owned portion of a 404 event is:
+
+```json
+{
+  "name": "faro.tracing.fetch",
+  "attributes": {
+    "http.request.method": "GET",
+    "url.full": "https://example.com/missing",
+    "server.address": "example.com",
+    "server.port": "443",
+    "http.response.status_code": "404",
+    "error.type": "404",
+    "duration_ns": "25000000"
+  },
+  "trace": {
+    "trace_id": "0123456789abcdef0123456789abcdef",
+    "span_id": "0123456789abcdef"
+  }
+}
+```
+
+This fragment omits the event timestamp, session metadata and optional action
+context. On the corresponding span, port and response code use `intValue`;
+the method, URL, address and error type use `stringValue`.
+
+### HTTP URL sanitization
+
+URL user information is replaced with `REDACTED:REDACTED`. Query values for
+`X-Amz-Signature`, `X-Amz-Credential`, `X-Amz-Security-Token`, `sig`, and
+`X-Goog-Signature` are replaced with `REDACTED`. Matching uses decoded,
+case-sensitive keys, including repeated keys. Other query parameters, the path
+and the fragment are retained. This follows the defaults in
+[HTTP semconv 1.44.0](https://opentelemetry.io/docs/specs/semconv/http/http-spans/).
+The policy does not identify arbitrary application-specific secrets in URLs.
+Only the telemetry copy is sanitized; the actual request URI is unchanged.
+
+### Migrating HTTP consumers
+
+Automatic HTTP spans and their events no longer emit `http.method`, `http.url`,
+`http.host`, `http.status_code`, `http.scheme`, `http.user_agent`,
+`http.content_type`, `http.request_size`, or `http.response_size`. Existing
+custom-span attributes are not rewritten. Scheme remains available in
+`url.full`; user agent, content type and body-size fields have no replacement
+in this focused schema. In particular, old Content-Length values must not be
+renamed to total request/response sizes: they do not measure headers or framing.
+
+Consumers must prefer the stable method, URL, address and response-code fields,
+with fallbacks to legacy fields for historical data and other SDK versions.
+Absence must be checked explicitly: some storage types default missing numeric
+fields to 0. Keep missing responses distinct from an actual HTTP response.
+Use `error.type` to detect new failure events, including failures with a 200
+response followed by a body error; retain legacy status-0 handling for old data.
+A present error type indicates failure even when the status code is absent.
+Do not synthesize a stable response code during migration.
+
+Update URL processing, typed storage schemas, HTTP queries, alert rules, and
+trace navigation before adopting the incompatible SDK payload. Host grouping
+must account for `server.address` excluding ports, with `server.port` available
+separately. New SDKs emit no temporary legacy aliases. Historical data is not
+rewritten and other producers can continue emitting legacy fields. See
+[#346](https://github.com/grafana/faro-flutter-sdk/issues/346) for migration scope.
 
 ---
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -768,92 +768,89 @@ remain outside this migration; this is not full HTTP semconv conformance.
 
 ### HTTP span and event attributes
 
-The private-preview HTTP schema uses the following attributes. Request fields
-are set when the span starts. The outer Faro payload structure is unchanged.
+Automatic HTTP spans use stable OpenTelemetry attributes. Faro HTTP events
+retain their existing contract independently of the span schema. The outer
+Faro payload, event name `faro.tracing.fetch`, trace/span IDs, duration, session
+metadata and user-action correlation are unchanged.
 
-| Attribute | Span type | HTTP event type | Availability |
-| --- | --- | --- | --- |
-| `http.request.method` | string | string | Request start; method behavior described above |
-| `http.request.method_original` | string | string | When a known method's spelling was normalized |
-| `url.full` | string | string | Request start; sanitized absolute request URL |
-| `server.address` | string | string | Request start; URI host without port or IPv6 brackets |
-| `server.port` | integer | decimal string | Request start; effective port, including HTTP 80 and HTTPS 443 defaults |
-| `http.response.status_code` | integer | decimal string | Only when an actual response is received |
-| `error.type` | string | string | HTTP error code or exception type; absent on ordinary success |
-| `duration_ns` | Not added; derived from timestamps | decimal string | Ended span with a valid time interval |
+| Data | Span attribute | Faro event attribute |
+| --- | --- | --- |
+| Method | `http.request.method` | `http.method`; also `http.request.method` for known methods |
+| Original known method | `http.request.method_original` | `http.request.method_original` |
+| URL | `url.full` (sanitized) | `http.url` (original URL) |
+| Host | `server.address` | `http.host` |
+| Effective port | `server.port` (integer, including default 80/443) | No new field |
+| Response status | `http.response.status_code` (integer, actual responses only) | `http.status_code` (string; `"0"` on failures without a response) |
+| Duration | Span timestamps | `duration_ns` (string, nanoseconds) |
 
-Successful requests leave span status UNSET. HTTP error responses (400 and
-above) set ERROR and a string code such as `"404"` in `error.type`, without a
-redundant code-only status description. Failures without a response set ERROR
-and use `error.runtimeType.toString()` (for example `SocketException` or
-`HttpException`) for `error.type`; the response code is absent, never 0.
-Later failures preserve an already recorded error and its diagnostic information.
-An error while reading a response preserves its actual response code.
+Events also retain `http.scheme`, `http.user_agent`, `http.request_size`,
+`http.response_size` and `http.content_type`, including their previous string
+values and availability. These fields are not added to the span. Size fields
+retain their Content-Length meaning, including unknown lengths; they do not
+measure headers or total wire size. Other span attributes, such as session
+correlation, are copied as before. User-action fields are moved into the event's
+`action` object by the exporter.
 
-Events also retain the span's other attributes as strings, including session
-correlation. The event's `trace` object carries `trace_id` and `span_id`.
-Existing user-action name/parent attributes are moved into the event's `action`
-object by the exporter. For example, the HTTP-owned portion of a 404 event is:
+Successful spans leave status UNSET. HTTP responses of 400 and above set ERROR
+and a string code such as `"404"` in `error.type`, on both the span and event.
+Failures without a response set span ERROR with the exception type in
+`error.type`, while omitting the span response code. Events preserve the legacy
+status `"0"` and do not gain the newly generated exception-type attribute.
+Body failures retain the actual response code. Spans record their exception
+error type, while events keep the prior HTTP event behavior. Previously
+recorded error types are preserved.
+
+For example, the HTTP portion of a 404 event retains this shape:
 
 ```json
 {
   "name": "faro.tracing.fetch",
   "attributes": {
     "http.request.method": "GET",
-    "url.full": "https://example.com/missing",
-    "server.address": "example.com",
-    "server.port": "443",
-    "http.response.status_code": "404",
+    "http.method": "GET",
+    "http.url": "https://example.com/missing",
+    "http.host": "example.com",
+    "http.scheme": "https",
+    "http.user_agent": "Dart/3.12 (dart:io)",
+    "http.status_code": "404",
+    "http.request_size": "0",
+    "http.response_size": "0",
+    "http.content_type": "null",
     "error.type": "404",
     "duration_ns": "25000000"
-  },
-  "trace": {
-    "trace_id": "0123456789abcdef0123456789abcdef",
-    "span_id": "0123456789abcdef"
   }
 }
 ```
 
-This fragment omits the event timestamp, session metadata and optional action
-context. On the corresponding span, port and response code use `intValue`;
-the method, URL, address and error type use `stringValue`.
+This fragment omits timestamp, trace context, session metadata and optional
+user-action context. All event attribute values remain strings.
 
-### HTTP URL sanitization
+### HTTP span URL sanitization
 
-URL user information is replaced with `REDACTED:REDACTED`. Query values for
-`X-Amz-Signature`, `X-Amz-Credential`, `X-Amz-Security-Token`, `sig`, and
-`X-Goog-Signature` are replaced with `REDACTED`. Matching uses decoded,
-case-sensitive keys, including repeated keys. Other query parameters, the path
-and the fragment are retained. This follows the defaults in
+In `url.full`, URL user information is replaced with `REDACTED:REDACTED`.
+Query values for `X-Amz-Signature`, `X-Amz-Credential`, `X-Amz-Security-Token`,
+`sig`, and `X-Goog-Signature` are replaced with `REDACTED`. Matching uses decoded,
+case-sensitive keys, including repeated keys. Other query parameters, path and
+fragment are retained. This follows the defaults in
 [HTTP semconv 1.44.0](https://opentelemetry.io/docs/specs/semconv/http/http-spans/).
-The policy does not identify arbitrary application-specific secrets in URLs.
-Only the telemetry copy is sanitized; the actual request URI is unchanged.
+It does not identify arbitrary application-specific secrets in URLs.
+The actual request and the legacy event's `http.url` are unchanged by this
+span-only policy.
 
-### Migrating HTTP consumers
+### Migrating span consumers
 
-Automatic HTTP spans and their events no longer emit `http.method`, `http.url`,
-`http.host`, `http.status_code`, `http.scheme`, `http.user_agent`,
-`http.content_type`, `http.request_size`, or `http.response_size`. Existing
-custom-span attributes are not rewritten. Scheme remains available in
-`url.full`; user agent, content type and body-size fields have no replacement
-in this focused schema. In particular, old Content-Length values must not be
-renamed to total request/response sizes: they do not measure headers or framing.
+Automatic spans no longer contain `http.method`, `http.url`, `http.host`,
+`http.status_code`, `http.scheme`, `http.user_agent`, `http.content_type`,
+`http.request_size`, or `http.response_size`. Existing custom spans are not
+rewritten. Span consumers should prefer the stable fields with legacy fallbacks
+for historical data and other SDK versions. Check response-code presence
+explicitly and use `error.type` for failures, including body failures after a
+successful response. Host grouping uses `server.address`, with `server.port`
+available separately.
 
-Consumers must prefer the stable method, URL, address and response-code fields,
-with fallbacks to legacy fields for historical data and other SDK versions.
-Absence must be checked explicitly: some storage types default missing numeric
-fields to 0. Keep missing responses distinct from an actual HTTP response.
-Use `error.type` to detect new failure events, including failures with a 200
-response followed by a body error; retain legacy status-0 handling for old data.
-A present error type indicates failure even when the status code is absent.
-Do not synthesize a stable response code during migration.
-
-Update URL processing, typed storage schemas, HTTP queries, alert rules, and
-trace navigation before adopting the incompatible SDK payload. Host grouping
-must account for `server.address` excluding ports, with `server.port` available
-separately. New SDKs emit no temporary legacy aliases. Historical data is not
-rewritten and other producers can continue emitting legacy fields. See
-[#346](https://github.com/grafana/faro-flutter-sdk/issues/346) for migration scope.
+HTTP event queries and event storage retain their existing schema. Span URL
+processing, trace filters and trace navigation still need to support the new
+span attributes. See [#346](https://github.com/grafana/faro-flutter-sdk/issues/346).
 
 ---
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -767,7 +767,7 @@ except for the integer port and response status.
 | --- | --- | --- |
 | Method | `http.request.method` | `http.method`; also `http.request.method` for known methods |
 | Original spelling of a normalized method | `http.request.method_original` | `http.request.method_original` |
-| URL | `url.full` (sanitized) | `http.url` (original request URL) |
+| URL | `url.full` (sanitized) | `http.url` (sanitized) |
 | Host without port | `server.address` | `http.host` |
 | Effective port, including defaults 80/443 | `server.port` (integer) | — |
 | Response status | `http.response.status_code` (integer, only with a response) | `http.status_code`; `"0"` for failures without a response |
@@ -789,9 +789,10 @@ type in `error.type`, unless the span already has an error. These failures do
 not add exception types to HTTP events. When a response exists, both status-code
 attributes contain its actual code, including after a body failure.
 
-### HTTP span URL sanitization
+### HTTP URL sanitization
 
-The span's `url.full` replaces URL user information with `REDACTED:REDACTED`
+The span's `url.full` and event's `http.url` replace URL user information
+with `REDACTED:REDACTED`
 and the following query values with `REDACTED`:
 
 - `X-Amz-Signature`
@@ -804,7 +805,7 @@ and the following query values with `REDACTED`:
 
 Matching uses decoded, case-sensitive keys and covers repeated parameters.
 Other query parameters, the path and the fragment use their original values.
-The request sent to the server and the event's `http.url` use the original URL.
+The request sent to the server uses the original URL.
 
 ---
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -736,7 +736,7 @@ Automatically instrumented HTTP spans use the instrumentation scope
 Application spans and WebView lifetime spans use `faro-mobile-flutter`.
 
 The HTTP scope identifies spans whose accompanying event is
-`faro.tracing.fetch`. For compatibility, spans with a nonempty `http.method`
+`faro.tracing.fetch`. Spans with a nonempty `http.method`
 or `http.scheme` also produce fetch events. The `http.request.method`
 attribute alone does not classify a span as an HTTP request. Other spans,
 including WebView lifetime spans, produce `span.<name>` events.
@@ -747,110 +747,62 @@ name for `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`,
 produces a span named `GET`. The URL is recorded separately in `url.full`;
 URL templates are not supported.
 
-For these methods, spans and HTTP events include `http.request.method`,
-set to the method name. HTTP events use the name
-`faro.tracing.fetch` and include `duration_ns`, trace/span IDs, and session
-attributes for correlation.
-
 Known method values passed to `open()` or `openUrl()` are normalized to
 uppercase, matching Dart's HTTP client. For example, `get` and `GeT` produce
 `GET`. When the supplied spelling differs, spans and HTTP events also include
 `http.request.method_original` with that spelling. HTTP convenience methods
 such as `getUrl()` and `postUrl()` use uppercase verbs.
 
-For other method values passed to `open()` or `openUrl()`, the SDK
-uses `HTTP <method>` as the span name and records the supplied value in
-`http.request.method` without changing its case. This preserves the existing
-unknown-method value and naming behavior while migrating the attribute key.
-Unknown-method normalization to `_OTHER` and a configurable known-method list
-remain outside this migration; this is not full HTTP semconv conformance.
-
+For other method values passed to `open()` or `openUrl()`, the span name is
+`HTTP <method>` and `http.request.method` contains the supplied value, including
+its case.
 
 ### HTTP span and event attributes
 
-Automatic HTTP spans use stable OpenTelemetry attributes. Faro HTTP events
-retain their existing contract independently of the span schema. The outer
-Faro payload, event name `faro.tracing.fetch`, trace/span IDs, duration, session
-metadata and user-action correlation are unchanged.
+Automatic HTTP instrumentation records spans and `faro.tracing.fetch` events.
+Event attribute values are strings. The HTTP span attributes below are strings
+except for the integer port and response status.
 
-| Data | Span attribute | Faro event attribute |
+| Data | Span | HTTP event |
 | --- | --- | --- |
 | Method | `http.request.method` | `http.method`; also `http.request.method` for known methods |
-| Original known method | `http.request.method_original` | `http.request.method_original` |
-| URL | `url.full` (sanitized) | `http.url` (original URL) |
-| Host | `server.address` | `http.host` |
-| Effective port | `server.port` (integer, including default 80/443) | No new field |
-| Response status | `http.response.status_code` (integer, actual responses only) | `http.status_code` (string; `"0"` on failures without a response) |
-| Duration | Span timestamps | `duration_ns` (string, nanoseconds) |
+| Original spelling of a normalized method | `http.request.method_original` | `http.request.method_original` |
+| URL | `url.full` (sanitized) | `http.url` (original request URL) |
+| Host without port | `server.address` | `http.host` |
+| Effective port, including defaults 80/443 | `server.port` (integer) | — |
+| Response status | `http.response.status_code` (integer, only with a response) | `http.status_code`; `"0"` for failures without a response |
+| Duration | Start and end timestamps | `duration_ns` (nanoseconds) |
 
-Events also retain `http.scheme`, `http.user_agent`, `http.request_size`,
-`http.response_size` and `http.content_type`, including their previous string
-values and availability. These fields are not added to the span. Size fields
-retain their Content-Length meaning, including unknown lengths; they do not
-measure headers or total wire size. Other span attributes, such as session
-correlation, are copied as before. User-action fields are moved into the event's
-`action` object by the exporter.
+Request attributes are available at span start. HTTP events also include
+`http.scheme` and `http.user_agent`. After a response arrives, events include
+`http.request_size`, `http.response_size` and `http.content_type`. The size
+fields represent Content-Length in bytes, with `-1` for unknown lengths.
+Events carry trace/span IDs in `trace`, session metadata and optional user-action
+context in `action`.
 
-Successful spans leave status UNSET. HTTP responses of 400 and above set ERROR
-and a string code such as `"404"` in `error.type`, on both the span and event.
-Failures without a response set span ERROR with the exception type in
-`error.type`, while omitting the span response code. Events preserve the legacy
-status `"0"` and do not gain the newly generated exception-type attribute.
-Body failures retain the actual response code. Spans record their exception
-error type, while events keep the prior HTTP event behavior. Previously
-recorded error types are preserved.
+Responses below 400 leave span status UNSET. Responses of 400 or higher set
+ERROR and a string response code such as `"404"` in `error.type` on the span and
+event, without a code-only status description. An existing error takes precedence.
 
-For example, the HTTP portion of a 404 event retains this shape:
-
-```json
-{
-  "name": "faro.tracing.fetch",
-  "attributes": {
-    "http.request.method": "GET",
-    "http.method": "GET",
-    "http.url": "https://example.com/missing",
-    "http.host": "example.com",
-    "http.scheme": "https",
-    "http.user_agent": "Dart/3.12 (dart:io)",
-    "http.status_code": "404",
-    "http.request_size": "0",
-    "http.response_size": "0",
-    "http.content_type": "null",
-    "error.type": "404",
-    "duration_ns": "25000000"
-  }
-}
-```
-
-This fragment omits timestamp, trace context, session metadata and optional
-user-action context. All event attribute values remain strings.
+Transport and response-body failures set span status ERROR and use the exception
+type in `error.type`, unless the span already has an error. These failures do
+not add exception types to HTTP events. When a response exists, both status-code
+attributes contain its actual code, including after a body failure.
 
 ### HTTP span URL sanitization
 
-In `url.full`, URL user information is replaced with `REDACTED:REDACTED`.
-Query values for `X-Amz-Signature`, `X-Amz-Credential`, `X-Amz-Security-Token`,
-`sig`, and `X-Goog-Signature` are replaced with `REDACTED`. Matching uses decoded,
-case-sensitive keys, including repeated keys. Other query parameters, path and
-fragment are retained. This follows the defaults in
-[HTTP semconv 1.44.0](https://opentelemetry.io/docs/specs/semconv/http/http-spans/).
-It does not identify arbitrary application-specific secrets in URLs.
-The actual request and the legacy event's `http.url` are unchanged by this
-span-only policy.
+The span's `url.full` replaces URL user information with `REDACTED:REDACTED`
+and the following query values with `REDACTED`:
 
-### Migrating span consumers
+- `X-Amz-Signature`
+- `X-Amz-Credential`
+- `X-Amz-Security-Token`
+- `sig`
+- `X-Goog-Signature`
 
-Automatic spans no longer contain `http.method`, `http.url`, `http.host`,
-`http.status_code`, `http.scheme`, `http.user_agent`, `http.content_type`,
-`http.request_size`, or `http.response_size`. Existing custom spans are not
-rewritten. Span consumers should prefer the stable fields with legacy fallbacks
-for historical data and other SDK versions. Check response-code presence
-explicitly and use `error.type` for failures, including body failures after a
-successful response. Host grouping uses `server.address`, with `server.port`
-available separately.
-
-HTTP event queries and event storage retain their existing schema. Span URL
-processing, trace filters and trace navigation still need to support the new
-span attributes. See [#346](https://github.com/grafana/faro-flutter-sdk/issues/346).
+Matching uses decoded, case-sensitive keys and covers repeated parameters.
+Other query parameters, the path and the fragment use their original values.
+The request sent to the server and the event's `http.url` use the original URL.
 
 ---
 

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -112,7 +112,7 @@ class FaroHttpTrackingClient implements HttpClient {
         'http.request.method': recordedMethod,
         if (isKnownMethod && recordedMethod != method)
           'http.request.method_original': method,
-        'url.full': _sanitizeHttpUrl(url),
+        'url.full': _redactHttpSpanUrl(url),
         'server.address': url.host,
         'server.port': url.port,
         UserActionConstants.pendingOperationKey: true,
@@ -272,13 +272,17 @@ class FaroHttpTrackingClient implements HttpClient {
   Future<HttpClientRequest> putUrl(Uri url) => _openUrl('PUT', url);
 }
 
-// Sanitize only the telemetry copy, preserving the actual request and the
-// encoding/order of non-sensitive query parameters.
-String _sanitizeHttpUrl(Uri url) {
+// Redact the HTTP span URL without changing the request or Faro event URL.
+// OTel HTTP client URL redaction rules (the query-key list is Development):
+// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span
+// Preserve the encoding/order of non-sensitive query parameters.
+String _redactHttpSpanUrl(Uri url) {
   const sensitiveKeys = {
     'X-Amz-Signature',
     'X-Amz-Credential',
     'X-Amz-Security-Token',
+    'AWSAccessKeyId',
+    'Signature',
     'sig',
     'X-Goog-Signature',
   };
@@ -376,7 +380,7 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
           'status_code': '${value.statusCode}',
           'method': innerContext.method,
           'request_size': '${innerContext.contentLength}',
-          'url': _sanitizeHttpUrl(innerContext.uri),
+          'url': innerContext.uri.toString(),
         },
         spanContext: _httpSpan.spanContext,
         onFinish: _finishOperation,

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/integrations/http_tracking_filter.dart';
+import 'package:faro/src/integrations/http_url_redaction.dart';
 import 'package:faro/src/models/log_level.dart';
 import 'package:faro/src/tracing/faro_span_context.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
@@ -112,7 +113,7 @@ class FaroHttpTrackingClient implements HttpClient {
         'http.request.method': recordedMethod,
         if (isKnownMethod && recordedMethod != method)
           'http.request.method_original': method,
-        'url.full': _redactHttpSpanUrl(url),
+        'url.full': redactHttpSpanUrl(url),
         'server.address': url.host,
         'server.port': url.port,
         UserActionConstants.pendingOperationKey: true,
@@ -270,44 +271,6 @@ class FaroHttpTrackingClient implements HttpClient {
 
   @override
   Future<HttpClientRequest> putUrl(Uri url) => _openUrl('PUT', url);
-}
-
-// Redact the HTTP span URL without changing the request or Faro event URL.
-// OTel HTTP client URL redaction rules (the query-key list is Development):
-// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span
-// Preserve the encoding/order of non-sensitive query parameters.
-String _redactHttpSpanUrl(Uri url) {
-  const sensitiveKeys = {
-    'X-Amz-Signature',
-    'X-Amz-Credential',
-    'X-Amz-Security-Token',
-    'AWSAccessKeyId',
-    'Signature',
-    'sig',
-    'X-Goog-Signature',
-  };
-  final query = url.query
-      .split('&')
-      .map((part) {
-        final separator = part.indexOf('=');
-        final key = separator < 0 ? part : part.substring(0, separator);
-        try {
-          if (sensitiveKeys.contains(Uri.decodeQueryComponent(key))) {
-            return '$key=REDACTED';
-          }
-        } on FormatException {
-          // Invalid UTF-8 cannot match a sensitive key. Do not let telemetry
-          // sanitization prevent the HTTP client from handling the request.
-        }
-        return part;
-      })
-      .join('&');
-  return url
-      .replace(
-        userInfo: url.userInfo.isEmpty ? null : 'REDACTED:REDACTED',
-        query: url.hasQuery ? query : null,
-      )
-      .toString();
 }
 
 void _recordHttpError(Span span, Object error, StackTrace? stackTrace) {

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -135,7 +135,11 @@ class FaroHttpTrackingClient implements HttpClient {
     try {
       // ignore: close_sinks
       final request = await innerClient.openUrl(method, url);
-      return FaroTrackingHttpClientRequest(request, httpSpan: httpSpan);
+      return FaroTrackingHttpClientRequest(
+        request,
+        httpSpan: httpSpan,
+        redactedUrl: redactedUrl,
+      );
     } catch (error, stackTrace) {
       _recordHttpError(httpSpan, error, stackTrace);
       httpSpan.end();
@@ -291,13 +295,18 @@ void _recordHttpError(Span span, Object error, StackTrace? stackTrace) {
 }
 
 class FaroTrackingHttpClientRequest implements HttpClientRequest {
-  FaroTrackingHttpClientRequest(this.innerContext, {required Span httpSpan})
-    : _httpSpan = httpSpan {
+  FaroTrackingHttpClientRequest(
+    this.innerContext, {
+    required Span httpSpan,
+    String? redactedUrl,
+  }) : _httpSpan = httpSpan,
+       _redactedUrl = redactedUrl ?? redactHttpUrl(innerContext.uri) {
     innerContext.headers.add('traceparent', _httpSpan.traceparent);
   }
 
   final HttpClientRequest innerContext;
   final Span _httpSpan;
+  final String _redactedUrl;
   var _operationFinished = false;
 
   void _finishOperation() {
@@ -344,7 +353,7 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
           'status_code': '${value.statusCode}',
           'method': innerContext.method,
           'request_size': '${innerContext.contentLength}',
-          'url': innerContext.uri.toString(),
+          'url': _redactedUrl,
         },
         spanContext: _httpSpan.spanContext,
         onFinish: _finishOperation,

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -107,13 +107,14 @@ class FaroHttpTrackingClient implements HttpClient {
     final upperMethod = method.toUpperCase();
     final isKnownMethod = _knownMethods.contains(upperMethod);
     final recordedMethod = isKnownMethod ? upperMethod : method;
+    final redactedUrl = redactHttpUrl(url);
     final httpSpan = _startHttpSpan(
       isKnownMethod ? recordedMethod : 'HTTP $method',
       attributes: {
         'http.request.method': recordedMethod,
         if (isKnownMethod && recordedMethod != method)
           'http.request.method_original': method,
-        'url.full': redactHttpSpanUrl(url),
+        'url.full': redactedUrl,
         'server.address': url.host,
         'server.port': url.port,
         UserActionConstants.pendingOperationKey: true,
@@ -126,7 +127,7 @@ class FaroHttpTrackingClient implements HttpClient {
         'http.request.method_original': method,
       'http.method': recordedMethod,
       'http.scheme': url.scheme,
-      'http.url': url.toString(),
+      'http.url': redactedUrl,
       'http.host': url.host,
       'http.user_agent': innerClient.userAgent ?? '',
     });

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -8,6 +8,7 @@ import 'package:faro/src/integrations/http_tracking_filter.dart';
 import 'package:faro/src/models/log_level.dart';
 import 'package:faro/src/tracing/faro_span_context.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
+import 'package:faro/src/tracing/http_event_attributes.dart';
 import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/user_actions/constants.dart';
 
@@ -117,6 +118,17 @@ class FaroHttpTrackingClient implements HttpClient {
         UserActionConstants.pendingOperationKey: true,
       },
     );
+
+    initializeHttpEventAttributes(httpSpan, {
+      if (isKnownMethod) 'http.request.method': recordedMethod,
+      if (isKnownMethod && recordedMethod != method)
+        'http.request.method_original': method,
+      'http.method': recordedMethod,
+      'http.scheme': url.scheme,
+      'http.url': url.toString(),
+      'http.host': url.host,
+      'http.user_agent': innerClient.userAgent ?? '',
+    });
 
     try {
       // ignore: close_sinks
@@ -295,6 +307,11 @@ String _sanitizeHttpUrl(Uri url) {
 }
 
 void _recordHttpError(Span span, Object error, StackTrace? stackTrace) {
+  preserveHttpEventErrorType(span);
+  if (span is InternalSpan &&
+      httpEventAttributes(span.otelSpan)?['http.status_code'] == null) {
+    updateHttpEventAttributes(span, {'http.status_code': '0'});
+  }
   // Keep the first error, including an HTTP error recorded before a body
   // failure. Exception types carry failure information without inventing a
   // response code or using high-cardinality exception messages as error.type.
@@ -333,10 +350,20 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
     try {
       final value = await responseFuture();
 
+      preserveHttpEventErrorType(_httpSpan);
+      updateHttpEventAttributes(_httpSpan, {
+        'http.status_code': '${value.statusCode}',
+        'http.request_size': '${innerContext.contentLength}',
+        'http.response_size': '${value.headers.contentLength}',
+        'http.content_type': '${value.headers.contentType}',
+      });
       _httpSpan.setAttribute('http.response.status_code', value.statusCode);
       // Successful responses leave status unset. Preserve an error already
       // recorded on the span instead of replacing its diagnostic information.
       if (value.statusCode >= 400 && _httpSpan.status != SpanStatusCode.error) {
+        updateHttpEventAttributes(_httpSpan, {
+          'error.type': value.statusCode.toString(),
+        });
         _httpSpan.setAttribute('error.type', value.statusCode.toString());
         _httpSpan.setStatus(SpanStatusCode.error);
       }

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -108,15 +108,12 @@ class FaroHttpTrackingClient implements HttpClient {
     final httpSpan = _startHttpSpan(
       isKnownMethod ? recordedMethod : 'HTTP $method',
       attributes: {
-        if (isKnownMethod) 'http.request.method': recordedMethod,
+        'http.request.method': recordedMethod,
         if (isKnownMethod && recordedMethod != method)
           'http.request.method_original': method,
-        // Retain the legacy field until HTTP event/query consumers migrate.
-        'http.method': recordedMethod,
-        'http.scheme': url.scheme,
-        'http.url': url.toString(),
-        'http.host': url.host,
-        'http.user_agent': innerClient.userAgent ?? '',
+        'url.full': _sanitizeHttpUrl(url),
+        'server.address': url.host,
+        'server.port': url.port,
         UserActionConstants.pendingOperationKey: true,
       },
     );
@@ -126,9 +123,7 @@ class FaroHttpTrackingClient implements HttpClient {
       final request = await innerClient.openUrl(method, url);
       return FaroTrackingHttpClientRequest(request, httpSpan: httpSpan);
     } catch (error, stackTrace) {
-      httpSpan.setAttribute('http.status_code', 0);
-      httpSpan.setStatus(SpanStatusCode.error, message: error.toString());
-      httpSpan.recordException(error, stackTrace: stackTrace);
+      _recordHttpError(httpSpan, error, stackTrace);
       httpSpan.end();
       rethrow;
     }
@@ -265,6 +260,51 @@ class FaroHttpTrackingClient implements HttpClient {
   Future<HttpClientRequest> putUrl(Uri url) => _openUrl('PUT', url);
 }
 
+// Sanitize only the telemetry copy, preserving the actual request and the
+// encoding/order of non-sensitive query parameters.
+String _sanitizeHttpUrl(Uri url) {
+  const sensitiveKeys = {
+    'X-Amz-Signature',
+    'X-Amz-Credential',
+    'X-Amz-Security-Token',
+    'sig',
+    'X-Goog-Signature',
+  };
+  final query = url.query
+      .split('&')
+      .map((part) {
+        final separator = part.indexOf('=');
+        final key = separator < 0 ? part : part.substring(0, separator);
+        try {
+          if (sensitiveKeys.contains(Uri.decodeQueryComponent(key))) {
+            return '$key=REDACTED';
+          }
+        } on FormatException {
+          // Invalid UTF-8 cannot match a sensitive key. Do not let telemetry
+          // sanitization prevent the HTTP client from handling the request.
+        }
+        return part;
+      })
+      .join('&');
+  return url
+      .replace(
+        userInfo: url.userInfo.isEmpty ? null : 'REDACTED:REDACTED',
+        query: url.hasQuery ? query : null,
+      )
+      .toString();
+}
+
+void _recordHttpError(Span span, Object error, StackTrace? stackTrace) {
+  // Keep the first error, including an HTTP error recorded before a body
+  // failure. Exception types carry failure information without inventing a
+  // response code or using high-cardinality exception messages as error.type.
+  if (span.status != SpanStatusCode.error) {
+    span.setAttribute('error.type', error.runtimeType.toString());
+    span.setStatus(SpanStatusCode.error, message: error.toString());
+  }
+  span.recordException(error, stackTrace: stackTrace);
+}
+
 class FaroTrackingHttpClientRequest implements HttpClientRequest {
   FaroTrackingHttpClientRequest(this.innerContext, {required Span httpSpan})
     : _httpSpan = httpSpan {
@@ -274,7 +314,6 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
   final HttpClientRequest innerContext;
   final Span _httpSpan;
   var _operationFinished = false;
-  var _statusCodeRecorded = false;
 
   void _finishOperation() {
     if (_operationFinished) {
@@ -285,11 +324,7 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
   }
 
   void _recordOperationError(Object error, [StackTrace? stackTrace]) {
-    if (!_statusCodeRecorded) {
-      _httpSpan.setAttribute('http.status_code', 0);
-    }
-    _httpSpan.setStatus(SpanStatusCode.error, message: error.toString());
-    _httpSpan.recordException(error, stackTrace: stackTrace);
+    _recordHttpError(_httpSpan, error, stackTrace);
   }
 
   Future<HttpClientResponse> _trackResponseFuture(
@@ -298,13 +333,7 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
     try {
       final value = await responseFuture();
 
-      _httpSpan.setAttributes({
-        'http.status_code': value.statusCode,
-        'http.request_size': innerContext.contentLength,
-        'http.response_size': value.headers.contentLength,
-        'http.content_type': '${value.headers.contentType}',
-      });
-      _statusCodeRecorded = true;
+      _httpSpan.setAttribute('http.response.status_code', value.statusCode);
       // Successful responses leave status unset. Preserve an error already
       // recorded on the span instead of replacing its diagnostic information.
       if (value.statusCode >= 400 && _httpSpan.status != SpanStatusCode.error) {
@@ -320,7 +349,7 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
           'status_code': '${value.statusCode}',
           'method': innerContext.method,
           'request_size': '${innerContext.contentLength}',
-          'url': innerContext.uri.toString(),
+          'url': _sanitizeHttpUrl(innerContext.uri),
         },
         spanContext: _httpSpan.spanContext,
         onFinish: _finishOperation,

--- a/lib/src/integrations/http_url_redaction.dart
+++ b/lib/src/integrations/http_url_redaction.dart
@@ -1,0 +1,38 @@
+/// Redacts the HTTP span URL without changing the request or Faro event URL.
+///
+/// OTel HTTP client URL redaction rules (the query-key list is Development):
+/// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span
+/// Preserves the encoding/order of non-sensitive query parameters.
+String redactHttpSpanUrl(Uri url) {
+  const sensitiveKeys = {
+    'X-Amz-Signature',
+    'X-Amz-Credential',
+    'X-Amz-Security-Token',
+    'AWSAccessKeyId',
+    'Signature',
+    'sig',
+    'X-Goog-Signature',
+  };
+  final query = url.query
+      .split('&')
+      .map((part) {
+        final separator = part.indexOf('=');
+        final key = separator < 0 ? part : part.substring(0, separator);
+        try {
+          if (sensitiveKeys.contains(Uri.decodeQueryComponent(key))) {
+            return '$key=REDACTED';
+          }
+        } on FormatException {
+          // Invalid UTF-8 cannot match a sensitive key. Do not let telemetry
+          // sanitization prevent the HTTP client from handling the request.
+        }
+        return part;
+      })
+      .join('&');
+  return url
+      .replace(
+        userInfo: url.userInfo.isEmpty ? null : 'REDACTED:REDACTED',
+        query: url.hasQuery ? query : null,
+      )
+      .toString();
+}

--- a/lib/src/integrations/http_url_redaction.dart
+++ b/lib/src/integrations/http_url_redaction.dart
@@ -1,9 +1,9 @@
-/// Redacts the HTTP span URL without changing the request or Faro event URL.
+/// Redacts HTTP span and event URLs without changing the request URL.
 ///
 /// OTel HTTP client URL redaction rules (the query-key list is Development):
 /// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span
 /// Preserves the encoding/order of non-sensitive query parameters.
-String redactHttpSpanUrl(Uri url) {
+String redactHttpUrl(Uri url) {
   const sensitiveKeys = {
     'X-Amz-Signature',
     'X-Amz-Credential',

--- a/lib/src/integrations/http_url_redaction.dart
+++ b/lib/src/integrations/http_url_redaction.dart
@@ -1,10 +1,12 @@
-/// Redacts HTTP span and event URLs without changing the request URL.
+/// Redacts HTTP span, event and fallback error-log URLs.
+/// The request URL is unchanged.
 ///
 /// OTel HTTP client URL redaction rules (the query-key list is Development):
 /// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span
 /// Preserves the encoding/order of non-sensitive query parameters.
 String redactHttpUrl(Uri url) {
   const sensitiveKeys = {
+    // OpenTelemetry default sensitive query keys.
     'X-Amz-Signature',
     'X-Amz-Credential',
     'X-Amz-Security-Token',
@@ -12,6 +14,14 @@ String redactHttpUrl(Uri url) {
     'Signature',
     'sig',
     'X-Goog-Signature',
+    // Additional Faro defaults for common application credentials.
+    'token',
+    'access_token',
+    'refresh_token',
+    'api_key',
+    'apikey',
+    'password',
+    'client_secret',
   };
   final query = url.query
       .split('&')

--- a/lib/src/models/span_record.dart
+++ b/lib/src/models/span_record.dart
@@ -6,6 +6,7 @@ import 'package:faro/src/models/trace/trace_span_status.dart';
 import 'package:faro/src/tracing/dartastic_span_access.dart';
 import 'package:faro/src/tracing/extensions.dart';
 import 'package:faro/src/tracing/faro_span_context.dart';
+import 'package:faro/src/tracing/http_event_attributes.dart';
 import 'package:faro/src/util/constants.dart';
 import 'package:fixnum/fixnum.dart';
 
@@ -71,6 +72,26 @@ class SpanRecord {
     for (final attribute in _spanAttributes.toList()) {
       final value = attribute.value.toString();
       faroEventAttributes[attribute.key] = _sanitizeAttributeValue(value);
+    }
+
+    final httpAttributes = httpEventAttributes(_otelReadOnlySpan);
+    if (httpAttributes != null) {
+      // Automatic HTTP events preserve their existing contract independently
+      // of the stable OTel span schema. Custom spans keep generic conversion.
+      for (final key in [
+        'http.request.method',
+        'http.request.method_original',
+        'url.full',
+        'server.address',
+        'server.port',
+        'http.response.status_code',
+        'error.type',
+      ]) {
+        faroEventAttributes.remove(key);
+      }
+      for (final entry in httpAttributes.entries) {
+        faroEventAttributes[entry.key] = _sanitizeAttributeValue(entry.value);
+      }
     }
 
     // Add span duration in nanoseconds

--- a/lib/src/tracing/http_event_attributes.dart
+++ b/lib/src/tracing/http_event_attributes.dart
@@ -1,0 +1,41 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
+import 'package:faro/src/tracing/dartastic_span_access.dart';
+import 'package:faro/src/tracing/span.dart';
+
+// Event-only metadata follows the SDK span through batched export without
+// becoming OTel attributes. Weak keys also release unsampled/dropped spans.
+final _httpEventAttributes = Expando<Map<String, String>>();
+final _errorTypeCaptured = Expando<bool>();
+
+/// Captures the existing Faro HTTP event contract separately from OTel.
+void initializeHttpEventAttributes(Span span, Map<String, String> attributes) {
+  if (span is InternalSpan) {
+    _httpEventAttributes[span.otelSpan] = Map.of(attributes);
+    _errorTypeCaptured[span.otelSpan] = false;
+  }
+}
+
+/// Adds event-only HTTP metadata when a response or failure is observed.
+void updateHttpEventAttributes(Span span, Map<String, String> attributes) {
+  if (span is InternalSpan) {
+    _httpEventAttributes[span.otelSpan]?.addAll(attributes);
+  }
+}
+
+/// Retains the error type that existed before transport error handling.
+void preserveHttpEventErrorType(Span span) {
+  if (span is InternalSpan && span.otelSpan is otel.Span) {
+    if (_errorTypeCaptured[span.otelSpan] == true) return;
+    _errorTypeCaptured[span.otelSpan] = true;
+    final type = dartasticSpanAttributes(
+      span.otelSpan as otel.Span,
+    ).getString('error.type');
+    if (type != null) updateHttpEventAttributes(span, {'error.type': type});
+  }
+}
+
+/// Returns a copy so serialization cannot mutate request metadata.
+Map<String, String>? httpEventAttributes(Object span) {
+  final attributes = _httpEventAttributes[span];
+  return attributes == null ? null : Map.of(attributes);
+}

--- a/test/src/integrations/http_response_semantics_test.dart
+++ b/test/src/integrations/http_response_semantics_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/integrations/http_tracking_client.dart';
+import 'package:faro/src/integrations/http_tracking_filter.dart';
 import 'package:faro/src/models/span_record.dart';
 import 'package:faro/src/session/session_activity_kind.dart';
 import 'package:faro/src/tracing/faro_exporter.dart';
@@ -11,6 +12,8 @@ import 'package:faro/src/user_actions/telemetry_router.dart';
 import 'package:faro/src/user_actions/user_action_types.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+class _MockClient extends Mock implements HttpClient {}
 
 class _MockRequest extends Mock implements HttpClientRequest {}
 
@@ -58,7 +61,7 @@ void main() {
       enableMetrics: false,
       enableLogs: false,
     );
-    tracer = otel.OTel.tracer();
+    tracer = otel.OTel.tracerProvider().getTracer('faro-mobile-flutter.http');
   });
 
   setUp(processor.ended.clear);
@@ -72,11 +75,12 @@ void main() {
     int statusCode, {
     required bool useDone,
     bool existingError = false,
+    bool bodyError = false,
   }) async {
     final recordingSpan = tracer.startSpan(
-      'HTTP GET',
+      'GET',
       kind: otel.SpanKind.client,
-      attributes: otel.OTel.attributesFromMap({'http.method': 'GET'}),
+      attributes: otel.OTel.attributesFromMap({'http.request.method': 'GET'}),
     );
     final span = SpanProvider().getSpan(recordingSpan, otel.Context.current);
     if (existingError) {
@@ -106,12 +110,15 @@ void main() {
         cancelOnError: any(named: 'cancelOnError'),
       ),
     ).thenAnswer((invocation) {
-      return const Stream<List<int>>.empty().listen(
-        invocation.positionalArguments[0] as void Function(List<int>)?,
-        onError: invocation.namedArguments[#onError] as Function?,
-        onDone: invocation.namedArguments[#onDone] as void Function()?,
-        cancelOnError: invocation.namedArguments[#cancelOnError] as bool?,
-      );
+      return (bodyError
+              ? Stream<List<int>>.error(const SocketException('body failed'))
+              : const Stream<List<int>>.empty())
+          .listen(
+            invocation.positionalArguments[0] as void Function(List<int>)?,
+            onError: invocation.namedArguments[#onError] as Function?,
+            onDone: invocation.namedArguments[#onDone] as void Function()?,
+            cancelOnError: invocation.namedArguments[#cancelOnError] as bool?,
+          );
     });
 
     final tracked = FaroTrackingHttpClientRequest(request, httpSpan: span);
@@ -119,7 +126,14 @@ void main() {
         ? await tracked.done
         : await tracked.close();
     expect(recordingSpan.isEnded, isFalse);
-    await trackedResponse.drain<void>();
+    if (bodyError) {
+      await expectLater(
+        trackedResponse.drain<void>(),
+        throwsA(isA<SocketException>()),
+      );
+    } else {
+      await trackedResponse.drain<void>();
+    }
     expect(span.wasEnded, isTrue);
     expect(processor.ended, [same(recordingSpan)]);
     return recordingSpan;
@@ -130,6 +144,111 @@ void main() {
       attribute['key'] as String: attribute['value'],
   };
 
+  for (final status in [200, 500]) {
+    for (final priorError in [false, true]) {
+      test(
+        'body error preserves response $status and prior error $priorError',
+        () async {
+          final span = await completeResponse(
+            status,
+            useDone: false,
+            existingError: priorError,
+            bodyError: true,
+          );
+          final record = SpanRecord(otelReadOnlySpan: span);
+          final json = record.getSpan().toJson();
+          final attributes = attributesOf(json);
+          final expectedType = priorError
+              ? 'previous_failure'
+              : status >= 400
+              ? '$status'
+              : 'SocketException';
+          expect(attributes['http.response.status_code'], {'intValue': status});
+          expect(attributes['error.type'], {'stringValue': expectedType});
+          expect(json['status']['code'], 2);
+          expect(
+            json['status']['message'],
+            priorError
+                ? 'previous failure'
+                : status >= 400
+                ? isNull
+                : contains('body failed'),
+          );
+          final router = _RecordingRouter();
+          await FaroExporter(telemetryRouter: router).export([span]);
+          final event = router.items
+              .singleWhere((i) => i.asEvent != null)
+              .asEvent!;
+          expect(event.attributes!['http.response.status_code'], '$status');
+          expect(event.attributes!['error.type'], expectedType);
+        },
+      );
+    }
+  }
+
+  for (final phase in ['open', 'close', 'done', 'upload', 'abort']) {
+    test('$phase failure exports error type without a response code', () async {
+      final recordingSpan = tracer.startSpan(
+        'GET',
+        kind: otel.SpanKind.client,
+        attributes: otel.OTel.attributesFromMap({
+          'http.request.method': 'GET',
+          'url.full': 'https://example.com/',
+          'server.address': 'example.com',
+          'server.port': 443,
+        }),
+      );
+      final span = SpanProvider().getSpan(recordingSpan, otel.Context.current);
+      const error = SocketException('failure');
+      if (phase == 'open') {
+        final inner = _MockClient();
+        final uri = Uri.parse('https://example.com/');
+        when(() => inner.openUrl('GET', uri)).thenThrow(error);
+        final client = FaroHttpTrackingClient(
+          inner,
+          trackingFilter: HttpTrackingFilter(),
+          startHttpSpan: (_, {required attributes}) => span,
+        );
+        await expectLater(client.getUrl(uri), throwsA(same(error)));
+      } else {
+        final request = _MockRequest();
+        when(() => request.headers).thenReturn(_MockHeaders());
+        final tracked = FaroTrackingHttpClientRequest(request, httpSpan: span);
+        if (phase == 'abort') {
+          tracked.abort(error);
+        } else if (phase == 'upload') {
+          const stream = Stream<List<int>>.empty();
+          when(() => request.addStream(stream)).thenThrow(error);
+          await expectLater(tracked.addStream(stream), throwsA(same(error)));
+        } else {
+          when(request.close).thenThrow(error);
+          when(() => request.done).thenThrow(error);
+          await expectLater(
+            phase == 'done' ? tracked.done : tracked.close(),
+            throwsA(isA<Exception>()),
+          );
+        }
+      }
+      final record = SpanRecord(otelReadOnlySpan: recordingSpan);
+      final json = record.getSpan().toJson();
+      final attributes = attributesOf(json);
+      expect(json['status']['code'], 2);
+      expect(attributes['error.type'], {'stringValue': 'SocketException'});
+      expect(attributes, isNot(contains('http.response.status_code')));
+      expect(attributes, isNot(contains('http.status_code')));
+      expect(processor.ended, [same(recordingSpan)]);
+      final router = _RecordingRouter();
+      await FaroExporter(telemetryRouter: router).export([recordingSpan]);
+      final event = router.items.singleWhere((i) => i.asEvent != null).asEvent!;
+      expect(event.name, 'faro.tracing.fetch');
+      expect(event.attributes!['error.type'], 'SocketException');
+      expect(event.attributes, isNot(contains('http.response.status_code')));
+      expect(event.attributes, isNot(contains('http.status_code')));
+      expect(event.trace, record.getFaroSpanContext());
+      expect(event.attributes, contains('duration_ns'));
+    });
+  }
+
   for (final useDone in [false, true]) {
     group(useDone ? 'done' : 'close', () {
       for (final statusCode in [200, 204, 302, 400, 404, 499, 500, 599]) {
@@ -139,7 +258,9 @@ void main() {
           final attributes = attributesOf(json);
 
           expect(json['status'], {'code': statusCode >= 400 ? 2 : 0});
-          expect(attributes['http.status_code'], {'intValue': statusCode});
+          expect(attributes['http.response.status_code'], {
+            'intValue': statusCode,
+          });
           if (statusCode >= 400) {
             expect(attributes['error.type'], {'stringValue': '$statusCode'});
           } else {
@@ -180,6 +301,7 @@ void main() {
           .asEvent!;
       final record = SpanRecord(otelReadOnlySpan: span);
       expect(event.name, 'faro.tracing.fetch');
+      expect(event.attributes!['http.response.status_code'], '$statusCode');
       expect(event.trace, record.getFaroSpanContext());
       expect(
         int.parse(event.attributes!['duration_ns']!),

--- a/test/src/integrations/http_response_semantics_test.dart
+++ b/test/src/integrations/http_response_semantics_test.dart
@@ -7,6 +7,7 @@ import 'package:faro/src/integrations/http_tracking_filter.dart';
 import 'package:faro/src/models/span_record.dart';
 import 'package:faro/src/session/session_activity_kind.dart';
 import 'package:faro/src/tracing/faro_exporter.dart';
+import 'package:faro/src/tracing/http_event_attributes.dart';
 import 'package:faro/src/tracing/span.dart';
 import 'package:faro/src/user_actions/telemetry_router.dart';
 import 'package:faro/src/user_actions/user_action_types.dart';
@@ -88,6 +89,14 @@ void main() {
       span.setAttribute('error.type', 'previous_failure');
     }
 
+    initializeHttpEventAttributes(span, {
+      'http.method': 'GET',
+      'http.request.method': 'GET',
+      'http.url': 'https://example.com/test',
+      'http.host': 'example.com',
+      'http.scheme': 'https',
+      'http.user_agent': '',
+    });
     final request = _MockRequest();
     final response = _MockResponse();
     final requestHeaders = _MockHeaders();
@@ -179,8 +188,15 @@ void main() {
           final event = router.items
               .singleWhere((i) => i.asEvent != null)
               .asEvent!;
-          expect(event.attributes!['http.response.status_code'], '$status');
-          expect(event.attributes!['error.type'], expectedType);
+          expect(event.attributes!['http.status_code'], '$status');
+          expect(
+            event.attributes!['error.type'],
+            priorError
+                ? 'previous_failure'
+                : status >= 400
+                ? '$status'
+                : isNull,
+          );
         },
       );
     }
@@ -199,6 +215,7 @@ void main() {
         }),
       );
       final span = SpanProvider().getSpan(recordingSpan, otel.Context.current);
+      initializeHttpEventAttributes(span, {'http.method': 'GET'});
       const error = SocketException('failure');
       if (phase == 'open') {
         final inner = _MockClient();
@@ -241,9 +258,9 @@ void main() {
       await FaroExporter(telemetryRouter: router).export([recordingSpan]);
       final event = router.items.singleWhere((i) => i.asEvent != null).asEvent!;
       expect(event.name, 'faro.tracing.fetch');
-      expect(event.attributes!['error.type'], 'SocketException');
+      expect(event.attributes, isNot(contains('error.type')));
       expect(event.attributes, isNot(contains('http.response.status_code')));
-      expect(event.attributes, isNot(contains('http.status_code')));
+      expect(event.attributes!['http.status_code'], '0');
       expect(event.trace, record.getFaroSpanContext());
       expect(event.attributes, contains('duration_ns'));
     });
@@ -301,7 +318,7 @@ void main() {
           .asEvent!;
       final record = SpanRecord(otelReadOnlySpan: span);
       expect(event.name, 'faro.tracing.fetch');
-      expect(event.attributes!['http.response.status_code'], '$statusCode');
+      expect(event.attributes!['http.status_code'], '$statusCode');
       expect(event.trace, record.getFaroSpanContext());
       expect(
         int.parse(event.attributes!['duration_ns']!),

--- a/test/src/integrations/http_response_semantics_test.dart
+++ b/test/src/integrations/http_response_semantics_test.dart
@@ -229,6 +229,7 @@ void main() {
         await expectLater(client.getUrl(uri), throwsA(same(error)));
       } else {
         final request = _MockRequest();
+        when(() => request.uri).thenReturn(Uri.parse('https://example.com/'));
         when(() => request.headers).thenReturn(_MockHeaders());
         final tracked = FaroTrackingHttpClientRequest(request, httpSpan: span);
         if (phase == 'abort') {

--- a/test/src/integrations/http_span_naming_test.dart
+++ b/test/src/integrations/http_span_naming_test.dart
@@ -337,53 +337,18 @@ void main() {
     });
   }
 
-  for (final pair in [
-    (
-      'https://example.com/?%FF=keep&sig=secret',
-      'https://example.com/?%FF=keep&sig=REDACTED',
-    ),
-    (
-      'https://alice:secret@example.com/path?color=blue#section',
-      'https://REDACTED:REDACTED@example.com/path?color=blue#section',
-    ),
-    (
-      'https://alice@example.com/path',
-      'https://REDACTED:REDACTED@example.com/path',
-    ),
-    (
-      'https://example.com/?sig=secret&sig=other&%73ig=encoded&Sig=visible',
-      'https://example.com/?sig=REDACTED&sig=REDACTED&sig=REDACTED&Sig=visible',
-    ),
-    (
-      'https://example.com/?X-Amz-Signature=a&X-Amz-Credential=b&'
-          'X-Amz-Security-Token=c&X-Goog-Signature=d&q=a%20b&q=two&flag',
-      'https://example.com/?X-Amz-Signature=REDACTED&'
-          'X-Amz-Credential=REDACTED&X-Amz-Security-Token=REDACTED&'
-          'X-Goog-Signature=REDACTED&q=a%20b&q=two&flag',
-    ),
-    (
-      'https://example.com/?AWSAccessKeyId=example-key&Signature=example-signature'
-          '&Signature=second&%53ignature=encoded&signature=visible',
-      'https://example.com/?AWSAccessKeyId=REDACTED&Signature=REDACTED'
-          '&Signature=REDACTED&Signature=REDACTED&signature=visible',
-    ),
-    (
-      'https://example.com/?sig=&sig',
-      'https://example.com/?sig=REDACTED&sig=REDACTED',
-    ),
-  ]) {
-    test(
-      'sanitizes telemetry URL without changing the request: ${pair.$1}',
-      () async {
-        await verifyRequest(
-          'GET',
-          (c, u) => c.getUrl(u),
-          fullUrl: pair.$1,
-          sanitizedUrl: pair.$2,
-        );
-      },
+  test('redacts span and event URLs without changing the request', () async {
+    await verifyRequest(
+      'GET',
+      (c, u) => c.getUrl(u),
+      fullUrl:
+          'https://alice:example-password@example.com/path?'
+          'sig=example-signature&color=blue#section',
+      sanitizedUrl:
+          'https://REDACTED:REDACTED@example.com/path?'
+          'sig=REDACTED&color=blue#section',
     );
-  }
+  });
 
   for (final method in [
     'GET',

--- a/test/src/integrations/http_span_naming_test.dart
+++ b/test/src/integrations/http_span_naming_test.dart
@@ -141,8 +141,10 @@ void main() {
     int statusCode = 200,
     bool known = true,
     String? normalizedMethod,
+    String? fullUrl,
+    String? sanitizedUrl,
   }) async {
-    final url = Uri.parse('http://example.com$path');
+    final url = Uri.parse(fullUrl ?? 'http://example.com$path');
     final innerClient = _MockClient();
     final filter = HttpTrackingFilter()
       ..configure(collectorUrl: null, ignoreUrls: null);
@@ -195,7 +197,7 @@ void main() {
       expect(span.name, expectedName);
       expect(
         record.getFaroEventAttributes()['http.request.method'],
-        known ? recordedMethod : isNull,
+        recordedMethod,
       );
       verify(() => innerClient.openUrl(method, url)).called(1);
       verify(
@@ -205,6 +207,11 @@ void main() {
         ),
       ).called(1);
       expect(span.isEnded, isFalse);
+      final initial = record.getFaroEventAttributes();
+      expect(initial['url.full'], sanitizedUrl ?? url.toString());
+      expect(initial['server.address'], url.host);
+      expect(initial['server.port'], '${url.port}');
+      expect(initial, isNot(contains('http.response.status_code')));
 
       final response = await tracked.close();
       await response.drain<void>();
@@ -228,16 +235,32 @@ void main() {
       expect(exported['traceId'], parent.traceId);
       expect(exported['parentSpanId'], parent.spanId);
       expect(exported['spanId'], isNot(parent.spanId));
-      expect(
-        attributes['http.request.method'],
-        known ? {'stringValue': recordedMethod} : isNull,
-      );
-      expect(attributes['http.method'], {'stringValue': recordedMethod});
+      expect(attributes['http.request.method'], {
+        'stringValue': recordedMethod,
+      });
+      expect(attributes, isNot(contains('http.method')));
       expect(
         attributes['http.request.method_original'],
         normalizedMethod != null ? {'stringValue': method} : isNull,
       );
-      expect(attributes['http.url'], {'stringValue': url.toString()});
+      expect(attributes['url.full'], {
+        'stringValue': sanitizedUrl ?? url.toString(),
+      });
+      expect(attributes['server.address'], {'stringValue': url.host});
+      expect(attributes['server.port'], {'intValue': url.port});
+      expect(attributes['http.response.status_code'], {'intValue': statusCode});
+      for (final key in [
+        'http.url',
+        'http.host',
+        'http.scheme',
+        'http.status_code',
+        'http.user_agent',
+        'http.request_size',
+        'http.response_size',
+        'http.content_type',
+      ]) {
+        expect(attributes, isNot(contains(key)));
+      }
       expect(attributes, isNot(contains('url.template')));
       expect(exported['status'], {'code': statusCode >= 400 ? 2 : 0});
       expect(
@@ -254,11 +277,13 @@ void main() {
         'trace_id': exported['traceId'],
         'span_id': exported['spanId'],
       });
-      expect(
-        event.attributes!['http.request.method'],
-        known ? recordedMethod : isNull,
-      );
-      expect(event.attributes!['http.method'], recordedMethod);
+      expect(event.attributes!['http.request.method'], recordedMethod);
+      expect(event.attributes, isNot(contains('http.method')));
+      expect(event.attributes!['url.full'], sanitizedUrl ?? url.toString());
+      expect(event.attributes!['server.address'], url.host);
+      expect(event.attributes!['server.port'], '${url.port}');
+      expect(event.attributes!['http.response.status_code'], '$statusCode');
+      expect(event.attributes!.values, everyElement(isA<String>()));
       expect(
         event.attributes!['http.request.method_original'],
         normalizedMethod != null ? method : isNull,
@@ -272,6 +297,60 @@ void main() {
       expect(duration >= BigInt.zero, isTrue);
       expect(router.items, hasLength(2));
     });
+  }
+
+  for (final url in [
+    'http://example.com/path',
+    'https://example.com/path',
+    'https://example.com:8443/path',
+    'http://127.0.0.1:8080/path',
+    'https://[::1]:8443/path',
+  ]) {
+    test('exports stable authority for $url', () async {
+      await verifyRequest('GET', (c, u) => c.getUrl(u), fullUrl: url);
+    });
+  }
+
+  for (final pair in [
+    (
+      'https://example.com/?%FF=keep&sig=secret',
+      'https://example.com/?%FF=keep&sig=REDACTED',
+    ),
+    (
+      'https://alice:secret@example.com/path?color=blue#section',
+      'https://REDACTED:REDACTED@example.com/path?color=blue#section',
+    ),
+    (
+      'https://alice@example.com/path',
+      'https://REDACTED:REDACTED@example.com/path',
+    ),
+    (
+      'https://example.com/?sig=secret&sig=other&%73ig=encoded&Sig=visible',
+      'https://example.com/?sig=REDACTED&sig=REDACTED&sig=REDACTED&Sig=visible',
+    ),
+    (
+      'https://example.com/?X-Amz-Signature=a&X-Amz-Credential=b&'
+          'X-Amz-Security-Token=c&X-Goog-Signature=d&q=a%20b&q=two&flag',
+      'https://example.com/?X-Amz-Signature=REDACTED&'
+          'X-Amz-Credential=REDACTED&X-Amz-Security-Token=REDACTED&'
+          'X-Goog-Signature=REDACTED&q=a%20b&q=two&flag',
+    ),
+    (
+      'https://example.com/?sig=&sig',
+      'https://example.com/?sig=REDACTED&sig=REDACTED',
+    ),
+  ]) {
+    test(
+      'sanitizes telemetry URL without changing the request: ${pair.$1}',
+      () async {
+        await verifyRequest(
+          'GET',
+          (c, u) => c.getUrl(u),
+          fullUrl: pair.$1,
+          sanitizedUrl: pair.$2,
+        );
+      },
+    );
   }
 
   for (final method in [
@@ -408,7 +487,7 @@ void main() {
         record.getFaroEventAttributes()['http.request.method'],
         wireMethod,
       );
-      expect(record.getFaroEventAttributes()['http.method'], wireMethod);
+      expect(record.getFaroEventAttributes(), isNot(contains('http.method')));
       expect(
         record.getFaroEventAttributes()['http.request.method_original'],
         input,

--- a/test/src/integrations/http_span_naming_test.dart
+++ b/test/src/integrations/http_span_naming_test.dart
@@ -160,13 +160,14 @@ void main() {
     when(() => request.headers).thenReturn(requestHeaders);
     when(() => request.method).thenReturn(method);
     when(() => request.uri).thenReturn(url);
-    when(() => request.contentLength).thenReturn(0);
+    when(() => innerClient.userAgent).thenReturn('compatibility-test-agent');
+    when(() => request.contentLength).thenReturn(123);
     when(request.close).thenAnswer((_) async => response);
     when(() => request.done).thenAnswer((_) async => response);
     when(() => response.statusCode).thenReturn(statusCode);
     when(() => response.headers).thenReturn(responseHeaders);
-    when(() => responseHeaders.contentLength).thenReturn(0);
-    when(() => responseHeaders.contentType).thenReturn(null);
+    when(() => responseHeaders.contentLength).thenReturn(456);
+    when(() => responseHeaders.contentType).thenReturn(ContentType.json);
     when(
       () => response.listen(
         any(),
@@ -197,7 +198,7 @@ void main() {
       expect(span.name, expectedName);
       expect(
         record.getFaroEventAttributes()['http.request.method'],
-        recordedMethod,
+        known ? recordedMethod : isNull,
       );
       verify(() => innerClient.openUrl(method, url)).called(1);
       verify(
@@ -208,10 +209,13 @@ void main() {
       ).called(1);
       expect(span.isEnded, isFalse);
       final initial = record.getFaroEventAttributes();
-      expect(initial['url.full'], sanitizedUrl ?? url.toString());
-      expect(initial['server.address'], url.host);
-      expect(initial['server.port'], '${url.port}');
+      expect(initial['http.url'], url.toString());
+      expect(initial['http.host'], url.host);
+      expect(initial['http.scheme'], url.scheme);
+      expect(initial, isNot(contains('http.status_code')));
       expect(initial, isNot(contains('http.response.status_code')));
+      initial['http.url'] = 'mutated-by-consumer';
+      expect(record.getFaroEventAttributes()['http.url'], url.toString());
 
       final response = await tracked.close();
       await response.drain<void>();
@@ -277,12 +281,27 @@ void main() {
         'trace_id': exported['traceId'],
         'span_id': exported['spanId'],
       });
-      expect(event.attributes!['http.request.method'], recordedMethod);
-      expect(event.attributes, isNot(contains('http.method')));
-      expect(event.attributes!['url.full'], sanitizedUrl ?? url.toString());
-      expect(event.attributes!['server.address'], url.host);
-      expect(event.attributes!['server.port'], '${url.port}');
-      expect(event.attributes!['http.response.status_code'], '$statusCode');
+      expect(
+        event.attributes!['http.request.method'],
+        known ? recordedMethod : isNull,
+      );
+      expect(event.attributes!['http.method'], recordedMethod);
+      expect(event.attributes!['http.url'], url.toString());
+      expect(event.attributes!['http.host'], url.host);
+      expect(event.attributes!['http.scheme'], url.scheme);
+      expect(event.attributes!['http.status_code'], '$statusCode');
+      expect(event.attributes!['http.user_agent'], 'compatibility-test-agent');
+      expect(event.attributes!['http.request_size'], '123');
+      expect(event.attributes!['http.response_size'], '456');
+      expect(event.attributes!['http.content_type'], '${ContentType.json}');
+      for (final key in [
+        'url.full',
+        'server.address',
+        'server.port',
+        'http.response.status_code',
+      ]) {
+        expect(event.attributes, isNot(contains(key)));
+      }
       expect(event.attributes!.values, everyElement(isA<String>()));
       expect(
         event.attributes!['http.request.method_original'],
@@ -487,7 +506,7 @@ void main() {
         record.getFaroEventAttributes()['http.request.method'],
         wireMethod,
       );
-      expect(record.getFaroEventAttributes(), isNot(contains('http.method')));
+      expect(record.getFaroEventAttributes()['http.method'], wireMethod);
       expect(
         record.getFaroEventAttributes()['http.request.method_original'],
         input,

--- a/test/src/integrations/http_span_naming_test.dart
+++ b/test/src/integrations/http_span_naming_test.dart
@@ -223,7 +223,7 @@ void main() {
       final response = await tracked.close();
       expect(
         (response as FaroTrackingHttpResponse).userAttributes['url'],
-        url.toString(),
+        sanitizedUrl ?? url.toString(),
       );
       await response.drain<void>();
       expect(processor.ended, [same(span)]);
@@ -343,10 +343,12 @@ void main() {
       (c, u) => c.getUrl(u),
       fullUrl:
           'https://alice:example-password@example.com/path?'
-          'sig=example-signature&color=blue#section',
+          'sig=example-signature&token=example-token&password=example-password'
+          '&api_key=example-key&color=blue#section',
       sanitizedUrl:
           'https://REDACTED:REDACTED@example.com/path?'
-          'sig=REDACTED&color=blue#section',
+          'sig=REDACTED&token=REDACTED&password=REDACTED&api_key=REDACTED'
+          '&color=blue#section',
     );
   });
 

--- a/test/src/integrations/http_span_naming_test.dart
+++ b/test/src/integrations/http_span_naming_test.dart
@@ -209,13 +209,16 @@ void main() {
       ).called(1);
       expect(span.isEnded, isFalse);
       final initial = record.getFaroEventAttributes();
-      expect(initial['http.url'], url.toString());
+      expect(initial['http.url'], sanitizedUrl ?? url.toString());
       expect(initial['http.host'], url.host);
       expect(initial['http.scheme'], url.scheme);
       expect(initial, isNot(contains('http.status_code')));
       expect(initial, isNot(contains('http.response.status_code')));
       initial['http.url'] = 'mutated-by-consumer';
-      expect(record.getFaroEventAttributes()['http.url'], url.toString());
+      expect(
+        record.getFaroEventAttributes()['http.url'],
+        sanitizedUrl ?? url.toString(),
+      );
 
       final response = await tracked.close();
       expect(
@@ -290,7 +293,7 @@ void main() {
         known ? recordedMethod : isNull,
       );
       expect(event.attributes!['http.method'], recordedMethod);
-      expect(event.attributes!['http.url'], url.toString());
+      expect(event.attributes!['http.url'], sanitizedUrl ?? url.toString());
       expect(event.attributes!['http.host'], url.host);
       expect(event.attributes!['http.scheme'], url.scheme);
       expect(event.attributes!['http.status_code'], '$statusCode');

--- a/test/src/integrations/http_span_naming_test.dart
+++ b/test/src/integrations/http_span_naming_test.dart
@@ -218,6 +218,10 @@ void main() {
       expect(record.getFaroEventAttributes()['http.url'], url.toString());
 
       final response = await tracked.close();
+      expect(
+        (response as FaroTrackingHttpResponse).userAttributes['url'],
+        url.toString(),
+      );
       await response.drain<void>();
       expect(processor.ended, [same(span)]);
 
@@ -353,6 +357,12 @@ void main() {
       'https://example.com/?X-Amz-Signature=REDACTED&'
           'X-Amz-Credential=REDACTED&X-Amz-Security-Token=REDACTED&'
           'X-Goog-Signature=REDACTED&q=a%20b&q=two&flag',
+    ),
+    (
+      'https://example.com/?AWSAccessKeyId=example-key&Signature=example-signature'
+          '&Signature=second&%53ignature=encoded&signature=visible',
+      'https://example.com/?AWSAccessKeyId=REDACTED&Signature=REDACTED'
+          '&Signature=REDACTED&Signature=REDACTED&signature=visible',
     ),
     (
       'https://example.com/?sig=&sig',

--- a/test/src/integrations/http_tracking_client_test.dart
+++ b/test/src/integrations/http_tracking_client_test.dart
@@ -537,8 +537,20 @@ void main() {
     });
 
     test(
-      'network_error log from unsupported onError carries span trace context',
+      'network_error log redacts the URL and preserves span trace context',
       () async {
+        when(() => mockHttpClientRequest.uri).thenReturn(
+          Uri.parse(
+            'https://alice:example-password@example.com/path?'
+            'sig=example-signature&token=example-token'
+            '&password=example-password'
+            '&api_key=example-key&color=blue',
+          ),
+        );
+        trackedRequest = FaroTrackingHttpClientRequest(
+          mockHttpClientRequest,
+          httpSpan: mockSpan,
+        );
         final response = await trackedRequest.close();
         // An onError with an unsupported signature (neither one- nor two-arg)
         // forces the integration onto its fallback pushLog path.
@@ -553,6 +565,13 @@ void main() {
 
         final logItem = router.ingested.firstWhere(
           (item) => item.type == TelemetryItemType.log,
+        );
+        expect(
+          logItem.asLog!.message,
+          'network_error on : GET : '
+          'https://REDACTED:REDACTED@example.com/path?'
+          'sig=REDACTED&token=REDACTED&password=REDACTED&api_key=REDACTED'
+          '&color=blue',
         );
         expect(
           logItem.asLog!.trace,

--- a/test/src/integrations/http_tracking_client_test.dart
+++ b/test/src/integrations/http_tracking_client_test.dart
@@ -131,7 +131,6 @@ void main() {
       mockRequestHeaders = MockHttpHeaders();
       mockResponseHeaders = MockHttpHeaders();
       mockSpan = MockSpan();
-
       when(() => mockSpan.status).thenReturn(SpanStatusCode.unset);
 
       when(() => mockSpan.traceId).thenReturn('trace-id');
@@ -192,7 +191,9 @@ void main() {
       await expectLater(trackedRequest.close, throwsA(isA<Exception>()));
       await Future<void>.delayed(Duration.zero);
 
-      verify(() => mockSpan.setAttribute('http.status_code', 0)).called(1);
+      verifyNever(
+        () => mockSpan.setAttribute('http.response.status_code', any()),
+      );
       verify(
         () => mockSpan.setStatus(
           SpanStatusCode.error,
@@ -282,7 +283,9 @@ void main() {
       trackedRequest.abort(error, stackTrace);
 
       verify(() => mockHttpClientRequest.abort(error, stackTrace)).called(1);
-      verify(() => mockSpan.setAttribute('http.status_code', 0)).called(1);
+      verifyNever(
+        () => mockSpan.setAttribute('http.response.status_code', any()),
+      );
       verify(
         () => mockSpan.setStatus(
           SpanStatusCode.error,
@@ -295,21 +298,26 @@ void main() {
       verify(() => mockSpan.end()).called(1);
     });
 
-    test('abort without exception still records status_code 0', () {
-      trackedRequest.abort();
+    test(
+      'abort without exception still records an error without a response code',
+      () {
+        trackedRequest.abort();
 
-      verify(() => mockHttpClientRequest.abort(any(), any())).called(1);
-      verify(() => mockSpan.setAttribute('http.status_code', 0)).called(1);
-      verify(
-        () => mockSpan.setStatus(
-          SpanStatusCode.error,
-          message: any(named: 'message'),
-        ),
-      ).called(1);
-      verify(() => mockSpan.end()).called(1);
-    });
+        verify(() => mockHttpClientRequest.abort(any(), any())).called(1);
+        verifyNever(
+          () => mockSpan.setAttribute('http.response.status_code', any()),
+        );
+        verify(
+          () => mockSpan.setStatus(
+            SpanStatusCode.error,
+            message: any(named: 'message'),
+          ),
+        ).called(1);
+        verify(() => mockSpan.end()).called(1);
+      },
+    );
 
-    test('addStream failure records status_code 0 and ends the span', () async {
+    test('addStream failure omits response code and ends the span', () async {
       const stream = Stream<List<int>>.empty();
       when(
         () => mockHttpClientRequest.addStream(stream),
@@ -320,7 +328,9 @@ void main() {
         throwsA(isA<SocketException>()),
       );
 
-      verify(() => mockSpan.setAttribute('http.status_code', 0)).called(1);
+      verifyNever(
+        () => mockSpan.setAttribute('http.response.status_code', any()),
+      );
       verify(
         () => mockSpan.setStatus(
           SpanStatusCode.error,
@@ -347,6 +357,7 @@ void main() {
       mockRequestHeaders = MockHttpHeaders();
       mockResponseHeaders = MockHttpHeaders();
       mockSpan = MockSpan();
+      when(() => mockSpan.status).thenReturn(SpanStatusCode.unset);
       responseStreamController = StreamController<List<int>>();
       router = _RecordingRouter();
       pod.overrideProvider<TelemetryRouter>(

--- a/test/src/integrations/http_url_redaction_test.dart
+++ b/test/src/integrations/http_url_redaction_test.dart
@@ -1,0 +1,92 @@
+import 'package:faro/src/integrations/http_url_redaction.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('redactHttpUrl', () {
+    for (final key in [
+      'X-Amz-Signature',
+      'X-Amz-Credential',
+      'X-Amz-Security-Token',
+      'AWSAccessKeyId',
+      'Signature',
+      'sig',
+      'X-Goog-Signature',
+    ]) {
+      test('redacts the value of $key', () {
+        expect(
+          redactHttpUrl(Uri.parse('https://example.com/?$key=example-value')),
+          'https://example.com/?$key=REDACTED',
+        );
+      });
+    }
+
+    final cases = [
+      (
+        'redacts username and password',
+        'https://alice:example-password@example.com/path?color=blue#section',
+        'https://REDACTED:REDACTED@example.com/path?color=blue#section',
+      ),
+      (
+        'redacts a username without a password',
+        'https://alice@example.com/path',
+        'https://REDACTED:REDACTED@example.com/path',
+      ),
+      (
+        'redacts encoded credentials and preserves IPv6 authority',
+        'https://alice:p%40ss@[::1]:8443/path?sig=example#fragment',
+        'https://REDACTED:REDACTED@[::1]:8443/path?sig=REDACTED#fragment',
+      ),
+      (
+        'redacts repeated and encoded keys with case-sensitive matching',
+        'https://example.com/?sig=one&sig=two&%73ig=three&Sig=visible'
+            '&Signature=four&%53ignature=five&signature=visible',
+        'https://example.com/?sig=REDACTED&sig=REDACTED&sig=REDACTED'
+            '&Sig=visible&Signature=REDACTED&Signature=REDACTED'
+            '&signature=visible',
+      ),
+      (
+        'redacts empty values and keys without an equals sign',
+        'https://example.com/?sig=&sig',
+        'https://example.com/?sig=REDACTED&sig=REDACTED',
+      ),
+      (
+        'redacts the entire value including equals signs',
+        'https://example.com/?sig=a=b%3Dc&color=blue',
+        'https://example.com/?sig=REDACTED&color=blue',
+      ),
+      (
+        'tolerates invalid UTF-8 query keys and redacts invalid values',
+        'https://example.com/?%FF=keep&sig=%FF',
+        'https://example.com/?%FF=keep&sig=REDACTED',
+      ),
+      (
+        'preserves unrelated query encoding, ordering, duplicates and flags',
+        'https://example.com/?q=a%20b&sig=example&q=a+b&x=a%2Fb&&flag&',
+        'https://example.com/?q=a%20b&sig=REDACTED&q=a+b&x=a%2Fb&&flag&',
+      ),
+    ];
+    for (final (description, input, expected) in cases) {
+      test(description, () {
+        expect(redactHttpUrl(Uri.parse(input)), expected);
+      });
+    }
+
+    for (final url in [
+      'https://example.com/path',
+      'https://example.com/path?',
+      'https://example.com/path#fragment',
+      'https://example.com/?token=example&password=example#sig=example',
+    ]) {
+      test('preserves a URL without recognized sensitive components: $url', () {
+        expect(redactHttpUrl(Uri.parse(url)), url);
+      });
+    }
+
+    test('redacting an already redacted URL leaves it unchanged', () {
+      const redacted =
+          'https://REDACTED:REDACTED@example.com/?'
+          'sig=REDACTED&Signature=REDACTED&color=blue';
+      expect(redactHttpUrl(Uri.parse(redacted)), redacted);
+    });
+  });
+}

--- a/test/src/integrations/http_url_redaction_test.dart
+++ b/test/src/integrations/http_url_redaction_test.dart
@@ -11,6 +11,13 @@ void main() {
       'Signature',
       'sig',
       'X-Goog-Signature',
+      'token',
+      'access_token',
+      'refresh_token',
+      'api_key',
+      'apikey',
+      'password',
+      'client_secret',
     ]) {
       test('redacts the value of $key', () {
         expect(
@@ -75,7 +82,7 @@ void main() {
       'https://example.com/path',
       'https://example.com/path?',
       'https://example.com/path#fragment',
-      'https://example.com/?token=example&password=example#sig=example',
+      'https://example.com/?customer_code=example&Token=example#sig=example',
     ]) {
       test('preserves a URL without recognized sensitive components: $url', () {
         expect(redactHttpUrl(Uri.parse(url)), url);


### PR DESCRIPTION
## Description

Automatic HTTP client spans use stable attributes: `http.request.method`,
`url.full`, `server.address`, `server.port`, and `http.response.status_code`.
Failures without a response omit the span status code and record an exception
`error.type`.

The `faro.tracing.fetch` event keeps its existing fields and string serialization.
Its HTTP metadata is captured separately from span attributes, preserving status,
size, duration and trace/session/action correlation. Span `url.full`, event `http.url`, and fallback `network_error` log URLs
redact URL credentials and the documented sensitive query keys, including common
application credentials such as `token`, `api_key`, and `password`.
The request URL is unchanged; exact telemetry URL filters use redacted values.
The public Dart API and outer Faro payload are unchanged.

## Related Issue(s)

Fixes #346

## Type of Change

- [x] 💥 Breaking change (HTTP span attributes and sensitive URL values)
- [x] 📝 Documentation

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Additional Notes

All six local pre-release checks passed. Initial example and QuickPizza runs
covered Android and iOS. Fresh Android runs of both apps verified eight matching
span/event pairs with the expanded URL redaction against stored telemetry. A
truncated response also verified the redacted fallback log and trace correlation.
The existing HTTP event query still returns the requests. Manual HTTP-view
verification of this final revision is pending.

Public redaction configuration is planned as a separate follow-up.
