### PR TITLE
feat(http): configure sensitive query parameter redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Application-specific HTTP query values can be redacted** alongside the
+  built-in credential parameters. The same policy applies to spans, HTTP
+  events and fallback network-error logs without changing requests. See the
+  Reference docs for configuration and matching behavior
+  ([#346](https://github.com/grafana/faro-flutter-sdk/issues/346)).
+
 - **Known HTTP methods include `http.request.method`** on spans and
   `faro.tracing.fetch` events
   ([#109](https://github.com/grafana/faro-flutter-sdk/issues/109)).

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -806,9 +806,45 @@ query values with `REDACTED`:
 - `api_key`, `apikey`
 - `password`, `client_secret`
 
-Matching uses decoded, case-sensitive keys and covers repeated parameters.
-Other query parameters, the path and the fragment use their original values.
-The request sent to the server uses the original URL.
+Add application-specific names with `FaroConfig.sensitiveHttpQueryParameters`:
+
+```dart
+FaroConfig(
+  appName: 'shop',
+  appEnv: 'production',
+  apiKey: 'your-api-key',
+  collectorUrl: 'https://collector.example/collect',
+  sensitiveHttpQueryParameters: {'customer_code', 'checkout_session'},
+)
+```
+
+These names **extend** the defaults above. Omitted, `null` or empty input adds
+nothing; built-in protections cannot be removed. The config copies the input
+into an immutable set, so later changes to the caller's collection have no
+effect. Unlike this Faro API, OpenTelemetry's declarative
+`sensitive_query_parameters` setting replaces its defaults.
+
+Matching uses exact decoded, case-sensitive query names and covers repeated
+parameters. Supply plain names, without URL encoding. For example, `Token`
+only matches if explicitly added; `token` is already a default. Matching does
+not use substrings or regular expressions. Empty names match explicit empty
+query names (`=value`); empty separators are preserved. Invalid UTF-8 names
+are left unchanged when they cannot be decoded. Values of matching names are
+redacted even if those values are malformed.
+
+Other query parameters retain their encoding, order and repeated values in
+Dart's `Uri` representation. The path and fragment keep their original values.
+The request sent to the server uses the original URI.
+
+Clients created before initialization use the configured policy for requests
+started during or after `Faro.init`. Requests started before init use the
+built-in defaults. Each request captures one redacted URL for its span, event
+and fallback log. Subsequent `init` calls are ignored; resetting a session does
+not change the policy. The testing-only `Faro.resetForTesting` restores the
+defaults until the next initialization.
+
+This setting applies to automatic HTTP URL fields. It does not sanitize
+arbitrary exception messages, log text, custom attributes or WebView URLs.
 
 ---
 

--- a/lib/src/configurations/faro_config.dart
+++ b/lib/src/configurations/faro_config.dart
@@ -36,6 +36,7 @@ class FaroConfig {
     this.fetchVitalsInterval = const Duration(seconds: 30),
     BatchConfig? batchConfig,
     this.ignoreUrls,
+    Set<String>? sensitiveHttpQueryParameters,
     this.maxBufferLimit = 30,
     this.collectorHeaders,
     this.sessionAttributes,
@@ -49,6 +50,9 @@ class FaroConfig {
        assert(appEnv.isNotEmpty, 'appEnv cannot be empty'),
        assert(apiKey.isNotEmpty, 'apiKey cannot be empty'),
        assert(maxBufferLimit > 0, 'maxBufferLimit must be greater than 0'),
+       sensitiveHttpQueryParameters = Set.unmodifiable(
+         sensitiveHttpQueryParameters ?? const <String>{},
+       ),
        batchConfig = batchConfig ?? BatchConfig();
   final String appName;
   final String appEnv;
@@ -75,6 +79,21 @@ class FaroConfig {
   final int maxBufferLimit;
   final Duration? fetchVitalsInterval;
   final List<RegExp>? ignoreUrls;
+
+  /// Additional query parameter names whose values Faro redacts in HTTP URLs.
+  ///
+  /// Extends the built-in sensitive names; cannot remove built-in protections.
+  /// Omitted, null or empty input adds no names. Matching uses exact decoded,
+  /// case-sensitive names. Supply names as plain text, without URL encoding.
+  ///
+  /// Applies to automatic HTTP span URLs, HTTP event URLs and fallback
+  /// network-error log URLs. The actual request URI is unchanged. This does
+  /// not sanitize arbitrary exception messages, log text or custom attributes.
+  ///
+  /// Copied into an immutable set when this config is constructed. Changes
+  /// to the caller's set do not affect the config or the active policy.
+  /// For example: `{'customer_code', 'checkout_session'}`.
+  final Set<String> sensitiveHttpQueryParameters;
 
   /// Custom attributes to include in all session data.
   ///

--- a/lib/src/faro.dart
+++ b/lib/src/faro.dart
@@ -14,6 +14,7 @@ import 'package:faro/src/device_info/session_attributes_provider.dart';
 import 'package:faro/src/faro_widgets_binding_observer.dart';
 import 'package:faro/src/integrations/flutter_error_integration.dart';
 import 'package:faro/src/integrations/http_tracking_filter.dart';
+import 'package:faro/src/integrations/http_url_redaction_policy.dart';
 import 'package:faro/src/integrations/native_integration.dart';
 import 'package:faro/src/integrations/on_error_integration.dart';
 import 'package:faro/src/models/models.dart';
@@ -192,6 +193,10 @@ class Faro {
       return;
     }
 
+    // Install before the first await so requests during init are protected.
+    pod
+        .resolve(httpUrlRedactionPolicyProvider)
+        .configure(optionsConfiguration.sensitiveHttpQueryParameters);
     _dataCollectionPolicy = await DataCollectionPolicyFactory().create();
 
     final attributesProvider = await SessionAttributesProviderFactory()

--- a/lib/src/integrations/http_tracking_client.dart
+++ b/lib/src/integrations/http_tracking_client.dart
@@ -6,6 +6,7 @@ import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/integrations/http_tracking_filter.dart';
 import 'package:faro/src/integrations/http_url_redaction.dart';
+import 'package:faro/src/integrations/http_url_redaction_policy.dart';
 import 'package:faro/src/models/log_level.dart';
 import 'package:faro/src/tracing/faro_span_context.dart';
 import 'package:faro/src/tracing/faro_tracer.dart';
@@ -107,7 +108,13 @@ class FaroHttpTrackingClient implements HttpClient {
     final upperMethod = method.toUpperCase();
     final isKnownMethod = _knownMethods.contains(upperMethod);
     final recordedMethod = isKnownMethod ? upperMethod : method;
-    final redactedUrl = redactHttpUrl(url);
+    // Capture once, before opening the request. A client can outlive init or
+    // test resets. In-flight requests keep the same URL in every output.
+    final redactedUrl = redactHttpUrl(
+      url,
+      sensitiveQueryParameters:
+          _currentHttpUrlRedactionPolicy().sensitiveQueryParameters,
+    );
     final httpSpan = _startHttpSpan(
       isKnownMethod ? recordedMethod : 'HTTP $method',
       attributes: {
@@ -278,6 +285,9 @@ class FaroHttpTrackingClient implements HttpClient {
   Future<HttpClientRequest> putUrl(Uri url) => _openUrl('PUT', url);
 }
 
+HttpUrlRedactionPolicy _currentHttpUrlRedactionPolicy() =>
+    pod.resolve(httpUrlRedactionPolicyProvider);
+
 void _recordHttpError(Span span, Object error, StackTrace? stackTrace) {
   preserveHttpEventErrorType(span);
   if (span is InternalSpan &&
@@ -300,7 +310,13 @@ class FaroTrackingHttpClientRequest implements HttpClientRequest {
     required Span httpSpan,
     String? redactedUrl,
   }) : _httpSpan = httpSpan,
-       _redactedUrl = redactedUrl ?? redactHttpUrl(innerContext.uri) {
+       _redactedUrl =
+           redactedUrl ??
+           redactHttpUrl(
+             innerContext.uri,
+             sensitiveQueryParameters:
+                 _currentHttpUrlRedactionPolicy().sensitiveQueryParameters,
+           ) {
     innerContext.headers.add('traceparent', _httpSpan.traceparent);
   }
 

--- a/lib/src/integrations/http_url_redaction.dart
+++ b/lib/src/integrations/http_url_redaction.dart
@@ -1,35 +1,44 @@
+/// Built-in sensitive query names, always retained by the HTTP policy.
+const defaultSensitiveHttpQueryParameters = <String>{
+  // OpenTelemetry default sensitive query keys.
+  'X-Amz-Signature',
+  'X-Amz-Credential',
+  'X-Amz-Security-Token',
+  'AWSAccessKeyId',
+  'Signature',
+  'sig',
+  'X-Goog-Signature',
+  // Additional Faro defaults for common application credentials.
+  'token',
+  'access_token',
+  'refresh_token',
+  'api_key',
+  'apikey',
+  'password',
+  'client_secret',
+};
+
 /// Redacts HTTP span, event and fallback error-log URLs.
 /// The request URL is unchanged.
 ///
 /// OTel HTTP client URL redaction rules (the query-key list is Development):
 /// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span
 /// Preserves the encoding/order of non-sensitive query parameters.
-String redactHttpUrl(Uri url) {
-  const sensitiveKeys = {
-    // OpenTelemetry default sensitive query keys.
-    'X-Amz-Signature',
-    'X-Amz-Credential',
-    'X-Amz-Security-Token',
-    'AWSAccessKeyId',
-    'Signature',
-    'sig',
-    'X-Goog-Signature',
-    // Additional Faro defaults for common application credentials.
-    'token',
-    'access_token',
-    'refresh_token',
-    'api_key',
-    'apikey',
-    'password',
-    'client_secret',
-  };
+String redactHttpUrl(
+  Uri url, {
+  Set<String> sensitiveQueryParameters = defaultSensitiveHttpQueryParameters,
+}) {
   final query = url.query
       .split('&')
       .map((part) {
+        // Empty separators are not query parameters with an empty name.
+        if (part.isEmpty) return part;
         final separator = part.indexOf('=');
         final key = separator < 0 ? part : part.substring(0, separator);
         try {
-          if (sensitiveKeys.contains(Uri.decodeQueryComponent(key))) {
+          if (sensitiveQueryParameters.contains(
+            Uri.decodeQueryComponent(key),
+          )) {
             return '$key=REDACTED';
           }
         } on FormatException {

--- a/lib/src/integrations/http_url_redaction_policy.dart
+++ b/lib/src/integrations/http_url_redaction_policy.dart
@@ -1,0 +1,25 @@
+import 'package:dartypod/dartypod.dart';
+import 'package:faro/src/core/pod.dart';
+import 'package:faro/src/integrations/http_url_redaction.dart';
+
+/// Internal HTTP URL policy for one Faro initialization.
+class HttpUrlRedactionPolicy {
+  Set<String> _sensitiveQueryParameters = defaultSensitiveHttpQueryParameters;
+
+  /// Immutable effective names, including all built-in protections.
+  Set<String> get sensitiveQueryParameters => _sensitiveQueryParameters;
+
+  /// Installs application additions without retaining caller-owned state.
+  void configure(Set<String> additionalNames) {
+    _sensitiveQueryParameters = Set.unmodifiable({
+      ...defaultSensitiveHttpQueryParameters,
+      ...additionalNames,
+    });
+  }
+}
+
+/// Resolving after a test reset returns the default policy again.
+final httpUrlRedactionPolicyProvider = Provider<HttpUrlRedactionPolicy>(
+  (_) => HttpUrlRedactionPolicy(),
+  scope: faroInitScope,
+);

--- a/test/src/configurations/faro_config_test.dart
+++ b/test/src/configurations/faro_config_test.dart
@@ -10,6 +10,7 @@ void main() {
       String apiKey = 'test-api-key',
       String collectorUrl = 'https://example.com',
       Sampling? sampling,
+      Set<String>? sensitiveHttpQueryParameters,
       bool persistSession = true,
       FaroEngineRole engineRole = FaroEngineRole.automatic,
     }) {
@@ -19,10 +20,46 @@ void main() {
         apiKey: apiKey,
         collectorUrl: collectorUrl,
         sampling: sampling,
+        sensitiveHttpQueryParameters: sensitiveHttpQueryParameters,
         persistSession: persistSession,
         engineRole: engineRole,
       );
     }
+
+    group('sensitive HTTP query parameters:', () {
+      test('omitted, null and empty mean no application additions', () {
+        expect(createConfig().sensitiveHttpQueryParameters, isEmpty);
+        expect(
+          createConfig(
+            // Explicit null is part of the public constructor contract.
+            // ignore: avoid_redundant_argument_values
+            sensitiveHttpQueryParameters: null,
+          ).sensitiveHttpQueryParameters,
+          isEmpty,
+        );
+        expect(
+          createConfig(
+            sensitiveHttpQueryParameters: {},
+          ).sensitiveHttpQueryParameters,
+          isEmpty,
+        );
+      });
+
+      test('copies caller names without normalization and is immutable', () {
+        final names = {'customer_code', 'Token', ' customer_code '};
+        final config = createConfig(sensitiveHttpQueryParameters: names);
+        names.clear();
+        expect(config.sensitiveHttpQueryParameters, {
+          'customer_code',
+          'Token',
+          ' customer_code ',
+        });
+        expect(
+          () => config.sensitiveHttpQueryParameters.add('new_name'),
+          throwsUnsupportedError,
+        );
+      });
+    });
 
     group('sampling:', () {
       test('should default to null (100% sampled)', () {

--- a/test/src/faro_test.dart
+++ b/test/src/faro_test.dart
@@ -5,8 +5,10 @@ import 'dart:io';
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart' as otel;
 import 'package:faro/src/configurations/batch_config.dart';
 import 'package:faro/src/configurations/faro_config.dart';
+import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/data_collection_policy.dart';
 import 'package:faro/src/faro.dart';
+import 'package:faro/src/integrations/http_url_redaction_policy.dart';
 import 'package:faro/src/models/models.dart';
 import 'package:faro/src/native_platform_interaction/faro_native_methods.dart';
 import 'package:faro/src/offline_transport/offline_transport.dart';
@@ -130,6 +132,48 @@ void main() {
       // Clean up the singleton state after each test
       BatchTransportFactory().reset();
     });
+
+    test(
+      'HTTP policy is installed before init awaits and follows reset',
+      () async {
+        FaroConfig config(Set<String> names) => FaroConfig(
+          appName: appName,
+          appEnv: appEnv,
+          apiKey: apiKey,
+          collectorUrl: null,
+          transports: [],
+          persistSession: false,
+          persistUser: false,
+          enableUiActivityMonitoring: false,
+          sensitiveHttpQueryParameters: names,
+        );
+        Set<String> effectiveNames() => pod
+            .resolve(httpUrlRedactionPolicyProvider)
+            .sensitiveQueryParameters;
+
+        expect(effectiveNames(), contains('token'));
+        expect(effectiveNames(), isNot(contains('customer_code')));
+        final names = {'customer_code'};
+        final options = config(names);
+        names.clear();
+        final initialization = Faro().init(optionsConfiguration: options);
+        // No await: requests started during initialization need protection too.
+        expect(effectiveNames(), containsAll(['token', 'customer_code']));
+        await initialization;
+        await Faro().init(optionsConfiguration: config({'ignored'}));
+        expect(effectiveNames(), contains('customer_code'));
+        expect(effectiveNames(), isNot(contains('ignored')));
+        await Faro().resetSession();
+        expect(effectiveNames(), contains('customer_code'));
+
+        await Faro.resetForTesting();
+        expect(effectiveNames(), contains('token'));
+        expect(effectiveNames(), isNot(contains('customer_code')));
+        await Faro().init(optionsConfiguration: config({'checkout_session'}));
+        expect(effectiveNames(), containsAll(['token', 'checkout_session']));
+        expect(effectiveNames(), isNot(contains('customer_code')));
+      },
+    );
 
     test('init called with no error', () async {
       TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/src/integrations/http_span_naming_test.dart
+++ b/test/src/integrations/http_span_naming_test.dart
@@ -6,6 +6,7 @@ import 'package:faro/src/core/pod.dart';
 import 'package:faro/src/faro.dart';
 import 'package:faro/src/integrations/http_tracking_client.dart';
 import 'package:faro/src/integrations/http_tracking_filter.dart';
+import 'package:faro/src/integrations/http_url_redaction_policy.dart';
 import 'package:faro/src/models/span_record.dart';
 import 'package:faro/src/models/trace/trace_resource_spans.dart';
 import 'package:faro/src/session/session_activity_kind.dart';
@@ -73,6 +74,7 @@ void main() {
 
   setUp(() {
     pod.clearScope(tracerScope);
+    pod.clearScope(faroInitScope);
     processor.started.clear();
     processor.ended.clear();
   });
@@ -451,6 +453,127 @@ void main() {
       });
     }
   }
+
+  for (final status in [200, 500]) {
+    test('pre-existing client uses current policy for HTTP $status', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final client = FaroHttpOverrides(null).createHttpClient(null)
+        ..findProxy = (_) => 'DIRECT';
+      addTearDown(() async {
+        client.close(force: true);
+        await server.close(force: true);
+      });
+      final received = <Uri>[];
+      server.listen((request) async {
+        received.add(request.uri);
+        request.response.statusCode = status;
+        await request.response.close();
+      });
+      final uri = Uri.parse(
+        'http://127.0.0.1:${server.port}/test?'
+        'token=dummy&customer_code=one&customer_code=two&q=a%2Fb',
+      );
+      Future<void> send() async {
+        final request = await client.getUrl(uri);
+        final response = await request.close();
+        await response.drain<void>();
+      }
+
+      await send(); // Resolves defaults before configuration.
+      pod.resolve(httpUrlRedactionPolicyProvider).configure({'customer_code'});
+      await send(); // Same client must see the configured names.
+      pod.clearScope(faroInitScope);
+      await send(); // Same client must see defaults after a scope reset.
+      pod.resolve(httpUrlRedactionPolicyProvider).configure({'q'});
+      await send(); // And the next initialization's policy.
+
+      expect(received, List.filled(4, Uri.parse('/test?${uri.query}')));
+      final router = _RecordingRouter();
+      await FaroExporter(telemetryRouter: router).export(processor.ended);
+      final events = router.items.where((i) => i.asEvent != null).toList();
+      expect(events, hasLength(4));
+      for (var i = 0; i < 4; i++) {
+        final expectedUrl = uri
+            .toString()
+            .replaceAll('token=dummy', 'token=REDACTED')
+            .replaceAll(
+              'customer_code=one',
+              i == 1 ? 'customer_code=REDACTED' : 'customer_code=one',
+            )
+            .replaceAll(
+              'customer_code=two',
+              i == 1 ? 'customer_code=REDACTED' : 'customer_code=two',
+            )
+            .replaceAll('q=a%2Fb', i == 3 ? 'q=REDACTED' : 'q=a%2Fb');
+        final record = SpanRecord(otelReadOnlySpan: processor.ended[i]);
+        final attributes = record.getSpan().toJson()['attributes'] as List;
+        expect(attributes.singleWhere((a) => a['key'] == 'url.full')['value'], {
+          'stringValue': expectedUrl,
+        });
+        expect(events[i].asEvent!.attributes!['http.url'], expectedUrl);
+        expect(events[i].asEvent!.attributes!['http.status_code'], '$status');
+      }
+    });
+  }
+
+  test(
+    'in-flight body failure keeps one URL in span, event and fallback log',
+    () async {
+      final router = _RecordingRouter();
+      pod.overrideProvider<TelemetryRouter>(
+        telemetryRouterProvider,
+        (_) => router,
+      );
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final client = FaroHttpOverrides(null).createHttpClient(null)
+        ..findProxy = (_) => 'DIRECT';
+      addTearDown(() async {
+        pod.removeOverride(telemetryRouterProvider);
+        client.close(force: true);
+        await server.close(force: true);
+      });
+      final received = Completer<Uri>();
+      server.listen((request) async {
+        received.complete(request.uri);
+        final socket = await request.response.detachSocket(writeHeaders: false);
+        socket.write(
+          'HTTP/1.1 200 OK\r\nContent-Length: 10\r\n'
+          'Connection: close\r\n\r\nx',
+        );
+        await socket.close();
+      });
+      pod.resolve(httpUrlRedactionPolicyProvider).configure({'customer_code'});
+      final uri = Uri.parse(
+        'http://127.0.0.1:${server.port}/test?'
+        'token=dummy&customer_code=dummy&other=visible',
+      );
+      final pendingRequest = client.getUrl(uri);
+      // Change policy while openUrl is awaiting the connection, before the
+      // request/response wrappers exist. They must retain the request snapshot.
+      pod.clearScope(faroInitScope);
+      pod.resolve(httpUrlRedactionPolicyProvider).configure({'other'});
+      final request = await pendingRequest;
+      final response = await request.close();
+      final finished = Completer<void>();
+      // The unsupported callback signature exercises the fallback log path.
+      // ignore: cancel_subscriptions
+      response.listen((_) {}, onError: () {}, onDone: finished.complete);
+      await finished.future;
+      expect(await received.future, Uri.parse('/test?${uri.query}'));
+      await FaroExporter(telemetryRouter: router).export(processor.ended);
+      final record = SpanRecord(otelReadOnlySpan: processor.ended.single);
+      final expectedUrl = uri.toString().replaceAll('=dummy', '=REDACTED');
+      final attributes = record.getSpan().toJson()['attributes'] as List;
+      expect(attributes.singleWhere((a) => a['key'] == 'url.full')['value'], {
+        'stringValue': expectedUrl,
+      });
+      final event = router.items.singleWhere((i) => i.asEvent != null).asEvent!;
+      expect(event.attributes!['http.url'], expectedUrl);
+      final log = router.items.singleWhere((i) => i.asLog != null).asLog!;
+      expect(log.message, 'network_error on : GET : $expectedUrl');
+      expect(log.trace, record.getFaroSpanContext());
+    },
+  );
 
   for (final input in ['get', 'GeT', 'post', 'PoSt']) {
     test('records the actual wire method for $input', () async {

--- a/test/src/integrations/http_url_redaction_policy_test.dart
+++ b/test/src/integrations/http_url_redaction_policy_test.dart
@@ -1,0 +1,46 @@
+import 'package:faro/src/integrations/http_url_redaction.dart';
+import 'package:faro/src/integrations/http_url_redaction_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('defaults and empty configuration retain all built-in protections', () {
+    final policy = HttpUrlRedactionPolicy();
+    final url = Uri.parse(
+      'https://example.com/?'
+      'X-Amz-Signature=x&X-Amz-Credential=x&X-Amz-Security-Token=x'
+      '&AWSAccessKeyId=x&Signature=x&sig=x&X-Goog-Signature=x'
+      '&token=x&access_token=x&refresh_token=x&api_key=x&apikey=x'
+      '&password=x&client_secret=x',
+    );
+    for (final configure in [false, true]) {
+      if (configure) policy.configure({});
+      expect(
+        redactHttpUrl(
+          url,
+          sensitiveQueryParameters: policy.sensitiveQueryParameters,
+        ),
+        url.toString().replaceAll('=x', '=REDACTED'),
+      );
+    }
+  });
+
+  test(
+    'configuration adds names, snapshots inputs and exposes immutable state',
+    () {
+      final names = {'custom'};
+      final policy = HttpUrlRedactionPolicy()..configure(names);
+      names.clear();
+      expect(
+        redactHttpUrl(
+          Uri.parse('https://example.com/?custom=x&token=x'),
+          sensitiveQueryParameters: policy.sensitiveQueryParameters,
+        ),
+        'https://example.com/?custom=REDACTED&token=REDACTED',
+      );
+      expect(
+        () => policy.sensitiveQueryParameters.clear(),
+        throwsUnsupportedError,
+      );
+    },
+  );
+}

--- a/test/src/integrations/http_url_redaction_test.dart
+++ b/test/src/integrations/http_url_redaction_test.dart
@@ -3,6 +3,58 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('redactHttpUrl', () {
+    test('uses an explicit policy without reading SDK state', () {
+      expect(
+        redactHttpUrl(
+          Uri.parse('https://example.com/?customer_code=dummy&token=keep'),
+          sensitiveQueryParameters: {'customer_code'},
+        ),
+        'https://example.com/?customer_code=REDACTED&token=keep',
+      );
+    });
+
+    test('matches decoded custom names exactly, preserving other segments', () {
+      expect(
+        redactHttpUrl(
+          Uri.parse(
+            'https://example.com/?customer_code=one'
+            '&customer_code=two&Customer_code=keep&mycustomer_code=keep'
+            '&a%2Bb=one&a+b=two&a%20b=three&a%252Bb=keep'
+            '&a.b=one&axb=keep&x=a%2Fb&q=a+b&q=a%20b&&flag&',
+          ),
+          sensitiveQueryParameters: {'customer_code', 'a+b', 'a b', 'a.b'},
+        ),
+        'https://example.com/?customer_code=REDACTED'
+        '&customer_code=REDACTED&Customer_code=keep&mycustomer_code=keep'
+        '&a%2Bb=REDACTED&a+b=REDACTED&a%20b=REDACTED&a%252Bb=keep'
+        '&a.b=REDACTED&axb=keep&x=a%2Fb&q=a+b&q=a%20b&&flag&',
+      );
+    });
+
+    test('handles malformed custom values and preserves malformed names', () {
+      expect(
+        redactHttpUrl(
+          Uri.parse(
+            'https://example.com/?%FF=keep&custom=%FF&custom'
+            '&custom=&custom=a=b&custom%FF=keep',
+          ),
+          sensitiveQueryParameters: {'custom'},
+        ),
+        'https://example.com/?%FF=keep&custom=REDACTED&custom=REDACTED'
+        '&custom=REDACTED&custom=REDACTED&custom%FF=keep',
+      );
+    });
+
+    test('empty name redacts explicit values but preserves separators', () {
+      expect(
+        redactHttpUrl(
+          Uri.parse('https://example.com/?&=dummy&&flag&'),
+          sensitiveQueryParameters: {''},
+        ),
+        'https://example.com/?&=REDACTED&&flag&',
+      );
+    });
+
     for (final key in [
       'X-Amz-Signature',
       'X-Amz-Credential',


### PR DESCRIPTION
## Description

Applications can add sensitive query parameter names through `FaroConfig.sensitiveHttpQueryParameters`. For example, `{'customer_code', 'checkout_session'}` redacts those values alongside the existing defaults in HTTP spans, fetch events and fallback network-error logs, while preserving the request sent to the server.

Names are copied into an immutable set and matched exactly after decoding, with case preserved. Omitted, null and empty inputs retain all built-in protections. The policy is installed before initialization awaits and resolved per request, so existing clients see the configured names and each in-flight request uses one consistent redacted URL.

## Related Issue(s)

Related to #346. Follow-up to merged #349; targets `main`.

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md under the "Unreleased" section

## Additional Notes

Tests were written before implementation for configuration semantics, mutation, matching edge cases, initialization/reset behavior and consistent span/event/fallback-log propagation. Loopback tests verify that the server receives the original URI.

All six pre-release checks passed. Android runs of the example app and Flutter demo verified 10 HTTP span/event pairs and two fallback logs against stored telemetry using dummy query credentials. This setting is limited to automatic HTTP URL fields; arbitrary exception messages, log text, custom attributes and WebView URLs remain outside its scope.
